### PR TITLE
eorm CLI: Don't drop database

### DIFF
--- a/orm/eyened_orm/cli.py
+++ b/orm/eyened_orm/cli.py
@@ -71,7 +71,7 @@ _register_model_commands()
 @eorm.command()
 @click.option("--recreate", is_flag=True, default=False, help="Drop and create the database before creating the models")
 def initialize_database(recreate: bool):
-    """Initialize an empty database, create ORM tables, and stamp Alembic head."""
+    """Initialize an empty database and create ORM tables."""
     from eyened_orm.base import Base
 
     print("Initializing database...")

--- a/orm/eyened_orm/cli.py
+++ b/orm/eyened_orm/cli.py
@@ -69,7 +69,8 @@ _register_model_commands()
 
 
 @eorm.command()
-def initialize_database():
+@click.option("--recreate", is_flag=True, default=False, help="Drop and create the database before creating the models")
+def initialize_database(recreate: bool):
     """Initialize an empty database, create ORM tables, and stamp Alembic head."""
     from eyened_orm.base import Base
 
@@ -77,9 +78,10 @@ def initialize_database():
     database = get_database(confirmation=True)
     db_config = database.database_settings
 
-    print("Recreating empty database (drop if exists)...")
-    if not drop_create_db(db_config):
-        raise click.ClickException("Failed to recreate empty database.")
+    if recreate:
+        print("Recreating empty database (drop if exists)...")
+        if not drop_create_db(db_config):
+            raise click.ClickException("Failed to recreate empty database.")
 
     print("Creating tables...")
     Base.metadata.create_all(database.engine)


### PR DESCRIPTION
This helps when the user that is configured in the env where you are running the `eorm` CLI has no permissions to drop/create databases.

A production database account should not have rights to drop or create databases. And a production setup should not have a simple way to drop the production database.