### PR TITLE
Repository layer refactoring

### DIFF
--- a/docs/superpowers/plans/2026-07-06-form-schema-phase1.md
+++ b/docs/superpowers/plans/2026-07-06-form-schema-phase1.md
@@ -1,0 +1,382 @@
+# form_schema Repository/Service Migration (RBAC Step 1, Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the two `form_schema` endpoints (`GET /form-schemas` list, `GET /form-schemas/{id}` get-by-id-with-404) through a `FormSchemaService`/`FormSchemaRepository`, reusing the foundation scaffolding, committing directly onto the current `feature/rbac-step1-service-layer` branch (which is not merged to `development` as part of this work, so `development` is never touched).
+
+**Architecture:** Identical to the reviewed Device/Patient slices — thin route (parse → Service → `DTOConverter` → return), Service with constructor-injected Repository raising `NotFoundError`, framework-agnostic Repository taking a `Session`. No new exception types, handler, or fixtures: all exist from the foundation.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model — `form_schema_repository.py`, `form_schema_service.py`.
+- **Class names:** `FormSchemaRepository` / `FormSchemaService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repository via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by the foundation's `server/tests/conftest.py`).
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `Base`'s generic classmethods, or the foundation's `exceptions.py`/`main.py` (reused as-is).
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`.
+
+> **Reused from the foundation (`feature/rbac-step1-service-layer`):** `NotFoundError` (`server/services/exceptions.py`), the central handler in `server/main.py`, the `session` fixture already imported in `server/tests/conftest.py`, and both `__init__.py` packages. `FormSchema` (`orm/eyened_orm/form_annotation.py:32`) needs only `SchemaName` (unique `str`) to construct — `FormSchemaID` autoincrements; `Schema`/`EntityType` are optional. `DTOConverter.form_schema_to_get` (`server/dtos/dto_converter.py:552`) and `FormSchemaGET` (`server/dtos/dtos_main.py`) already exist.
+
+---
+
+## Task 0 (git): Continue on the current feature branch — do NOT touch `development`
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer` (its existing commits are already pushed to remote); it is not merged to `development` as part of this work, so `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+All Task 1–3 commits land directly on `feature/rbac-step1-service-layer`, alongside the foundation commits.
+
+---
+
+### Task 1: FormSchemaRepository
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/form_schema_repository.py`
+- Modify: `orm/eyened_orm/repositories/__init__.py` (add `FormSchemaRepository`)
+- Test: `orm/eyened_orm/tests/test_form_schema_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm.FormSchema` (columns `FormSchemaID`, `SchemaName`).
+- Produces:
+  - `FormSchemaRepository().list_all(session: Session) -> list[FormSchema]` — ordered by `SchemaName` ascending.
+  - `FormSchemaRepository().get_by_id(session: Session, form_schema_id: int) -> FormSchema | None` — `None` if absent.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_form_schema_repository.py`:
+
+```python
+from eyened_orm import FormSchema
+from eyened_orm.repositories.form_schema_repository import FormSchemaRepository
+
+
+def test_list_all_orders_by_schema_name(session):
+    # list_all returns every schema sorted by name ascending.
+    session.add_all(
+        [
+            FormSchema(SchemaName="Zeta"),
+            FormSchema(SchemaName="Alpha"),
+            FormSchema(SchemaName="Mu"),
+        ]
+    )
+    session.flush()
+
+    result = FormSchemaRepository().list_all(session)
+
+    assert [s.SchemaName for s in result] == ["Alpha", "Mu", "Zeta"]
+
+
+def test_get_by_id_returns_the_schema(session):
+    # A known id returns that schema.
+    schema = FormSchema(SchemaName="Alpha")
+    session.add(schema)
+    session.flush()
+
+    result = FormSchemaRepository().get_by_id(session, schema.FormSchemaID)
+
+    assert result is not None
+    assert result.SchemaName == "Alpha"
+
+
+def test_get_by_id_unknown_id_returns_none(session):
+    # An unknown id returns None — the repository never raises for "not found".
+    assert FormSchemaRepository().get_by_id(session, 999_999) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_form_schema_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.form_schema_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `orm/eyened_orm/repositories/form_schema_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from eyened_orm import FormSchema
+
+
+class FormSchemaRepository:
+    """Data access for FormSchema rows."""
+
+    def list_all(self, session: Session) -> list[FormSchema]:
+        """Return all form schemas, ordered by schema name ascending."""
+        return list(
+            session.scalars(
+                select(FormSchema).order_by(FormSchema.SchemaName.asc())
+            ).all()
+        )
+
+    def get_by_id(self, session: Session, form_schema_id: int) -> FormSchema | None:
+        """Return the form schema with the given id, or None if absent."""
+        return session.get(FormSchema, form_schema_id)
+```
+
+Update `orm/eyened_orm/repositories/__init__.py`:
+
+```python
+from .device_repository import DeviceRepository
+from .form_schema_repository import FormSchemaRepository
+from .patient_repository import PatientRepository
+
+__all__ = ["DeviceRepository", "PatientRepository", "FormSchemaRepository"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_form_schema_repository.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/form_schema_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_form_schema_repository.py
+git commit -m "feat(repositories): add FormSchemaRepository"
+```
+
+---
+
+### Task 2: FormSchemaService
+
+**Files:**
+- Create: `server/services/form_schema_service.py`
+- Modify: `server/services/__init__.py` (re-export `FormSchemaService`)
+- Test: `server/tests/test_form_schema_service.py`
+
+**Interfaces:**
+- Consumes: `FormSchemaRepository.list_all` / `.get_by_id` (Task 1); `NotFoundError` (foundation).
+- Produces:
+  - `FormSchemaService(repository: FormSchemaRepository)`.
+  - `FormSchemaService.list_form_schemas(session: Session) -> list[FormSchema]`.
+  - `FormSchemaService.get_form_schema(session: Session, form_schema_id: int) -> FormSchema` — raises `NotFoundError` if absent.
+  - `get_form_schema_service() -> FormSchemaService` — default-wiring factory.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_form_schema_service.py`:
+
+```python
+import pytest
+
+from eyened_orm import FormSchema
+from eyened_orm.repositories.form_schema_repository import FormSchemaRepository
+
+from server.services.exceptions import NotFoundError
+from server.services.form_schema_service import FormSchemaService
+
+
+def test_list_form_schemas_returns_rows_in_order(session):
+    # The service hands back the repository's rows, order intact.
+    session.add_all([FormSchema(SchemaName="Zeta"), FormSchema(SchemaName="Alpha")])
+    session.flush()
+
+    service = FormSchemaService(FormSchemaRepository())
+    result = service.list_form_schemas(session)
+
+    assert [s.SchemaName for s in result] == ["Alpha", "Zeta"]
+
+
+def test_get_form_schema_returns_the_schema(session):
+    # An existing schema is returned by the service unchanged.
+    schema = FormSchema(SchemaName="Alpha")
+    session.add(schema)
+    session.flush()
+
+    service = FormSchemaService(FormSchemaRepository())
+    result = service.get_form_schema(session, schema.FormSchemaID)
+
+    assert result.SchemaName == "Alpha"
+
+
+def test_get_form_schema_unknown_id_raises_not_found(session):
+    # A missing schema makes the service raise NotFoundError (-> 404 via handler).
+    service = FormSchemaService(FormSchemaRepository())
+
+    with pytest.raises(NotFoundError):
+        service.get_form_schema(session, 999_999)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_schema_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.form_schema_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/form_schema_service.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import FormSchema
+from eyened_orm.repositories.form_schema_repository import FormSchemaRepository
+
+from .exceptions import NotFoundError
+
+
+class FormSchemaService:
+    """Business logic for form schemas."""
+
+    def __init__(self, repository: FormSchemaRepository) -> None:
+        self.repository = repository
+
+    def list_form_schemas(self, session: Session) -> list[FormSchema]:
+        """Return all form schemas, ordered by schema name."""
+        return self.repository.list_all(session)
+
+    def get_form_schema(self, session: Session, form_schema_id: int) -> FormSchema:
+        """Return the form schema with the given id.
+
+        Raises:
+            NotFoundError: If no form schema with ``form_schema_id`` exists.
+        """
+        schema = self.repository.get_by_id(session, form_schema_id)
+        if schema is None:
+            raise NotFoundError(f"FormSchema {form_schema_id} not found")
+        return schema
+
+
+def get_form_schema_service() -> FormSchemaService:
+    """Default FormSchemaService wiring for FastAPI ``Depends()``."""
+    return FormSchemaService(FormSchemaRepository())
+```
+
+Update `server/services/__init__.py`:
+
+```python
+from .device_service import DeviceService
+from .exceptions import NotFoundError, ServiceError
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_schema_service.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/form_schema_service.py server/services/__init__.py server/tests/test_form_schema_service.py
+git commit -m "feat(services): add FormSchemaService with NotFoundError on missing schema"
+```
+
+---
+
+### Task 3: Rewire `routes/form_schema.py` to use FormSchemaService
+
+**Files:**
+- Modify: `server/routes/form_schema.py`
+
+**Interfaces:**
+- Consumes: `FormSchemaService.list_form_schemas` / `.get_form_schema` and `get_form_schema_service` (Task 2); existing `DTOConverter.form_schema_to_get`, `FormSchemaGET`, `get_db`, `get_current_user`. The old inline `raise HTTPException(404, "FormSchema not found")` is removed — the 404 now flows from `NotFoundError` through the foundation's central handler.
+- Produces: unchanged HTTP contract — `GET /form-schemas` returns `list[FormSchemaGET]`; `GET /form-schemas/{form_schema_id}` returns `FormSchemaGET`, still 404 for unknown ids.
+
+- [ ] **Step 1: Replace the inline queries with Service calls**
+
+Replace the entire contents of `server/routes/form_schema.py` with:
+
+```python
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_main import FormSchemaGET
+from ..services.form_schema_service import FormSchemaService, get_form_schema_service
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+@router.get("/form-schemas", response_model=list[FormSchemaGET])
+async def list_form_schemas(
+    db: Session = Depends(get_db),
+    service: FormSchemaService = Depends(get_form_schema_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Return all form schemas."""
+    rows = service.list_form_schemas(db)
+    return [DTOConverter.form_schema_to_get(s) for s in rows]
+
+
+@router.get("/form-schemas/{form_schema_id}", response_model=FormSchemaGET)
+async def get_form_schema(
+    form_schema_id: int,
+    db: Session = Depends(get_db),
+    service: FormSchemaService = Depends(get_form_schema_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    schema = service.get_form_schema(db, form_schema_id)
+    return DTOConverter.form_schema_to_get(schema)
+```
+
+- [ ] **Step 2: Verify the router imports and exposes both routes**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "from server.routes import form_schema; print(sorted(r.path for r in form_schema.router.routes))"`
+Expected: prints `['/form-schemas', '/form-schemas/{form_schema_id}']` with no traceback.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+Run: `dev/.venv/bin/pytest -q`
+Expected: all tests pass (foundation suite + the new Task 1–2 tests); no import/collection errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/form_schema.py
+git commit -m "refactor(routes): route form_schema endpoints through FormSchemaService"
+```
+
+---
+
+## Verification (end-to-end, on `feature/rbac-step1-service-layer`)
+
+1. **Full suite green:** `dev/.venv/bin/pytest -q` — foundation suite plus the new FormSchema repository/service tests pass.
+2. **Both routes exposed:** the Task 3 Step 2 command prints `['/form-schemas', '/form-schemas/{form_schema_id}']`.
+3. **App boots:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "import server.main; print('ok')"` → `ok`.
+4. **Manual smoke (optional, real dev DB + server):** `GET /api/form-schemas` returns a JSON list; `GET /api/form-schemas/999999` returns HTTP 404 `{"detail": "FormSchema 999999 not found"}` — proving the `NotFoundError` → central-handler path is live rather than the old inline `HTTPException`.
+5. **Branch isolation:** `development` has not moved; `git log development..HEAD` shows only foundation + form_schema commits — confirming `development` was never touched.
+
+## Post-implementation (push only — still no `development` change)
+
+```bash
+git push origin feature/rbac-step1-service-layer
+```
+
+This updates the remote with the form_schema commits. Do NOT open or merge a PR into `development` yet (per the current constraint). When you are ready to integrate later, the single `feature/rbac-step1-service-layer` branch carries the foundation + form_schema work together.
+
+## Out of scope / follow-up
+
+- Phase 2 (`studies`, `feature`, `tag`), Phase 3 (`subtask`, `task`), Phase 4 (`import_api`, `instances`, `form_annotations`, `segmentations`) — each a further increment on this branch (or its own PR later), same pattern.
+- RBAC enforcement itself is **Step 2** (`PermissionDeniedError` + per-method authz).

--- a/docs/superpowers/plans/2026-07-06-studies-phase2.md
+++ b/docs/superpowers/plans/2026-07-06-studies-phase2.md
@@ -1,0 +1,928 @@
+# studies Repository/Service Migration (RBAC Step 1, Phase 2a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the three `studies` tag endpoints (`POST /studies/{id}/tags`, `DELETE /studies/{id}/tags/{tag_id}`, `PATCH /studies/{id}/tags/{tag_id}`) through a `StudyService`/`StudyRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as the reviewed Device/Patient/FormSchema slices — thin route (parse → Service → `DTOConverter` → return), Service with a constructor-injected Repository raising domain exceptions, framework-agnostic Repository taking a `Session`. This is the **first write-carrying module**, so it introduces three conventions (documented below and reused by the `feature`/`tag` plans): the Service owns `session.commit()`; audit logging is a constructor-injected Service dependency (not the global reached from inside the Service); and routes pass a services-layer `ActingUser` value object instead of the handler-layer `CurrentUser`.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model — `study_repository.py`, `study_service.py`.
+- **Class names:** `StudyRepository` / `StudyService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repository via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by the foundation's `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `Base`'s generic classmethods, or the pre-existing Device/Patient/FormSchema slices.
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions introduced by this phase (reused by `feature`/`tag`)
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session whose context manager only *closes* — it does **not** commit. So any Service method that mutates must call `session.commit()` itself. The Service is the transaction boundary.
+- **Audit logging is injected, not global-reached.** Per python-design-patterns Pattern 7 (Dependency Injection) and Pattern 2/3 (SRP / Separation of Concerns): the Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the method that performs the mutation (so the old→new `changes` diff is computed next to the write). The `get_<model>_service()` factory wires the real logger via `get_db_logger()`; Service tests inject `None` (no logging) or a small hand-rolled fake. Every logging call stays guarded by `if self.logger is not None:` — matching today's `if logger:` guard, since `get_db_logger()` returns `None` when DB logging is disabled.
+- **Acting user:** routes must not leak the handler-layer `CurrentUser` (defined in `server/routes/auth.py`) into a Service — that would invert the API→Service dependency arrow. Routes map it onto a minimal, framework-agnostic `ActingUser(id, username)` value object defined in the services layer; the Service (and Step 2's authz checks) read from that.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer`:** `ServiceError`/`NotFoundError` and the central handler (`server/services/exceptions.py`, registered in `server/main.py` — the handler dispatches every `ServiceError` subclass by MRO, so the new `BadRequestError` needs **no** `main.py` change); the `session` fixture already imported in `server/tests/conftest.py`; both `repositories/` and `services/` packages with their `__init__.py` re-exports. Existing ORM facts confirmed for this plan: `Study` (`orm/eyened_orm/study.py:21`) needs `PatientID` (FK) + `StudyDate` (a `date`); `Patient` needs `PatientIdentifier` + `ProjectID`; `Project` needs `ProjectName` + `External` (`ExternalEnum.N`); `Creator` (`orm/eyened_orm/creator.py:12`) needs `CreatorName` (unique) + `IsHuman` (bool); `Tag` (`orm/eyened_orm/tag.py:47`) needs `TagName` + `TagType` + `TagDescription` (non-null) + `CreatorID`; `StudyTagLink` (`orm/eyened_orm/tag.py:105`) has composite PK `(TagID, StudyID)` plus `CreatorID`, nullable `Comment`, `DateInserted`. The in-memory SQLite test DB runs with `PRAGMA foreign_keys=ON`, so every FK above must reference a real row. `DTOConverter.link_to_tag_metadata` (`server/dtos/dto_converter.py:143`), `TagMeta`, `ObjectTagPOST` (`tag_id`, `comment`), and `ObjectTagPATCH` (`comment`) already exist.
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `dev/.venv/bin/pytest -q`
+Expected: the existing suite (foundation + Device/Patient/FormSchema slices) collects and passes. **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+### Task 1: Add `BadRequestError` (400) to the exception hierarchy
+
+The `studies` endpoints raise HTTP 400 ("Tag type must be Study"), which the foundation's hierarchy (only `NotFoundError` → 404) cannot express yet. Add one subclass; the central handler already dispatches it by MRO, so no `main.py` change.
+
+**Files:**
+- Modify: `server/services/exceptions.py` (add `BadRequestError`)
+- Modify: `server/services/__init__.py` (re-export `BadRequestError`)
+- Test: `server/tests/test_services_exceptions.py` (extend — this file already exists from the foundation)
+
+**Interfaces:**
+- Consumes: existing `ServiceError` base + `service_error_to_response` (foundation).
+- Produces: `BadRequestError(ServiceError)` with `status_code = 400`, constructor `BadRequestError(detail: str)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_services_exceptions.py`:
+
+```python
+def test_bad_request_error_maps_to_400_response():
+    """BadRequestError maps to HTTP 400, carrying its detail message in the body."""
+    from server.services.exceptions import BadRequestError
+
+    resp = service_error_to_response(BadRequestError("Tag type must be Study"))
+    assert resp.status_code == 400
+    assert json.loads(resp.body) == {"detail": "Tag type must be Study"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_services_exceptions.py::test_bad_request_error_maps_to_400_response -v`
+Expected: FAIL — `ImportError: cannot import name 'BadRequestError'`.
+
+- [ ] **Step 3: Add the exception**
+
+In `server/services/exceptions.py`, add this class immediately after `NotFoundError`:
+
+```python
+class BadRequestError(ServiceError):
+    """A request violates a business precondition (maps to HTTP 400).
+
+    Distinct from ``pydantic.ValidationError`` (request-schema validation,
+    handled by FastAPI before the Service runs); this is a domain-rule
+    violation raised by the Service itself.
+    """
+
+    status_code = 400
+```
+
+Update `server/services/__init__.py` to re-export it:
+
+```python
+from .device_service import DeviceService
+from .exceptions import BadRequestError, NotFoundError, ServiceError
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_services_exceptions.py -v`
+Expected: PASS (all pre-existing exception tests + the new 400 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/exceptions.py server/services/__init__.py server/tests/test_services_exceptions.py
+git commit -m "feat(services): add BadRequestError (400) to the domain exception hierarchy"
+```
+
+---
+
+### Task 2: Add the `ActingUser` value object
+
+A minimal, framework-agnostic value object so Services never import the handler-layer `CurrentUser`. Routes map their `CurrentUser` onto it; Step 2's authz reads from it.
+
+This is a pure, logic-free value object (two fields, no methods), so it carries
+no unit test of its own — exercising it would only re-test stdlib `dataclass`
+behavior. Its construction and use are covered end-to-end by the Task 4 Service
+tests (which build an `ActingUser` for every call) and the Task 5 route.
+
+**Files:**
+- Create: `server/services/acting_user.py`
+- Modify: `server/services/__init__.py` (re-export `ActingUser`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ActingUser(id: int, username: str)` — a frozen dataclass.
+
+- [ ] **Step 1: Write the value object**
+
+Create `server/services/acting_user.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ActingUser:
+    """The authenticated user performing a service operation.
+
+    A framework-agnostic value object so Services never import ``CurrentUser``
+    from the routes/handler layer (which would invert the API -> Service
+    dependency arrow). Routes build this from their ``CurrentUser``; the
+    Service uses it for audit logging now and for Step 2 authz later.
+    """
+
+    id: int
+    username: str
+```
+
+Update `server/services/__init__.py`:
+
+```python
+from .acting_user import ActingUser
+from .device_service import DeviceService
+from .exceptions import BadRequestError, NotFoundError, ServiceError
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "ActingUser",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+]
+```
+
+- [ ] **Step 2: Verify it imports and constructs**
+
+Run: `dev/.venv/bin/python -c "from server.services import ActingUser; a = ActingUser(id=1, username='x'); print(a.id, a.username)"`
+Expected: prints `1 x` with no traceback.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/services/acting_user.py server/services/__init__.py
+git commit -m "feat(services): add ActingUser value object for the service layer"
+```
+
+---
+
+### Task 3: StudyRepository
+
+Named read methods for the three lookups the `studies` handlers perform inline today. Writes (add/delete/commit) stay in the Service (they are trivial session ops, not endpoint-shaped queries), matching the spec's "Repositories exist for the complex, endpoint-shaped queries — not to reimplement basic CRUD."
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/study_repository.py`
+- Modify: `orm/eyened_orm/repositories/__init__.py` (add `StudyRepository`)
+- Test: `orm/eyened_orm/tests/test_study_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm.Study`, `eyened_orm.Tag`, `eyened_orm.StudyTagLink`.
+- Produces:
+  - `StudyRepository().get_by_id(session: Session, study_id: int) -> Study | None`.
+  - `StudyRepository().get_tag(session: Session, tag_id: int) -> Tag | None`.
+  - `StudyRepository().get_link(session: Session, tag_id: int, study_id: int) -> StudyTagLink | None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_study_repository.py`:
+
+```python
+import datetime
+
+from eyened_orm import Creator, Patient, Project, Study, StudyTagLink, Tag
+from eyened_orm.project import ExternalEnum
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.study_repository import StudyRepository
+
+
+def _make_study(session) -> Study:
+    project = Project(ProjectName="P", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier="ID1", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    return study
+
+
+def _make_creator(session) -> Creator:
+    creator = Creator(CreatorName="tester", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return creator
+
+
+def _make_study_tag(session, creator_id: int) -> Tag:
+    tag = Tag(
+        TagName="Baseline",
+        TagType=TagType.Study,
+        TagDescription="",
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_get_link_returns_the_link(session):
+    """get_link resolves the StudyTagLink by its composite (TagID, StudyID) key."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_study_tag(session, creator.CreatorID)
+    session.add(
+        StudyTagLink(TagID=tag.TagID, StudyID=study.StudyID, CreatorID=creator.CreatorID)
+    )
+    session.flush()
+
+    result = StudyRepository().get_link(session, tag.TagID, study.StudyID)
+    assert result is not None
+    assert result.TagID == tag.TagID
+    assert result.StudyID == study.StudyID
+
+
+def test_get_link_absent_returns_none(session):
+    """get_link returns None (never raises) when the pair is not linked."""
+    study = _make_study(session)
+    assert StudyRepository().get_link(session, 999_999, study.StudyID) is None
+```
+
+> **Note — why no direct `get_by_id`/`get_tag` tests:** both are thin `session.get(...)`
+> wrappers whose happy path *and* not-found path are already exercised through the
+> Task 4 Service tests (e.g. `test_tag_study_unknown_study_raises_not_found`,
+> `test_tag_study_unknown_tag_raises_not_found`). Only `get_link`'s composite-key
+> lookup is fallible enough to warrant its own repository-level test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_study_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.study_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `orm/eyened_orm/repositories/study_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import Study, StudyTagLink, Tag
+
+
+class StudyRepository:
+    """Data access for Study rows and their Tag links."""
+
+    def get_by_id(self, session: Session, study_id: int) -> Study | None:
+        """Return the study with the given id, or None if absent."""
+        return session.get(Study, study_id)
+
+    def get_tag(self, session: Session, tag_id: int) -> Tag | None:
+        """Return the tag with the given id, or None if absent.
+
+        Kept here (rather than depending on a future TagRepository) so this
+        module migrates independently; ``studies`` only needs to read a Tag to
+        validate its ``TagType`` before linking.
+        """
+        return session.get(Tag, tag_id)
+
+    def get_link(
+        self, session: Session, tag_id: int, study_id: int
+    ) -> StudyTagLink | None:
+        """Return the StudyTagLink for (tag, study), or None if not linked."""
+        return session.get(StudyTagLink, {"TagID": tag_id, "StudyID": study_id})
+```
+
+Update `orm/eyened_orm/repositories/__init__.py`:
+
+```python
+from .device_repository import DeviceRepository
+from .form_schema_repository import FormSchemaRepository
+from .patient_repository import PatientRepository
+from .study_repository import StudyRepository
+
+__all__ = [
+    "DeviceRepository",
+    "PatientRepository",
+    "FormSchemaRepository",
+    "StudyRepository",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_study_repository.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/study_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_study_repository.py
+git commit -m "feat(repositories): add StudyRepository"
+```
+
+---
+
+### Task 4: StudyService
+
+Holds the business rules the `studies` handlers encode today (existence → 404, wrong tag type → 400, create-vs-update-comment), owns the commit, and emits audit logging via an injected logger.
+
+**Files:**
+- Create: `server/services/study_service.py`
+- Modify: `server/services/__init__.py` (re-export `StudyService`)
+- Test: `server/tests/test_study_service.py`
+
+**Interfaces:**
+- Consumes: `StudyRepository` (Task 3); `NotFoundError`/`BadRequestError` (Task 1); `ActingUser` (Task 2); `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.StudyTagLink`, `eyened_orm.tag.TagType`.
+- Produces:
+  - `StudyService(repository: StudyRepository, logger: DatabaseModificationLogger | None = None)`.
+  - `StudyService.tag_study(session, study_id, tag_id, comment, actor) -> StudyTagLink` — 404 if study/tag absent, 400 if tag not a Study tag; creates the link (or updates its comment if already linked).
+  - `StudyService.untag_study(session, study_id, tag_id, actor) -> None` — 404 if study absent; idempotent delete (no error if not linked).
+  - `StudyService.patch_study_tag(session, study_id, tag_id, comment, actor) -> StudyTagLink` — 404 if study/tag/link absent, 400 if tag not a Study tag; updates the comment.
+  - `get_study_service() -> StudyService` — default-wiring factory (`StudyRepository()` + `get_db_logger()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_study_service.py`:
+
+```python
+import datetime
+
+import pytest
+
+from eyened_orm import Creator, Patient, Project, Study, StudyTagLink, Tag
+from eyened_orm.project import ExternalEnum
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.study_repository import StudyRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import BadRequestError, NotFoundError
+from server.services.study_service import StudyService
+
+
+def _make_study(session) -> Study:
+    project = Project(ProjectName="P", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier="ID1", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    return study
+
+
+def _make_creator(session) -> Creator:
+    creator = Creator(CreatorName="tester", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return creator
+
+
+def _make_tag(session, creator_id: int, tag_type: TagType = TagType.Study) -> Tag:
+    tag = Tag(
+        TagName=f"Tag-{tag_type.value}",
+        TagType=tag_type,
+        TagDescription="",
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _service(logger=None) -> StudyService:
+    return StudyService(StudyRepository(), logger=logger)
+
+
+def _actor() -> ActingUser:
+    return ActingUser(id=1, username="alice")
+
+
+def test_tag_study_creates_a_new_link(session):
+    """First-time tagging inserts a StudyTagLink carrying the comment and actor id."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID)
+
+    link = _service().tag_study(session, study.StudyID, tag.TagID, "hi", _actor())
+
+    assert link.TagID == tag.TagID
+    assert link.StudyID == study.StudyID
+    assert link.Comment == "hi"
+    assert link.CreatorID == 1
+
+
+def test_tag_study_unknown_study_raises_not_found(session):
+    """Tagging a non-existent study is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().tag_study(session, 999_999, 1, None, _actor())
+
+
+def test_tag_study_unknown_tag_raises_not_found(session):
+    """A valid study but unknown tag id is translated to NotFoundError (-> 404)."""
+    study = _make_study(session)
+    with pytest.raises(NotFoundError):
+        _service().tag_study(session, study.StudyID, 999_999, None, _actor())
+
+
+def test_tag_study_wrong_tag_type_raises_bad_request(session):
+    """A non-Study tag is rejected with BadRequestError (-> 400), not linked."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID, tag_type=TagType.ImageInstance)
+
+    with pytest.raises(BadRequestError):
+        _service().tag_study(session, study.StudyID, tag.TagID, None, _actor())
+
+
+def test_tag_study_existing_link_updates_comment(session):
+    """Re-tagging an already-linked pair updates the comment in place (idempotent)."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID)
+    service = _service()
+    service.tag_study(session, study.StudyID, tag.TagID, "first", _actor())
+
+    link = service.tag_study(session, study.StudyID, tag.TagID, "second", _actor())
+
+    assert link.Comment == "second"
+    # Still a single link (no duplicate row created).
+    assert StudyRepository().get_link(session, tag.TagID, study.StudyID) is not None
+
+
+def test_tag_study_logs_insert_when_logger_present(session):
+    """When a logger is injected, creating a link emits one insert audit record."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID)
+    logger = FakeAuditLogger()
+
+    _service(logger).tag_study(session, study.StudyID, tag.TagID, "hi", _actor())
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["user"] == "alice"
+    assert logger.inserts[0]["entity"] == "StudyTagLink"
+
+
+def test_untag_study_removes_the_link(session):
+    """Untagging deletes the existing StudyTagLink for the (study, tag) pair."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID)
+    service = _service()
+    service.tag_study(session, study.StudyID, tag.TagID, None, _actor())
+
+    service.untag_study(session, study.StudyID, tag.TagID, _actor())
+
+    assert StudyRepository().get_link(session, tag.TagID, study.StudyID) is None
+
+
+def test_untag_study_unknown_study_raises_not_found(session):
+    """Untagging a non-existent study is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().untag_study(session, 999_999, 1, _actor())
+
+
+def test_untag_study_no_link_is_idempotent(session):
+    """Untagging a study that has no such link is a silent no-op, not an error."""
+    study = _make_study(session)
+    # No link exists; deleting is a no-op, not an error.
+    _service().untag_study(session, study.StudyID, 999_999, _actor())
+
+
+def test_patch_study_tag_updates_comment(session):
+    """Patching an existing link overwrites its comment with the new value."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID)
+    service = _service()
+    service.tag_study(session, study.StudyID, tag.TagID, "old", _actor())
+
+    link = service.patch_study_tag(session, study.StudyID, tag.TagID, "new", _actor())
+
+    assert link.Comment == "new"
+
+
+def test_patch_study_tag_missing_link_raises_not_found(session):
+    """Patching when study+tag exist but no link does raises NotFoundError (-> 404)."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID)
+
+    with pytest.raises(NotFoundError):
+        _service().patch_study_tag(session, study.StudyID, tag.TagID, "x", _actor())
+
+
+def test_patch_study_tag_wrong_tag_type_raises_bad_request(session):
+    """Patching a link via a non-Study tag is rejected with BadRequestError (-> 400)."""
+    study = _make_study(session)
+    creator = _make_creator(session)
+    tag = _make_tag(session, creator.CreatorID, tag_type=TagType.Segmentation)
+
+    with pytest.raises(BadRequestError):
+        _service().patch_study_tag(session, study.StudyID, tag.TagID, "x", _actor())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_study_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.study_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/study_service.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import StudyTagLink
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.study_repository import StudyRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import BadRequestError, NotFoundError
+
+
+class StudyService:
+    """Business logic for tagging studies."""
+
+    def __init__(
+        self,
+        repository: StudyRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.logger = logger
+
+    def tag_study(
+        self,
+        session: Session,
+        study_id: int,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> StudyTagLink:
+        """Attach a Study tag to a study (idempotent; updates comment if linked).
+
+        Raises:
+            NotFoundError: If the study or tag does not exist.
+            BadRequestError: If the tag's type is not ``TagType.Study``.
+        """
+        study = self.repository.get_by_id(session, study_id)
+        if study is None:
+            raise NotFoundError(f"Study {study_id} not found")
+        tag = self.repository.get_tag(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+        if tag.TagType != TagType.Study:
+            raise BadRequestError("Tag type must be Study")
+
+        link = self.repository.get_link(session, tag_id, study_id)
+        if link is None:
+            link = StudyTagLink(
+                TagID=tag.TagID,
+                StudyID=study_id,
+                CreatorID=actor.id,
+                Comment=comment,
+            )
+            session.add(link)
+            session.commit()
+            session.refresh(link)
+            link.Tag = tag
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/studies/{study_id}/tags",
+                    entity="StudyTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "study_id": study_id,
+                        "comment": comment,
+                    },
+                )
+        elif comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            link.Tag = tag
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/studies/{study_id}/tags",
+                    entity="StudyTagLink",
+                    fields={"tag_id": tag.TagID, "study_id": study_id},
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+        return link
+
+    def untag_study(
+        self,
+        session: Session,
+        study_id: int,
+        tag_id: int,
+        actor: ActingUser,
+    ) -> None:
+        """Remove a Study tag from a study (idempotent).
+
+        Raises:
+            NotFoundError: If the study does not exist.
+        """
+        study = self.repository.get_by_id(session, study_id)
+        if study is None:
+            raise NotFoundError(f"Study {study_id} not found")
+        link = self.repository.get_link(session, tag_id, study_id)
+        if link is None:
+            return None
+
+        deleted_data = {
+            "tag_id": tag_id,
+            "study_id": study_id,
+            "comment": link.Comment,
+            "creator_id": link.CreatorID,
+        }
+        session.delete(link)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/studies/{study_id}/tags/{tag_id}",
+                entity="StudyTagLink",
+                fields={"tag_id": tag_id, "study_id": study_id},
+                deleted_data=deleted_data,
+            )
+        return None
+
+    def patch_study_tag(
+        self,
+        session: Session,
+        study_id: int,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> StudyTagLink:
+        """Update the comment on an existing Study tag link.
+
+        Raises:
+            NotFoundError: If the study, tag, or link does not exist.
+            BadRequestError: If the tag's type is not ``TagType.Study``.
+        """
+        study = self.repository.get_by_id(session, study_id)
+        if study is None:
+            raise NotFoundError(f"Study {study_id} not found")
+        tag = self.repository.get_tag(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+        if tag.TagType != TagType.Study:
+            raise BadRequestError("Tag type must be Study")
+        link = self.repository.get_link(session, tag_id, study_id)
+        if link is None:
+            raise NotFoundError(f"Tag {tag_id} is not linked to study {study_id}")
+
+        if comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"PATCH /api/studies/{study_id}/tags/{tag_id}",
+                    entity="StudyTagLink",
+                    fields={"tag_id": tag_id, "study_id": study_id},
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+        link.Tag = tag
+        return link
+
+
+def get_study_service() -> StudyService:
+    """Default StudyService wiring for FastAPI ``Depends()``."""
+    return StudyService(StudyRepository(), logger=get_db_logger())
+```
+
+Update `server/services/__init__.py`:
+
+```python
+from .acting_user import ActingUser
+from .device_service import DeviceService
+from .exceptions import BadRequestError, NotFoundError, ServiceError
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+from .study_service import StudyService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "ActingUser",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+    "StudyService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_study_service.py -v`
+Expected: PASS (12 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/study_service.py server/services/__init__.py server/tests/test_study_service.py
+git commit -m "feat(services): add StudyService with injected audit logging"
+```
+
+---
+
+### Task 5: Rewire `routes/studies.py` to use StudyService
+
+**Files:**
+- Modify: `server/routes/studies.py`
+
+**Interfaces:**
+- Consumes: `StudyService` + `get_study_service` (Task 4); `ActingUser` (Task 2); existing `DTOConverter.link_to_tag_metadata`, `TagMeta`, `ObjectTagPOST`, `ObjectTagPATCH`, `get_db`, `get_current_user`. The inline `db.get(...)`, `raise HTTPException(...)`, `db.commit()`, and `get_db_logger()` calls are removed — existence/type checks now raise domain exceptions handled centrally, the Service owns the commit, and the Service emits the audit log.
+- Produces: unchanged HTTP contract — `POST /studies/{id}/tags` → `TagMeta`; `DELETE /studies/{id}/tags/{tag_id}` → 204; `PATCH /studies/{id}/tags/{tag_id}` → `TagMeta`. Same 404 for unknown study/tag/link and 400 for wrong tag type (now flowing through the central handler).
+
+- [ ] **Step 1: Replace the handler bodies with Service calls**
+
+Replace the entire contents of `server/routes/studies.py` with:
+
+```python
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_aux import ObjectTagPATCH, ObjectTagPOST, TagMeta
+from ..services.acting_user import ActingUser
+from ..services.study_service import StudyService, get_study_service
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/studies/{study_id}/tags", response_model=TagMeta)
+async def tag_study(
+    study_id: int,
+    body: ObjectTagPOST,
+    db: Session = Depends(get_db),
+    service: StudyService = Depends(get_study_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
+    """Attach a Tag to a Study by tag ID (idempotent)."""
+    link = service.tag_study(
+        db,
+        study_id,
+        body.tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.link_to_tag_metadata(link)
+
+
+@router.delete("/studies/{study_id}/tags/{tag_id}", status_code=204)
+async def untag_study(
+    study_id: int,
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: StudyService = Depends(get_study_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Remove a Tag from a Study (idempotent)."""
+    service.untag_study(
+        db,
+        study_id,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.patch("/studies/{study_id}/tags/{tag_id}", response_model=TagMeta)
+async def patch_study_tag(
+    study_id: int,
+    tag_id: int,
+    body: ObjectTagPATCH,
+    db: Session = Depends(get_db),
+    service: StudyService = Depends(get_study_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
+    """Update comment on an existing Study tag link."""
+    link = service.patch_study_tag(
+        db,
+        study_id,
+        tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.link_to_tag_metadata(link)
+```
+
+- [ ] **Step 2: Verify the router imports and exposes all three routes**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "from server.routes import studies; print(sorted((r.path, tuple(sorted(r.methods))) for r in studies.router.routes))"`
+Expected: prints the three routes — `/studies/{study_id}/tags` (POST), `/studies/{study_id}/tags/{tag_id}` (DELETE and PATCH) — with no traceback.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+Run: `dev/.venv/bin/pytest -q`
+Expected: all tests pass (prior suite + the new Task 1–4 tests); no import/collection errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/studies.py
+git commit -m "refactor(routes): route studies tag endpoints through StudyService"
+```
+
+---
+
+## Verification (end-to-end, on `feature/rbac-step1-service-layer`)
+
+1. **Full suite green:** `dev/.venv/bin/pytest -q` — prior suite plus the new exception/ActingUser/StudyRepository/StudyService tests pass.
+2. **All three routes exposed:** the Task 5 Step 2 command prints the POST/DELETE/PATCH routes.
+3. **App boots:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "import server.main; print('ok')"` → `ok`.
+4. **Manual smoke (optional, real dev DB + server):**
+   - `POST /api/studies/999999/tags` with a JSON body `{"tag_id": 1}` → HTTP 404 `{"detail": "Study 999999 not found"}` (proves the `NotFoundError` → central-handler path is live).
+   - Tag a real study with a non-Study tag → HTTP 400 `{"detail": "Tag type must be Study"}` (proves the new `BadRequestError` → 400 path).
+   - Tag a real study with a real Study tag → HTTP 200 `TagMeta`; repeat → still 200 (idempotent); `DELETE` → 204.
+5. **Branch isolation:** `git log development..HEAD` shows only the RBAC-step1 commits; `development` has not moved.
+
+## Out of scope / follow-up
+
+- Phase 2b `feature` and Phase 2c `tag` — each its own plan/PR on this branch, same pattern. `feature` additionally introduces `ConflictError` (409) with a **structured** detail body (`{code, message, ...}`), which will widen `ServiceError`'s `detail` to accept a dict; `tag` reuses everything here.
+- Phase 3 (`subtask`, `task`), Phase 4 (`import_api`, `instances`, `form_annotations`, `segmentations`).
+- RBAC enforcement itself is **Step 2** (`PermissionDeniedError` + per-method authz checks that read `ActingUser`).
+```

--- a/docs/superpowers/plans/2026-07-07-feature-phase2b.md
+++ b/docs/superpowers/plans/2026-07-07-feature-phase2b.md
@@ -1,0 +1,1082 @@
+# feature Repository/Service Migration (RBAC Step 1, Phase 2b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the five `features` endpoints (`GET /features`, `POST /features`, `GET /features/{id}`, `PATCH /features/{id}`, `DELETE /features/{id}`) through a `FeatureService`/`FeatureRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as the reviewed Device/Patient/FormSchema/Study slices — thin route (parse → Service → `DTOConverter` → return), Service with a constructor-injected Repository raising domain exceptions and owning the commit, framework-agnostic Repository taking a `Session`. This phase reuses the conventions the `studies` slice introduced (Service owns `session.commit()`; audit logging is a constructor-injected dependency; routes pass an `ActingUser`), and adds **one new element**: `ConflictError` (409) carrying a **structured dict** detail body (`{code, message, ...}`), which requires widening `ServiceError.detail` from `str` to `str | dict`.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model — `feature_repository.py`, `feature_service.py`.
+- **Class names:** `FeatureRepository` / `FeatureService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repository via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by the foundation's `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `Base`'s generic classmethods, or the pre-existing Device/Patient/FormSchema/Study slices.
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions reused from the `studies` phase (Phase 2a)
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session that is only *closed*, never committed, by its context manager. Every mutating Service method calls `session.commit()` itself — the Service is the transaction boundary.
+- **Audit logging is injected, not global-reached.** The Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the mutating method. `get_feature_service()` wires the real logger via `get_db_logger()`; Service tests inject `None` or a small hand-rolled fake. Every logging call stays guarded by `if self.logger is not None:` (matching today's `if logger:` guard, since `get_db_logger()` returns `None` when DB logging is disabled).
+- **Acting user:** routes map their handler-layer `CurrentUser` onto the framework-agnostic `ActingUser(id, username)` value object (`server/services/acting_user.py`, already exists) before calling a Service.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer`:** `ServiceError`/`NotFoundError`/`BadRequestError` and the central handler (`server/services/exceptions.py`, registered in `server/main.py` via `register_exception_handlers` — the handler dispatches every `ServiceError` subclass by MRO, so the new `ConflictError` needs **no** `main.py` change); the `session` fixture already imported in `server/tests/conftest.py`; the `ActingUser` value object; both `repositories/` and `services/` packages with their `__init__.py` re-exports.
+
+> **Existing ORM/DTO facts confirmed for this plan:**
+> - `Feature` (`orm/eyened_orm/segmentation.py:590`): `FeatureID` (PK), `FeatureName` (`String(60)`, **unique**), `DateInserted` (server default). Properties: `subfeatures -> dict[int, str]`, `has_segmentations`, `is_child`.
+> - `FeatureFeatureLink` (`orm/eyened_orm/segmentation.py:562`, table `CompositeFeature`): composite PK `(ParentFeatureID, ChildFeatureID, FeatureIndex)`. `ParentFeatureID` FK → `Feature` `ON DELETE CASCADE` (`passive_deletes=True` on `Feature.FeatureAssociations`); `ChildFeatureID` FK → `Feature` `ON DELETE RESTRICT`. **`FeatureIndex` is 0-based** in the API path (the route uses `enumerate(...)` starting at 0 — preserve this; note `Feature.from_list` uses 1-based indices for a different, CLI code path we do not touch).
+> - `Segmentation.FeatureID` FK → `Feature`; used only to *count* references when guarding delete.
+> - DTOs (`server/dtos/dtos_main.py`): `FeaturePUT(name: str, subfeature_ids: list[int] | None)`, `FeaturePATCH(name: str | None, subfeature_ids: list[int] | None)`, `FeatureGET(...)`. `DTOConverter.feature_to_get(feature, segmentation_count=None)` (`server/dtos/dto_converter.py:479`) already exists and stays at the route boundary unchanged.
+> - The in-memory SQLite test DB runs with `PRAGMA foreign_keys=ON`, so every FK (a `FeatureFeatureLink`'s child id, a `Segmentation`'s feature id) must reference a real row.
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `dev/.venv/bin/pytest -q`
+Expected: the existing suite (foundation + Device/Patient/FormSchema/Study slices) collects and passes (baseline: 125 passed). **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+## Task 1: Add `ConflictError` (409) and widen `ServiceError.detail` to accept a dict
+
+The `DELETE /features/{id}` endpoint raises HTTP 409 with a **structured** detail body (`{code, message, segmentation_count}` or `{code, message, parents}`), which the hierarchy cannot express yet: `ServiceError.__init__` currently types `detail` as `str`. Widen it to `str | dict` and add one subclass; the central handler already dispatches by MRO and already serializes `exc.detail` straight into `{"detail": exc.detail}`, so a dict detail flows through unchanged and **no `main.py` change** is needed.
+
+**Files:**
+- Modify: `server/services/exceptions.py` (widen `detail` type; add `ConflictError`)
+- Modify: `server/services/__init__.py` (re-export `ConflictError`)
+- Test: `server/tests/test_services_exceptions.py` (extend — file already exists)
+
+**Interfaces:**
+- Consumes: existing `ServiceError` base + `service_error_to_response`.
+- Produces: `ConflictError(ServiceError)` with `status_code = 409`, constructor `ConflictError(detail: str | dict)`; `ServiceError.detail` now `str | dict`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_services_exceptions.py`:
+
+```python
+def test_conflict_error_maps_to_409_with_structured_detail():
+    """ConflictError maps to HTTP 409 and preserves a structured (dict) detail body."""
+    from server.services.exceptions import ConflictError
+
+    detail = {
+        "code": "FEATURE_HAS_SEGMENTATIONS",
+        "message": "Cannot delete feature 'X' because it has 3 linked segmentation(s).",
+        "segmentation_count": 3,
+    }
+    resp = service_error_to_response(ConflictError(detail))
+    assert resp.status_code == 409
+    assert json.loads(resp.body) == {"detail": detail}
+```
+
+> This test relies on `json` and `service_error_to_response` already being imported at the top of `test_services_exceptions.py` (they are — the existing `BadRequestError`/`NotFoundError` tests use them). Only `ConflictError` is imported inline, matching the existing `BadRequestError` test's style.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_services_exceptions.py::test_conflict_error_maps_to_409_with_structured_detail -v`
+Expected: FAIL — `ImportError: cannot import name 'ConflictError'`.
+
+- [ ] **Step 3: Widen the base type and add the exception**
+
+In `server/services/exceptions.py`, change the `ServiceError.__init__` signature so `detail` accepts a dict:
+
+```python
+class ServiceError(Exception):
+    """Base class for service-layer errors. Maps to HTTP ``status_code``."""
+
+    status_code: int = 500
+
+    def __init__(self, detail: str | dict) -> None:
+        self.detail = detail
+        super().__init__(detail)
+```
+
+Then add this class immediately after `BadRequestError`:
+
+```python
+class ConflictError(ServiceError):
+    """A request conflicts with the current state of a resource (maps to HTTP 409).
+
+    Its ``detail`` is a structured dict (``{"code", "message", ...}``) so the
+    client can branch on a stable ``code`` rather than parsing a message string.
+    The central handler serializes it into ``{"detail": <dict>}`` unchanged.
+    """
+
+    status_code = 409
+```
+
+Update `server/services/__init__.py` to re-export it:
+
+```python
+from .acting_user import ActingUser
+from .device_service import DeviceService
+from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+from .study_service import StudyService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "ConflictError",
+    "ActingUser",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+    "StudyService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_services_exceptions.py -v`
+Expected: PASS (all pre-existing exception tests + the new 409 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/exceptions.py server/services/__init__.py server/tests/test_services_exceptions.py
+git commit -m "feat(services): add ConflictError (409) with structured dict detail"
+```
+
+---
+
+## Task 2: FeatureRepository
+
+Named read/query methods for the lookups the `features` handlers perform inline today, plus `replace_subfeatures` (the module-level `set_subfeatures` helper moved down from the route — it is a query-shaped delete+reinsert, not a trivial single-row op, so it belongs in the Repository). No method commits; the Service owns the transaction boundary.
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/feature_repository.py`
+- Modify: `orm/eyened_orm/repositories/__init__.py` (add `FeatureRepository`)
+- Test: `orm/eyened_orm/tests/test_feature_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm.Feature`, `eyened_orm.segmentation.FeatureFeatureLink`, `eyened_orm.segmentation.Segmentation`.
+- Produces (all take `session: Session` first):
+  - `get_by_id(session, feature_id: int) -> Feature | None`
+  - `list_all(session) -> list[Feature]` — ordered by `FeatureName` ascending.
+  - `segmentation_counts(session) -> dict[int, int]` — `{FeatureID: count}` over all features that have segmentations.
+  - `count_segmentations(session, feature_id: int) -> int`
+  - `parent_names_of_child(session, feature_id: int) -> list[str]` — names of features that list this feature as a child.
+  - `list_subfeature_ids(session, feature_id: int) -> list[int]` — child ids ordered by `FeatureIndex`.
+  - `replace_subfeatures(session, parent_id: int, sub_ids: list[int] | None) -> None` — delete existing parent→child links, re-add 0-indexed; flushes, does **not** commit.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_feature_repository.py`:
+
+```python
+from eyened_orm import Feature
+from eyened_orm.repositories.feature_repository import FeatureRepository
+
+
+def _feat(session, name: str) -> Feature:
+    f = Feature(FeatureName=name)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def test_list_all_orders_by_name(session):
+    """list_all returns every feature sorted by FeatureName ascending."""
+    _feat(session, "Zeta")
+    _feat(session, "Alpha")
+    _feat(session, "Mu")
+    names = [f.FeatureName for f in FeatureRepository().list_all(session)]
+    assert names == ["Alpha", "Mu", "Zeta"]
+
+
+def test_replace_subfeatures_sets_ordered_children(session):
+    """replace_subfeatures writes child links preserving list order as 0-based FeatureIndex."""
+    parent = _feat(session, "parent")
+    a = _feat(session, "a")
+    b = _feat(session, "b")
+    repo = FeatureRepository()
+
+    repo.replace_subfeatures(session, parent.FeatureID, [b.FeatureID, a.FeatureID])
+
+    assert repo.list_subfeature_ids(session, parent.FeatureID) == [b.FeatureID, a.FeatureID]
+
+
+def test_replace_subfeatures_overwrites_previous(session):
+    """replace_subfeatures clears prior links before writing the new set."""
+    parent = _feat(session, "parent")
+    a = _feat(session, "a")
+    b = _feat(session, "b")
+    repo = FeatureRepository()
+    repo.replace_subfeatures(session, parent.FeatureID, [a.FeatureID])
+
+    repo.replace_subfeatures(session, parent.FeatureID, [b.FeatureID])
+
+    assert repo.list_subfeature_ids(session, parent.FeatureID) == [b.FeatureID]
+
+
+def test_parent_names_of_child_lists_parents(session):
+    """parent_names_of_child returns the names of features linking to this child."""
+    parent = _feat(session, "parent")
+    child = _feat(session, "child")
+    FeatureRepository().replace_subfeatures(session, parent.FeatureID, [child.FeatureID])
+
+    assert FeatureRepository().parent_names_of_child(session, child.FeatureID) == ["parent"]
+
+
+def test_count_segmentations_zero_when_none(session):
+    """count_segmentations returns 0 for a feature with no linked segmentations."""
+    f = _feat(session, "lonely")
+    assert FeatureRepository().count_segmentations(session, f.FeatureID) == 0
+
+
+def test_segmentation_counts_empty_when_no_segmentations(session):
+    """segmentation_counts returns an empty mapping when no segmentations exist."""
+    _feat(session, "x")
+    assert FeatureRepository().segmentation_counts(session) == {}
+```
+
+> **Note — why no dedicated `get_by_id` test:** it is a thin `session.get(...)` wrapper whose happy and not-found paths are exercised through the Task 3 Service tests (e.g. `test_get_feature_returns_it`, `test_get_feature_unknown_raises_not_found`). The `>0`/non-empty segmentation-count paths are forced with a hand-rolled fake in the Service tests (building a full `Segmentation` graph would add FK setup unrelated to what is being verified).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_feature_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.feature_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `orm/eyened_orm/repositories/feature_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import Session
+
+from eyened_orm import Feature
+from eyened_orm.segmentation import FeatureFeatureLink, Segmentation
+
+
+class FeatureRepository:
+    """Data access for Feature rows and their parent/child (composite) links."""
+
+    def get_by_id(self, session: Session, feature_id: int) -> Feature | None:
+        """Return the feature with the given id, or None if absent."""
+        return session.get(Feature, feature_id)
+
+    def list_all(self, session: Session) -> list[Feature]:
+        """Return all features ordered by name (ascending)."""
+        return list(
+            session.scalars(select(Feature).order_by(Feature.FeatureName.asc())).all()
+        )
+
+    def segmentation_counts(self, session: Session) -> dict[int, int]:
+        """Return {FeatureID: segmentation count} for features that have any."""
+        rows = session.execute(
+            select(Segmentation.FeatureID, func.count()).group_by(Segmentation.FeatureID)
+        ).all()
+        return {fid: cnt for fid, cnt in rows}
+
+    def count_segmentations(self, session: Session, feature_id: int) -> int:
+        """Return how many segmentations reference this feature."""
+        return session.execute(
+            select(func.count())
+            .select_from(Segmentation)
+            .where(Segmentation.FeatureID == feature_id)
+        ).scalar_one()
+
+    def parent_names_of_child(self, session: Session, feature_id: int) -> list[str]:
+        """Return the names of features that list this feature as a child."""
+        return list(
+            session.execute(
+                select(Feature.FeatureName)
+                .join(
+                    FeatureFeatureLink,
+                    Feature.FeatureID == FeatureFeatureLink.ParentFeatureID,
+                )
+                .where(FeatureFeatureLink.ChildFeatureID == feature_id)
+            )
+            .scalars()
+            .all()
+        )
+
+    def list_subfeature_ids(self, session: Session, feature_id: int) -> list[int]:
+        """Return this feature's child ids, ordered by FeatureIndex."""
+        return list(
+            session.execute(
+                select(FeatureFeatureLink.ChildFeatureID)
+                .where(FeatureFeatureLink.ParentFeatureID == feature_id)
+                .order_by(FeatureFeatureLink.FeatureIndex)
+            )
+            .scalars()
+            .all()
+        )
+
+    def replace_subfeatures(
+        self, session: Session, parent_id: int, sub_ids: list[int] | None
+    ) -> None:
+        """Replace all of a feature's child links with ``sub_ids`` (0-indexed).
+
+        Deletes existing parent->child links, then re-adds one link per id in
+        order. Flushes so a following read in the same transaction sees the new
+        state; does not commit (the Service owns the transaction boundary).
+        """
+        session.execute(
+            delete(FeatureFeatureLink).where(
+                FeatureFeatureLink.ParentFeatureID == parent_id
+            )
+        )
+        for idx, child_id in enumerate(sub_ids or []):
+            session.add(
+                FeatureFeatureLink(
+                    ParentFeatureID=parent_id,
+                    ChildFeatureID=child_id,
+                    FeatureIndex=idx,
+                )
+            )
+        session.flush()
+```
+
+Update `orm/eyened_orm/repositories/__init__.py`:
+
+```python
+from .device_repository import DeviceRepository
+from .feature_repository import FeatureRepository
+from .form_schema_repository import FormSchemaRepository
+from .patient_repository import PatientRepository
+from .study_repository import StudyRepository
+
+__all__ = [
+    "DeviceRepository",
+    "PatientRepository",
+    "FormSchemaRepository",
+    "StudyRepository",
+    "FeatureRepository",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_feature_repository.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/feature_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_feature_repository.py
+git commit -m "feat(repositories): add FeatureRepository"
+```
+
+---
+
+## Task 3: FeatureService
+
+Holds the business rules the `features` handlers encode today (existence → 404, two delete guards → 409, create/update-with-subfeatures orchestration), owns the commit, and emits audit logging via an injected logger.
+
+**Files:**
+- Create: `server/services/feature_service.py`
+- Modify: `server/services/__init__.py` (re-export `FeatureService`)
+- Test: `server/tests/test_feature_service.py`
+
+**Interfaces:**
+- Consumes: `FeatureRepository` (Task 2); `NotFoundError`/`ConflictError` (Task 1); `ActingUser`; `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.Feature`.
+- Produces:
+  - `FeatureService(repository: FeatureRepository, logger: DatabaseModificationLogger | None = None)`.
+  - `list_features(session, with_counts: bool) -> tuple[list[Feature], dict[int, int]]` — features ordered by name; counts is `{}` unless `with_counts`.
+  - `get_feature(session, feature_id) -> Feature` — 404 if absent.
+  - `create_feature(session, name, subfeature_ids, actor) -> Feature` — inserts a feature + its subfeature links.
+  - `update_feature(session, feature_id, name, subfeature_ids, actor) -> Feature` — 404 if absent; updates name and/or subfeatures (each optional).
+  - `delete_feature(session, feature_id, actor) -> None` — 404 if absent; 409 (`FEATURE_HAS_SEGMENTATIONS`) if any segmentation references it; 409 (`FEATURE_IS_CHILD`) if it is a child of any feature; else deletes.
+  - `get_feature_service() -> FeatureService` — default-wiring factory (`FeatureRepository()` + `get_db_logger()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_feature_service.py`:
+
+```python
+import pytest
+
+from eyened_orm import Feature
+from eyened_orm.repositories.feature_repository import FeatureRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import ConflictError, NotFoundError
+from server.services.feature_service import FeatureService
+
+
+def _make_feature(session, name: str) -> Feature:
+    f = Feature(FeatureName=name)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def _service(logger=None) -> FeatureService:
+    return FeatureService(FeatureRepository(), logger=logger)
+
+
+def _actor() -> ActingUser:
+    return ActingUser(id=1, username="alice")
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+class _SegBlockingRepo:
+    """Hand-rolled fake forcing the 'has segmentations' guard without a real Segmentation."""
+
+    def get_by_id(self, session, feature_id):
+        f = Feature(FeatureName="Retina")
+        f.FeatureID = feature_id
+        return f
+
+    def count_segmentations(self, session, feature_id):
+        return 3
+
+
+def test_create_feature_persists_with_subfeatures(session):
+    """Creating a feature with subfeature ids writes the ordered child links."""
+    child = _make_feature(session, "child")
+
+    feature = _service().create_feature(session, "parent", [child.FeatureID], _actor())
+
+    assert feature.FeatureName == "parent"
+    assert FeatureRepository().list_subfeature_ids(session, feature.FeatureID) == [
+        child.FeatureID
+    ]
+
+
+def test_create_feature_without_subfeatures(session):
+    """Creating a feature with no subfeatures leaves it childless."""
+    feature = _service().create_feature(session, "solo", None, _actor())
+
+    assert feature.FeatureName == "solo"
+    assert FeatureRepository().list_subfeature_ids(session, feature.FeatureID) == []
+
+
+def test_create_feature_logs_insert(session):
+    """Creating a feature emits one insert audit record naming the entity and user."""
+    logger = FakeAuditLogger()
+
+    _service(logger).create_feature(session, "solo", None, _actor())
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "Feature"
+    assert logger.inserts[0]["user"] == "alice"
+
+
+def test_get_feature_returns_it(session):
+    """get_feature returns the ORM object for an existing id."""
+    feature = _make_feature(session, "x")
+    assert _service().get_feature(session, feature.FeatureID).FeatureID == feature.FeatureID
+
+
+def test_get_feature_unknown_raises_not_found(session):
+    """get_feature on a missing id is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_feature(session, 999_999)
+
+
+def test_list_features_orders_by_name_and_omits_counts(session):
+    """list_features(with_counts=False) returns name-sorted features and an empty count map."""
+    _make_feature(session, "Zeta")
+    _make_feature(session, "Alpha")
+
+    features, counts = _service().list_features(session, with_counts=False)
+
+    assert [f.FeatureName for f in features] == ["Alpha", "Zeta"]
+    assert counts == {}
+
+
+def test_update_feature_changes_name(session):
+    """Updating name overwrites FeatureName in place."""
+    feature = _make_feature(session, "old")
+
+    updated = _service().update_feature(
+        session, feature.FeatureID, "new", None, _actor()
+    )
+
+    assert updated.FeatureName == "new"
+
+
+def test_update_feature_replaces_subfeatures(session):
+    """Updating subfeature_ids replaces the child link set."""
+    parent = _make_feature(session, "parent")
+    a = _make_feature(session, "a")
+    b = _make_feature(session, "b")
+    service = _service()
+    service.update_feature(session, parent.FeatureID, None, [a.FeatureID], _actor())
+
+    service.update_feature(session, parent.FeatureID, None, [b.FeatureID], _actor())
+
+    assert FeatureRepository().list_subfeature_ids(session, parent.FeatureID) == [
+        b.FeatureID
+    ]
+
+
+def test_update_feature_unknown_raises_not_found(session):
+    """Updating a missing feature is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().update_feature(session, 999_999, "x", None, _actor())
+
+
+def test_update_feature_logs_update(session):
+    """Updating a feature emits one update audit record."""
+    feature = _make_feature(session, "old")
+    logger = FakeAuditLogger()
+
+    _service(logger).update_feature(session, feature.FeatureID, "new", None, _actor())
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "Feature"
+
+
+def test_delete_feature_removes_it(session):
+    """Deleting an unreferenced feature removes it from the database."""
+    feature = _make_feature(session, "gone")
+
+    _service().delete_feature(session, feature.FeatureID, _actor())
+
+    assert FeatureRepository().get_by_id(session, feature.FeatureID) is None
+
+
+def test_delete_feature_unknown_raises_not_found(session):
+    """Deleting a missing feature is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().delete_feature(session, 999_999, _actor())
+
+
+def test_delete_feature_blocked_by_child_link_raises_conflict(session):
+    """A feature that is a child of another cannot be deleted (409 FEATURE_IS_CHILD)."""
+    parent = _make_feature(session, "parent")
+    child = _make_feature(session, "child")
+    FeatureRepository().replace_subfeatures(session, parent.FeatureID, [child.FeatureID])
+
+    with pytest.raises(ConflictError) as exc:
+        _service().delete_feature(session, child.FeatureID, _actor())
+
+    detail = exc.value.detail
+    assert detail["code"] == "FEATURE_IS_CHILD"
+    assert detail["parents"] == ["parent"]
+
+
+def test_delete_feature_blocked_by_segmentations_raises_conflict(session):
+    """A feature with linked segmentations cannot be deleted (409 FEATURE_HAS_SEGMENTATIONS)."""
+    service = FeatureService(_SegBlockingRepo())
+
+    with pytest.raises(ConflictError) as exc:
+        service.delete_feature(session, 7, _actor())
+
+    detail = exc.value.detail
+    assert detail["code"] == "FEATURE_HAS_SEGMENTATIONS"
+    assert detail["segmentation_count"] == 3
+
+
+def test_delete_feature_logs_delete(session):
+    """Deleting a feature emits one delete audit record."""
+    feature = _make_feature(session, "gone")
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_feature(session, feature.FeatureID, _actor())
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "Feature"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_feature_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.feature_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/feature_service.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import Feature
+from eyened_orm.repositories.feature_repository import FeatureRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import ConflictError, NotFoundError
+
+
+class FeatureService:
+    """Business logic for features and their composite (parent/child) links."""
+
+    def __init__(
+        self,
+        repository: FeatureRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.logger = logger
+
+    def list_features(
+        self, session: Session, with_counts: bool
+    ) -> tuple[list[Feature], dict[int, int]]:
+        """Return all features (name-sorted); counts is {} unless with_counts."""
+        features = self.repository.list_all(session)
+        counts = self.repository.segmentation_counts(session) if with_counts else {}
+        return features, counts
+
+    def get_feature(self, session: Session, feature_id: int) -> Feature:
+        """Return a feature by id.
+
+        Raises:
+            NotFoundError: If the feature does not exist.
+        """
+        feature = self.repository.get_by_id(session, feature_id)
+        if feature is None:
+            raise NotFoundError(f"Feature {feature_id} not found")
+        return feature
+
+    def create_feature(
+        self,
+        session: Session,
+        name: str,
+        subfeature_ids: list[int] | None,
+        actor: ActingUser,
+    ) -> Feature:
+        """Create a feature and set its subfeature links."""
+        feature = Feature(FeatureName=name)
+        session.add(feature)
+        session.flush()
+        self.repository.replace_subfeatures(session, feature.FeatureID, subfeature_ids)
+        session.commit()
+        session.refresh(feature)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/features",
+                entity="Feature",
+                entity_id=feature.FeatureID,
+                fields={"name": feature.FeatureName, "subfeature_ids": subfeature_ids or []},
+            )
+        return feature
+
+    def update_feature(
+        self,
+        session: Session,
+        feature_id: int,
+        name: str | None,
+        subfeature_ids: list[int] | None,
+        actor: ActingUser,
+    ) -> Feature:
+        """Update a feature's name and/or subfeature links (each optional).
+
+        Raises:
+            NotFoundError: If the feature does not exist.
+        """
+        feature = self.repository.get_by_id(session, feature_id)
+        if feature is None:
+            raise NotFoundError(f"Feature {feature_id} not found")
+
+        changes: dict[str, str] = {}
+        if name is not None:
+            changes["name"] = f"{feature.FeatureName} -> {name}"
+            feature.FeatureName = name
+        if subfeature_ids is not None:
+            current = self.repository.list_subfeature_ids(session, feature_id)
+            changes["subfeature_ids"] = f"{current} -> {subfeature_ids}"
+            self.repository.replace_subfeatures(session, feature_id, subfeature_ids)
+
+        session.commit()
+        session.refresh(feature)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/features/{feature_id}",
+                entity="Feature",
+                entity_id=feature_id,
+                changes=changes if changes else None,
+            )
+        return feature
+
+    def delete_feature(
+        self, session: Session, feature_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a feature, unless it is referenced by segmentations or is a child.
+
+        Raises:
+            NotFoundError: If the feature does not exist.
+            ConflictError: If segmentations reference it (FEATURE_HAS_SEGMENTATIONS)
+                or it is a child of another feature (FEATURE_IS_CHILD).
+        """
+        feature = self.repository.get_by_id(session, feature_id)
+        if feature is None:
+            raise NotFoundError(f"Feature {feature_id} not found")
+
+        seg_count = self.repository.count_segmentations(session, feature_id)
+        if seg_count > 0:
+            raise ConflictError(
+                {
+                    "code": "FEATURE_HAS_SEGMENTATIONS",
+                    "message": (
+                        f"Cannot delete feature '{feature.FeatureName}' because it has "
+                        f"{seg_count} linked segmentation(s)."
+                    ),
+                    "segmentation_count": seg_count,
+                }
+            )
+
+        parents = self.repository.parent_names_of_child(session, feature_id)
+        if parents:
+            raise ConflictError(
+                {
+                    "code": "FEATURE_IS_CHILD",
+                    "message": (
+                        f"Cannot delete feature '{feature.FeatureName}' because it is a "
+                        f"child of {len(parents)} feature(s). Remove those links first."
+                    ),
+                    "parents": parents,
+                }
+            )
+
+        deleted_data = {"name": feature.FeatureName}
+        session.delete(feature)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/features/{feature_id}",
+                entity="Feature",
+                entity_id=feature_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+
+def get_feature_service() -> FeatureService:
+    """Default FeatureService wiring for FastAPI ``Depends()``."""
+    return FeatureService(FeatureRepository(), logger=get_db_logger())
+```
+
+Update `server/services/__init__.py`:
+
+```python
+from .acting_user import ActingUser
+from .device_service import DeviceService
+from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
+from .feature_service import FeatureService
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+from .study_service import StudyService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "ConflictError",
+    "ActingUser",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+    "StudyService",
+    "FeatureService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_feature_service.py -v`
+Expected: PASS (15 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/feature_service.py server/services/__init__.py server/tests/test_feature_service.py
+git commit -m "feat(services): add FeatureService with ConflictError delete guards and injected audit logging"
+```
+
+---
+
+## Task 4: Rewire `routes/feature.py` to use FeatureService
+
+**Files:**
+- Modify: `server/routes/feature.py`
+
+**Interfaces:**
+- Consumes: `FeatureService` + `get_feature_service` (Task 3); `ActingUser`; existing `DTOConverter.feature_to_get`, `FeatureGET`/`FeaturePUT`/`FeaturePATCH`, `get_db`, `get_current_user`. The module-level `set_subfeatures` helper, all inline `db.get(...)`/`select(...)` queries, `raise HTTPException(...)`, `db.commit()`, and `get_db_logger()` calls are removed — they now live in the Repository/Service.
+- Produces: unchanged HTTP contract — `GET /features` → `list[FeatureGET]` (optional `?with_counts=`); `POST /features` → `FeatureGET`; `GET /features/{id}` → `FeatureGET`; `PATCH /features/{id}` → `FeatureGET`; `DELETE /features/{id}` → 204. Same 404 for unknown feature and same **structured** 409 bodies for the two delete guards (now flowing through the central handler).
+
+- [ ] **Step 1: Replace the module contents with thin Service-backed handlers**
+
+Replace the entire contents of `server/routes/feature.py` with:
+
+```python
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_main import FeatureGET, FeaturePATCH, FeaturePUT
+from ..services.acting_user import ActingUser
+from ..services.feature_service import FeatureService, get_feature_service
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+@router.get("/features", response_model=list[FeatureGET])
+async def list_features(
+    with_counts: bool = False,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Return all features (optionally with a per-feature segmentation count)."""
+    features, counts = service.list_features(db, with_counts)
+    if not with_counts:
+        return [DTOConverter.feature_to_get(f) for f in features]
+    return [DTOConverter.feature_to_get(f, counts.get(f.FeatureID, 0)) for f in features]
+
+
+@router.post("/features", response_model=FeatureGET)
+async def create_feature(
+    dto: FeaturePUT,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Create a feature and set its subfeature links."""
+    feature = service.create_feature(
+        db,
+        dto.name,
+        dto.subfeature_ids,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.feature_to_get(feature)
+
+
+@router.get("/features/{feature_id}", response_model=FeatureGET)
+async def get_feature(
+    feature_id: int,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Return a single feature by id."""
+    return DTOConverter.feature_to_get(service.get_feature(db, feature_id))
+
+
+@router.patch("/features/{feature_id}", response_model=FeatureGET)
+async def patch_feature(
+    feature_id: int,
+    dto: FeaturePATCH,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Update a feature's name and/or subfeature links."""
+    feature = service.update_feature(
+        db,
+        feature_id,
+        dto.name,
+        dto.subfeature_ids,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.feature_to_get(feature)
+
+
+@router.delete("/features/{feature_id}", status_code=204)
+async def delete_feature(
+    feature_id: int,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Delete a feature (409 if it has segmentations or is a child of another)."""
+    service.delete_feature(
+        db,
+        feature_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+```
+
+- [ ] **Step 2: Verify the router imports and exposes all five routes**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "from server.routes import feature; print(sorted((r.path, tuple(sorted(r.methods))) for r in feature.router.routes))"`
+Expected: prints the routes — `/features` (GET and POST), `/features/{feature_id}` (GET, PATCH, DELETE) — with no traceback.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+Run: `dev/.venv/bin/pytest -q`
+Expected: all tests pass (prior suite + the new Task 1–3 tests); no import/collection errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/feature.py
+git commit -m "refactor(routes): route feature endpoints through FeatureService"
+```
+
+---
+
+## Task 5 (fix): Populate `FeatureGET.subfeature_ids` from the ORM
+
+**Not a refactor step — a standalone bug fix, committed separately.** Today
+`DTOConverter.feature_to_get` reads `getattr(feature, "subfeature_ids_list", None)`
+and falls back to `getattr(feature, "ChildLinks", [])`, but **neither attribute
+exists on `Feature`** — so `GET /features` always returns `subfeature_ids: []`.
+The frontend relies on this field to pre-select a composite feature's current
+subfeatures when editing (`client/src/lib/components/FeatureForm.svelte:16`:
+`feature?.subfeature_ids?.map(String) ?? []`), so editing a composite feature
+currently shows none of its existing subfeatures checked.
+
+The converter already looks for a `subfeature_ids_list` property; the fix is to
+add that property to the `Feature` model (mirroring the adjacent `subfeatures`
+property). The `FeatureGET` schema is unchanged (`subfeature_ids: list[int]`),
+so **no `openapi.ts` regeneration is needed** — only the values become correct.
+
+**Files:**
+- Modify: `orm/eyened_orm/segmentation.py` (add `Feature.subfeature_ids_list`)
+- Test: `orm/eyened_orm/tests/test_feature_model.py` (new file)
+
+**Interfaces:**
+- Consumes: `Feature.FeatureAssociations` (existing parent→child link relationship).
+- Produces: `Feature.subfeature_ids_list -> list[int]` — child ids ordered by `FeatureIndex`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_feature_model.py`:
+
+```python
+from eyened_orm import Feature
+from eyened_orm.segmentation import FeatureFeatureLink
+
+
+def _feat(session, name: str) -> Feature:
+    f = Feature(FeatureName=name)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def test_subfeature_ids_list_returns_child_ids_in_index_order(session):
+    """subfeature_ids_list returns child ids ordered by FeatureIndex, not id."""
+    parent = _feat(session, "parent")
+    a = _feat(session, "a")
+    b = _feat(session, "b")
+    # Link out of natural id order to prove ordering is by FeatureIndex.
+    session.add(
+        FeatureFeatureLink(ParentFeatureID=parent.FeatureID, ChildFeatureID=b.FeatureID, FeatureIndex=0)
+    )
+    session.add(
+        FeatureFeatureLink(ParentFeatureID=parent.FeatureID, ChildFeatureID=a.FeatureID, FeatureIndex=1)
+    )
+    session.flush()
+    # The parent's FeatureAssociations collection was initialized empty when the
+    # object was created; expire it so the property reloads the links from the DB
+    # (this is exactly what happens for a feature freshly loaded in a request).
+    session.expire(parent, ["FeatureAssociations"])
+
+    assert parent.subfeature_ids_list == [b.FeatureID, a.FeatureID]
+
+
+def test_subfeature_ids_list_empty_without_children(session):
+    """A feature with no child links has an empty subfeature_ids_list."""
+    assert _feat(session, "solo").subfeature_ids_list == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_feature_model.py -v`
+Expected: FAIL — `AttributeError: 'Feature' object has no attribute 'subfeature_ids_list'`.
+
+- [ ] **Step 3: Add the property**
+
+In `orm/eyened_orm/segmentation.py`, add this property to the `Feature` class,
+immediately after the existing `subfeatures` property (around line 722):
+
+```python
+    @property
+    def subfeature_ids_list(self) -> List[int]:
+        """Child feature ids ordered by FeatureIndex (drives FeatureGET.subfeature_ids)."""
+        assocs = sorted(self.FeatureAssociations, key=lambda x: x.FeatureIndex)
+        return [assoc.ChildFeatureID for assoc in assocs]
+```
+
+> `List` is already imported in this module (used by the surrounding relationship
+> annotations), so no new import is required.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_feature_model.py -v`
+Expected: PASS (2 passed).
+
+Then confirm the converter now emits real ids (the property it already reaches for
+via `getattr` now exists):
+
+Run: `dev/.venv/bin/pytest -q`
+Expected: full suite still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/segmentation.py orm/eyened_orm/tests/test_feature_model.py
+git commit -m "fix(orm): populate FeatureGET.subfeature_ids via Feature.subfeature_ids_list"
+```
+
+---
+
+## Verification (end-to-end, on `feature/rbac-step1-service-layer`)
+
+1. **Full suite green:** `dev/.venv/bin/pytest -q` — prior suite plus the new exception/FeatureRepository/FeatureService tests pass.
+2. **All five routes exposed:** the Task 4 Step 2 command prints GET/POST `/features` and GET/PATCH/DELETE `/features/{feature_id}`.
+3. **App boots:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "import server.main; print('ok')"` → `ok`.
+4. **Manual smoke (optional, real dev DB + server):**
+   - `GET /api/features/999999` → HTTP 404 `{"detail": "Feature 999999 not found"}` (proves the `NotFoundError` → central-handler path is live).
+   - `DELETE` a feature that has linked segmentations → HTTP 409 `{"detail": {"code": "FEATURE_HAS_SEGMENTATIONS", ...}}` (proves the new structured `ConflictError` → 409 path).
+   - `DELETE` a feature that is a subfeature of another → HTTP 409 `{"detail": {"code": "FEATURE_IS_CHILD", ...}}`.
+   - `POST /api/features` with `{"name": "X", "subfeature_ids": [<id>]}` → 200 `FeatureGET`; `PATCH` its name → 200; `DELETE` an unreferenced feature → 204.
+5. **Subfeature ids populated (Task 5 fix):** `GET /api/features/{id}` for a composite feature returns a **non-empty** `subfeature_ids` matching its links (was always `[]` before); opening that feature in the frontend edit dialog now pre-selects its current subfeatures.
+6. **Branch isolation:** `git log development..HEAD` shows only the RBAC-step1 commits; `development` has not moved.
+
+## Out of scope / follow-up
+
+- Phase 2c `tag` — its own plan/PR on this branch, same pattern (reuses `ConflictError`/`BadRequestError`/`ActingUser`, adds nothing new to the exception hierarchy).
+- Phase 3 (`subtask`, `task`), Phase 4 (`import_api`, `instances`, `form_annotations`, `segmentations`).
+- Transaction-ownership review across all Services (spec "Follow-up work") once every phase has migrated.
+- RBAC enforcement itself is **Step 2** (`PermissionDeniedError` + per-method authz checks that read `ActingUser`).

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -1,4 +1,5 @@
 from .device_repository import DeviceRepository
+from .feature_repository import FeatureRepository
 from .form_schema_repository import FormSchemaRepository
 from .patient_repository import PatientRepository
 from .study_repository import StudyRepository
@@ -8,4 +9,5 @@ __all__ = [
     "PatientRepository",
     "FormSchemaRepository",
     "StudyRepository",
+    "FeatureRepository",
 ]

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -4,7 +4,7 @@ from .form_schema_repository import FormSchemaRepository
 from .patient_repository import PatientRepository
 from .study_repository import StudyRepository
 from .tag_repository import TagRepository
-from .task_repository import TaskRepository
+from .task_repository import SubTaskRepository, TaskRepository
 
 __all__ = [
     "DeviceRepository",
@@ -14,4 +14,5 @@ __all__ = [
     "FeatureRepository",
     "TagRepository",
     "TaskRepository",
+    "SubTaskRepository",
 ]

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -3,6 +3,7 @@ from .feature_repository import FeatureRepository
 from .form_schema_repository import FormSchemaRepository
 from .patient_repository import PatientRepository
 from .study_repository import StudyRepository
+from .tag_repository import TagRepository
 
 __all__ = [
     "DeviceRepository",
@@ -10,4 +11,5 @@ __all__ = [
     "FormSchemaRepository",
     "StudyRepository",
     "FeatureRepository",
+    "TagRepository",
 ]

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -4,6 +4,7 @@ from .form_schema_repository import FormSchemaRepository
 from .patient_repository import PatientRepository
 from .study_repository import StudyRepository
 from .tag_repository import TagRepository
+from .task_repository import TaskRepository
 
 __all__ = [
     "DeviceRepository",
@@ -12,4 +13,5 @@ __all__ = [
     "StudyRepository",
     "FeatureRepository",
     "TagRepository",
+    "TaskRepository",
 ]

--- a/orm/eyened_orm/repositories/feature_repository.py
+++ b/orm/eyened_orm/repositories/feature_repository.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import Session
+
+from eyened_orm import Feature
+from eyened_orm.segmentation import FeatureFeatureLink, Segmentation
+
+
+class FeatureRepository:
+    """Data access for Feature rows and their parent/child (composite) links."""
+
+    def get_by_id(self, session: Session, feature_id: int) -> Feature | None:
+        """Return the feature with the given id, or None if absent."""
+        return session.get(Feature, feature_id)
+
+    def list_all(self, session: Session) -> list[Feature]:
+        """Return all features ordered by name (ascending)."""
+        return list(
+            session.scalars(select(Feature).order_by(Feature.FeatureName.asc())).all()
+        )
+
+    def segmentation_counts(self, session: Session) -> dict[int, int]:
+        """Return {FeatureID: segmentation count} for features that have any."""
+        rows = session.execute(
+            select(Segmentation.FeatureID, func.count()).group_by(Segmentation.FeatureID)
+        ).all()
+        return {fid: cnt for fid, cnt in rows}
+
+    def count_segmentations(self, session: Session, feature_id: int) -> int:
+        """Return how many segmentations reference this feature."""
+        return session.execute(
+            select(func.count())
+            .select_from(Segmentation)
+            .where(Segmentation.FeatureID == feature_id)
+        ).scalar_one()
+
+    def parent_names_of_child(self, session: Session, feature_id: int) -> list[str]:
+        """Return the names of features that list this feature as a child."""
+        return list(
+            session.execute(
+                select(Feature.FeatureName)
+                .join(
+                    FeatureFeatureLink,
+                    Feature.FeatureID == FeatureFeatureLink.ParentFeatureID,
+                )
+                .where(FeatureFeatureLink.ChildFeatureID == feature_id)
+            )
+            .scalars()
+            .all()
+        )
+
+    def list_subfeature_ids(self, session: Session, feature_id: int) -> list[int]:
+        """Return this feature's child ids, ordered by FeatureIndex."""
+        return list(
+            session.execute(
+                select(FeatureFeatureLink.ChildFeatureID)
+                .where(FeatureFeatureLink.ParentFeatureID == feature_id)
+                .order_by(FeatureFeatureLink.FeatureIndex)
+            )
+            .scalars()
+            .all()
+        )
+
+    def replace_subfeatures(
+        self, session: Session, parent_id: int, sub_ids: list[int] | None
+    ) -> None:
+        """Replace all of a feature's child links with ``sub_ids`` (0-indexed).
+
+        Deletes existing parent->child links, then re-adds one link per id in
+        order. Flushes so a following read in the same transaction sees the new
+        state; does not commit (the Service owns the transaction boundary).
+        """
+        session.execute(
+            delete(FeatureFeatureLink).where(
+                FeatureFeatureLink.ParentFeatureID == parent_id
+            )
+        )
+        for idx, child_id in enumerate(sub_ids or []):
+            session.add(
+                FeatureFeatureLink(
+                    ParentFeatureID=parent_id,
+                    ChildFeatureID=child_id,
+                    FeatureIndex=idx,
+                )
+            )
+        session.flush()

--- a/orm/eyened_orm/repositories/tag_repository.py
+++ b/orm/eyened_orm/repositories/tag_repository.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, load_only, noload, selectinload
+
+from eyened_orm import Creator, CreatorTagLink, Tag
+
+
+class TagRepository:
+    """Data access for Tag rows and their per-user 'star' links."""
+
+    def get_by_id(self, session: Session, tag_id: int) -> Tag | None:
+        """Return the tag with the given id, or None if absent."""
+        return session.get(Tag, tag_id)
+
+    def list_all(self, session: Session) -> list[Tag]:
+        """Return all tags, loading only what TagGET needs.
+
+        Tag has six ``lazy="selectin"`` link collections; TagGET only needs the
+        Tag columns plus its Creator (id, name). We ``noload`` those collections
+        and ``selectinload`` just the Creator so listing tags does not fan out
+        into six extra per-tag queries. (Mirrors the query previously inline in
+        the ``GET /tags`` handler.) Ordering is unspecified (DB order), as today.
+        """
+        stmt = select(Tag).options(
+            load_only(
+                Tag.TagID,
+                Tag.TagName,
+                Tag.TagType,
+                Tag.TagDescription,
+                Tag.CreatorID,
+                Tag.DateInserted,
+            ),
+            noload(Tag.CreatorTagLinks),
+            noload(Tag.StudyTagLinks),
+            noload(Tag.ImageInstanceTagLinks),
+            noload(Tag.AnnotationTagLinks),
+            noload(Tag.SegmentationTagLinks),
+            noload(Tag.FormAnnotationTagLinks),
+            selectinload(Tag.Creator).load_only(
+                Creator.CreatorID, Creator.CreatorName
+            ),
+        )
+        return list(session.scalars(stmt).all())
+
+    def get_star_link(
+        self, session: Session, tag_id: int, creator_id: int
+    ) -> CreatorTagLink | None:
+        """Return the star link for (tag, creator), or None if not starred."""
+        return session.get(
+            CreatorTagLink, {"TagID": tag_id, "CreatorID": creator_id}
+        )

--- a/orm/eyened_orm/repositories/task_repository.py
+++ b/orm/eyened_orm/repositories/task_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, selectinload
 
-from eyened_orm import SubTask, Task
+from eyened_orm import ImageInstance, ImageStorage, SubTask, SubTaskImageLink, Task
 from eyened_orm.task import SubTaskState
 
 # Load task metadata without eager-loading every SubTask row (mirrors the
@@ -68,3 +68,68 @@ class TaskRepository:
         ).all()
         counts = {int(tid): (int(n), int(r)) for tid, n, r in rows}
         return {tid: counts.get(tid, (0, 0)) for tid in task_ids}
+
+
+# Eager-load the subtask's images down to their storage backend (mirrors the
+# route's former with_images option chain).
+_SUBTASK_IMAGE_LOADER = (
+    selectinload(SubTask.SubTaskImageLinks)
+    .selectinload(SubTaskImageLink.ImageInstance)
+    .selectinload(ImageInstance.ImageStorages)
+    .selectinload(ImageStorage.StorageBackend)
+)
+
+
+class SubTaskRepository:
+    """Data access for a task's SubTask rows (reads used by task.py)."""
+
+    def all_ids_for_task(self, session: Session, task_id: int) -> list[int]:
+        """Return the task's SubTaskIDs ordered ascending (backs absolute index)."""
+        return list(
+            session.execute(
+                select(SubTask.SubTaskID)
+                .where(SubTask.TaskID == task_id)
+                .order_by(SubTask.SubTaskID)
+            )
+            .scalars()
+            .all()
+        )
+
+    def count_for_task(
+        self,
+        session: Session,
+        task_id: int,
+        *,
+        status: SubTaskState | None = None,
+    ) -> int:
+        """Return the task's subtask count, optionally filtered by state."""
+        stmt = select(func.count()).select_from(SubTask).where(
+            SubTask.TaskID == task_id
+        )
+        if status is not None:
+            stmt = stmt.where(SubTask.TaskState == status)
+        return session.scalar(stmt) or 0
+
+    def list_for_task(
+        self,
+        session: Session,
+        task_id: int,
+        *,
+        status: SubTaskState | None = None,
+        limit: int,
+        offset: int,
+        with_images: bool = False,
+    ) -> list[SubTask]:
+        """Return a limit/offset window of the task's subtasks (SubTaskID order).
+
+        Optionally filters by ``status`` and eager-loads each subtask's images.
+        """
+        stmt = select(SubTask).where(SubTask.TaskID == task_id)
+        if status is not None:
+            stmt = stmt.where(SubTask.TaskState == status)
+        stmt = stmt.order_by(SubTask.SubTaskID)
+        if with_images:
+            stmt = stmt.options(_SUBTASK_IMAGE_LOADER)
+        return list(
+            session.execute(stmt.limit(limit).offset(offset)).scalars().all()
+        )

--- a/orm/eyened_orm/repositories/task_repository.py
+++ b/orm/eyened_orm/repositories/task_repository.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import SubTask, Task
+from eyened_orm.task import SubTaskState
+
+# Load task metadata without eager-loading every SubTask row (mirrors the
+# route's former ``_task_query_options``).
+_TASK_RELATIONS = (
+    selectinload(Task.Creator),
+    selectinload(Task.TaskDefinition),
+)
+
+
+class TaskRepository:
+    """Data access for Task rows and their subtask counts."""
+
+    def get_by_id(self, session: Session, task_id: int) -> Task | None:
+        """Return the task with the given id, or None if absent."""
+        return session.get(Task, task_id)
+
+    def get_with_relations(self, session: Session, task_id: int) -> Task | None:
+        """Return the task with Creator + TaskDefinition eager-loaded, or None."""
+        return (
+            session.execute(
+                select(Task).options(*_TASK_RELATIONS).where(Task.TaskID == task_id)
+            )
+            .scalars()
+            .first()
+        )
+
+    def list_all(self, session: Session) -> list[Task]:
+        """Return all tasks (TaskID order) with Creator + TaskDefinition loaded."""
+        return list(
+            session.execute(
+                select(Task).options(*_TASK_RELATIONS).order_by(Task.TaskID)
+            )
+            .scalars()
+            .all()
+        )
+
+    def subtask_counts(
+        self, session: Session, task_ids: list[int]
+    ) -> dict[int, tuple[int, int]]:
+        """Return {task_id: (num_subtasks, num_ready)} for the given task ids.
+
+        One grouped aggregate over ``SubTask`` (mirrors the route's former
+        ``_subtask_counts_by_task_id``). Every requested id is present in the
+        result: ids with no subtasks map to ``(0, 0)``.
+        """
+        if not task_ids:
+            return {}
+        rows = session.execute(
+            select(
+                SubTask.TaskID,
+                func.count().label("num"),
+                func.coalesce(
+                    func.sum(
+                        case((SubTask.TaskState == SubTaskState.Ready, 1), else_=0)
+                    ),
+                    0,
+                ).label("ready"),
+            )
+            .where(SubTask.TaskID.in_(task_ids))
+            .group_by(SubTask.TaskID)
+        ).all()
+        counts = {int(tid): (int(n), int(r)) for tid, n, r in rows}
+        return {tid: counts.get(tid, (0, 0)) for tid in task_ids}

--- a/orm/eyened_orm/segmentation.py
+++ b/orm/eyened_orm/segmentation.py
@@ -722,6 +722,12 @@ class Feature(Base):
         return {assoc.FeatureIndex: assoc.Child.FeatureName for assoc in assocs}
 
     @property
+    def subfeature_ids_list(self) -> List[int]:
+        """Child feature ids ordered by FeatureIndex (drives FeatureGET.subfeature_ids)."""
+        assocs = sorted(self.FeatureAssociations, key=lambda x: x.FeatureIndex)
+        return [assoc.ChildFeatureID for assoc in assocs]
+
+    @property
     def json(self) -> Dict[str, Any]:
         assocs = sorted(self.FeatureAssociations, key=lambda x: x.FeatureIndex)
         subfeatures = [

--- a/orm/eyened_orm/tests/test_device_repository.py
+++ b/orm/eyened_orm/tests/test_device_repository.py
@@ -3,7 +3,7 @@ from eyened_orm.repositories.device_repository import DeviceRepository
 
 
 def test_list_all_orders_by_manufacturer_then_model(session):
-    # list_all returns every device sorted by manufacturer, then model name.
+    """list_all returns every device sorted by manufacturer, then model name."""
     session.add_all(
         [
             DeviceModel(Manufacturer="Zeiss", ManufacturerModelName="Cirrus"),

--- a/orm/eyened_orm/tests/test_feature_model.py
+++ b/orm/eyened_orm/tests/test_feature_model.py
@@ -1,0 +1,35 @@
+from eyened_orm import Feature
+from eyened_orm.segmentation import FeatureFeatureLink
+
+
+def _feat(session, name: str) -> Feature:
+    f = Feature(FeatureName=name)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def test_subfeature_ids_list_returns_child_ids_in_index_order(session):
+    """subfeature_ids_list returns child ids ordered by FeatureIndex, not id."""
+    parent = _feat(session, "parent")
+    a = _feat(session, "a")
+    b = _feat(session, "b")
+    # Link out of natural id order to prove ordering is by FeatureIndex.
+    session.add(
+        FeatureFeatureLink(ParentFeatureID=parent.FeatureID, ChildFeatureID=b.FeatureID, FeatureIndex=0)
+    )
+    session.add(
+        FeatureFeatureLink(ParentFeatureID=parent.FeatureID, ChildFeatureID=a.FeatureID, FeatureIndex=1)
+    )
+    session.flush()
+    # The parent's FeatureAssociations collection was initialized empty when the
+    # object was created; expire it so the property reloads the links from the DB
+    # (this is exactly what happens for a feature freshly loaded in a request).
+    session.expire(parent, ["FeatureAssociations"])
+
+    assert parent.subfeature_ids_list == [b.FeatureID, a.FeatureID]
+
+
+def test_subfeature_ids_list_empty_without_children(session):
+    """A feature with no child links has an empty subfeature_ids_list."""
+    assert _feat(session, "solo").subfeature_ids_list == []

--- a/orm/eyened_orm/tests/test_feature_repository.py
+++ b/orm/eyened_orm/tests/test_feature_repository.py
@@ -1,0 +1,64 @@
+from eyened_orm import Feature
+from eyened_orm.repositories.feature_repository import FeatureRepository
+
+
+def _feat(session, name: str) -> Feature:
+    f = Feature(FeatureName=name)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def test_list_all_orders_by_name(session):
+    """list_all returns every feature sorted by FeatureName ascending."""
+    _feat(session, "Zeta")
+    _feat(session, "Alpha")
+    _feat(session, "Mu")
+    names = [f.FeatureName for f in FeatureRepository().list_all(session)]
+    assert names == ["Alpha", "Mu", "Zeta"]
+
+
+def test_replace_subfeatures_sets_ordered_children(session):
+    """replace_subfeatures writes child links preserving list order as 0-based FeatureIndex."""
+    parent = _feat(session, "parent")
+    a = _feat(session, "a")
+    b = _feat(session, "b")
+    repo = FeatureRepository()
+
+    repo.replace_subfeatures(session, parent.FeatureID, [b.FeatureID, a.FeatureID])
+
+    assert repo.list_subfeature_ids(session, parent.FeatureID) == [b.FeatureID, a.FeatureID]
+
+
+def test_replace_subfeatures_overwrites_previous(session):
+    """replace_subfeatures clears prior links before writing the new set."""
+    parent = _feat(session, "parent")
+    a = _feat(session, "a")
+    b = _feat(session, "b")
+    repo = FeatureRepository()
+    repo.replace_subfeatures(session, parent.FeatureID, [a.FeatureID])
+
+    repo.replace_subfeatures(session, parent.FeatureID, [b.FeatureID])
+
+    assert repo.list_subfeature_ids(session, parent.FeatureID) == [b.FeatureID]
+
+
+def test_parent_names_of_child_lists_parents(session):
+    """parent_names_of_child returns the names of features linking to this child."""
+    parent = _feat(session, "parent")
+    child = _feat(session, "child")
+    FeatureRepository().replace_subfeatures(session, parent.FeatureID, [child.FeatureID])
+
+    assert FeatureRepository().parent_names_of_child(session, child.FeatureID) == ["parent"]
+
+
+def test_count_segmentations_zero_when_none(session):
+    """count_segmentations returns 0 for a feature with no linked segmentations."""
+    f = _feat(session, "lonely")
+    assert FeatureRepository().count_segmentations(session, f.FeatureID) == 0
+
+
+def test_segmentation_counts_empty_when_no_segmentations(session):
+    """segmentation_counts returns an empty mapping when no segmentations exist."""
+    _feat(session, "x")
+    assert FeatureRepository().segmentation_counts(session) == {}

--- a/orm/eyened_orm/tests/test_form_schema_repository.py
+++ b/orm/eyened_orm/tests/test_form_schema_repository.py
@@ -3,7 +3,7 @@ from eyened_orm.repositories.form_schema_repository import FormSchemaRepository
 
 
 def test_list_all_orders_by_schema_name(session):
-    # list_all returns every schema sorted by name ascending.
+    """list_all returns every schema sorted by name ascending."""
     session.add_all(
         [
             FormSchema(SchemaName="Zeta"),
@@ -19,7 +19,7 @@ def test_list_all_orders_by_schema_name(session):
 
 
 def test_get_by_id_returns_the_schema(session):
-    # A known id returns that schema.
+    """A known id returns that schema."""
     schema = FormSchema(SchemaName="Alpha")
     session.add(schema)
     session.flush()
@@ -31,5 +31,5 @@ def test_get_by_id_returns_the_schema(session):
 
 
 def test_get_by_id_unknown_id_returns_none(session):
-    # An unknown id returns None — the repository never raises for "not found".
+    """An unknown id returns None — the repository never raises for "not found"."""
     assert FormSchemaRepository().get_by_id(session, 999_999) is None

--- a/orm/eyened_orm/tests/test_patient_repository.py
+++ b/orm/eyened_orm/tests/test_patient_repository.py
@@ -14,7 +14,7 @@ def _make_patient(session, identifier: str = "ID1") -> Patient:
 
 
 def test_get_with_attributes_returns_the_patient(session):
-    # Looking up an existing patient by id returns that patient.
+    """Looking up an existing patient by id returns that patient."""
     patient = _make_patient(session)
 
     result = PatientRepository().get_with_attributes(session, patient.PatientID)
@@ -24,5 +24,5 @@ def test_get_with_attributes_returns_the_patient(session):
 
 
 def test_get_with_attributes_unknown_id_returns_none(session):
-    # An unknown id returns None — the repository never raises for "not found".
+    """An unknown id returns None — the repository never raises for "not found"."""
     assert PatientRepository().get_with_attributes(session, 999_999) is None

--- a/orm/eyened_orm/tests/test_tag_repository.py
+++ b/orm/eyened_orm/tests/test_tag_repository.py
@@ -1,0 +1,34 @@
+from eyened_orm import Creator, Tag
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.tag_repository import TagRepository
+
+
+def _make_creator(session, name: str = "tester") -> Creator:
+    creator = Creator(CreatorName=name, IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return creator
+
+
+def _make_tag(
+    session, creator_id: int, name: str, tag_type: TagType = TagType.Study
+) -> Tag:
+    tag = Tag(
+        TagName=name, TagType=tag_type, TagDescription="", CreatorID=creator_id
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_list_all_returns_all_tags_with_creator(session):
+    """list_all returns every tag with its Creator eager-loaded (no lazy fan-out)."""
+    creator = _make_creator(session)
+    _make_tag(session, creator.CreatorID, "Beta")
+    _make_tag(session, creator.CreatorID, "Alpha", TagType.ImageInstance)
+
+    tags = TagRepository().list_all(session)
+
+    assert sorted(t.TagName for t in tags) == ["Alpha", "Beta"]
+    # Creator was selectinload-ed, so reading it needs no extra lazy query.
+    assert tags[0].Creator.CreatorName == "tester"

--- a/orm/eyened_orm/tests/test_task_repository.py
+++ b/orm/eyened_orm/tests/test_task_repository.py
@@ -1,6 +1,6 @@
 from eyened_orm import Creator, SubTask, Task, TaskDefinition
 from eyened_orm.task import SubTaskState, TaskState
-from eyened_orm.repositories.task_repository import TaskRepository
+from eyened_orm.repositories.task_repository import TaskRepository, SubTaskRepository
 
 
 def _creator(session, name: str = "tester") -> Creator:
@@ -87,3 +87,135 @@ def test_subtask_counts_fills_zero_for_task_without_subtasks(session):
     counts = TaskRepository().subtask_counts(session, [task.TaskID])
 
     assert counts == {task.TaskID: (0, 0)}
+
+
+def _make_image(session, public_id: str) -> "int":
+    """Build the minimal Series/Device graph an ImageInstance FK-requires.
+
+    Returns the new ImageInstanceID. Mirrors the smallest row set that
+    satisfies ImageInstance's NOT NULL FKs under PRAGMA foreign_keys=ON.
+    """
+    import datetime
+
+    from eyened_orm import (
+        DeviceInstance,
+        DeviceModel,
+        ImageInstance,
+        Patient,
+        Project,
+        Series,
+        Study,
+    )
+    from eyened_orm.project import ExternalEnum
+
+    project = Project(ProjectName="P", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier="ID1", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier="ds",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_all_ids_for_task_ordered(session):
+    """all_ids_for_task returns the task's SubTaskIDs ascending."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    a = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    b = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+
+    ids = SubTaskRepository().all_ids_for_task(session, task.TaskID)
+
+    assert ids == [a.SubTaskID, b.SubTaskID]
+
+
+def test_count_for_task_with_and_without_status(session):
+    """count_for_task counts all subtasks, or only those in the given state."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+    repo = SubTaskRepository()
+
+    assert repo.count_for_task(session, task.TaskID) == 3
+    assert repo.count_for_task(session, task.TaskID, status=SubTaskState.Ready) == 2
+
+
+def test_list_for_task_paginates_in_id_order(session):
+    """list_for_task returns a limit/offset window ordered by SubTaskID."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    made = [
+        _make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(5)
+    ]
+
+    rows = SubTaskRepository().list_for_task(
+        session, task.TaskID, limit=2, offset=1
+    )
+
+    assert [r.SubTaskID for r in rows] == [made[1].SubTaskID, made[2].SubTaskID]
+
+
+def test_list_for_task_filters_by_status(session):
+    """list_for_task with a status returns only subtasks in that state."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    ready = _make_subtask(session, task.TaskID, SubTaskState.Ready)
+
+    rows = SubTaskRepository().list_for_task(
+        session, task.TaskID, status=SubTaskState.Ready, limit=10, offset=0
+    )
+
+    assert [r.SubTaskID for r in rows] == [ready.SubTaskID]
+
+
+def test_list_for_task_with_images_loads_links(session):
+    """with_images eager-loads the SubTaskImageLinks -> ImageInstance chain."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    st = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    image_id = _make_image(session, "pub-1")
+    from eyened_orm import SubTaskImageLink
+
+    session.add(
+        SubTaskImageLink(
+            SubTaskID=st.SubTaskID, ImageInstanceID=image_id, ImageIndex=0
+        )
+    )
+    session.flush()
+
+    rows = SubTaskRepository().list_for_task(
+        session, task.TaskID, limit=10, offset=0, with_images=True
+    )
+
+    assert len(rows) == 1
+    assert [link.ImageInstance.PublicID for link in rows[0].SubTaskImageLinks] == [
+        "pub-1"
+    ]

--- a/orm/eyened_orm/tests/test_task_repository.py
+++ b/orm/eyened_orm/tests/test_task_repository.py
@@ -1,0 +1,89 @@
+from eyened_orm import Creator, SubTask, Task, TaskDefinition
+from eyened_orm.task import SubTaskState, TaskState
+from eyened_orm.repositories.task_repository import TaskRepository
+
+
+def _creator(session, name: str = "tester") -> Creator:
+    creator = Creator(CreatorName=name, IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return creator
+
+
+def _task_def(session, name: str = "td") -> TaskDefinition:
+    td = TaskDefinition(TaskDefinitionName=name)
+    session.add(td)
+    session.flush()
+    return td
+
+
+def _make_task(session, td_id: int, creator_id: int, name: str = "T") -> Task:
+    task = Task(
+        TaskName=name,
+        TaskDefinitionID=td_id,
+        CreatorID=creator_id,
+        TaskState=TaskState.NotStarted,
+    )
+    session.add(task)
+    session.flush()
+    return task
+
+
+def _make_subtask(session, task_id: int, state: SubTaskState) -> SubTask:
+    st = SubTask(TaskID=task_id, TaskState=state)
+    session.add(st)
+    session.flush()
+    return st
+
+
+def test_list_all_orders_by_id_with_relations(session):
+    """list_all returns every task in TaskID order, Creator/TaskDefinition eager."""
+    creator = _creator(session)
+    td = _task_def(session)
+    _make_task(session, td.TaskDefinitionID, creator.CreatorID, "A")
+    _make_task(session, td.TaskDefinitionID, creator.CreatorID, "B")
+
+    tasks = TaskRepository().list_all(session)
+
+    assert [t.TaskName for t in tasks] == ["A", "B"]
+    # Eager-loaded: reading these needs no extra lazy query.
+    assert tasks[0].Creator.CreatorName == "tester"
+    assert tasks[0].TaskDefinition.TaskDefinitionName == "td"
+
+
+def test_get_with_relations_eager_loads_creator_and_definition(session):
+    """get_with_relations returns the task with Creator + TaskDefinition loaded."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+
+    loaded = TaskRepository().get_with_relations(session, task.TaskID)
+
+    assert loaded is not None
+    assert loaded.Creator.CreatorName == "tester"
+    assert loaded.TaskDefinition.TaskDefinitionName == "td"
+
+
+def test_subtask_counts_totals_and_ready(session):
+    """subtask_counts returns (total, ready) per task id."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+
+    counts = TaskRepository().subtask_counts(session, [task.TaskID])
+
+    assert counts[task.TaskID] == (3, 2)
+
+
+def test_subtask_counts_fills_zero_for_task_without_subtasks(session):
+    """A requested task id with no subtasks maps to (0, 0), not a missing key."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+
+    counts = TaskRepository().subtask_counts(session, [task.TaskID])
+
+    assert counts == {task.TaskID: (0, 0)}

--- a/server/routes/feature.py
+++ b/server/routes/feature.py
@@ -1,161 +1,88 @@
-from fastapi import APIRouter, Depends, HTTPException, Response
-from sqlalchemy import select, delete, func
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy.orm import Session
-from eyened_orm import Feature
-from eyened_orm.segmentation import FeatureFeatureLink, Segmentation
+
 from ..db import get_db
-from ..utils.db_logging import get_db_logger
-from .auth import CurrentUser, get_current_user
-from ..dtos.dtos_main import FeaturePUT, FeaturePATCH, FeatureGET
 from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_main import FeatureGET, FeaturePATCH, FeaturePUT
+from ..services.acting_user import ActingUser
+from ..services.feature_service import FeatureService, get_feature_service
+from .auth import CurrentUser, get_current_user
 
 router = APIRouter()
 
-def set_subfeatures(db: Session, parent_id: int, sub_ids: list[int] | None) -> None:
-    db.execute(delete(FeatureFeatureLink).where(FeatureFeatureLink.ParentFeatureID == parent_id))
-    for idx, child_id in enumerate(sub_ids or []):
-        db.add(FeatureFeatureLink(ParentFeatureID=parent_id, ChildFeatureID=child_id, FeatureIndex=idx))
 
 @router.get("/features", response_model=list[FeatureGET])
 async def list_features(
     with_counts: bool = False,
     db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    """Return all features."""
-    rows = db.scalars(select(Feature).order_by(Feature.FeatureName.asc())).all()
+    """Return all features (optionally with a per-feature segmentation count)."""
+    features, counts = service.list_features(db, with_counts)
     if not with_counts:
-        return [DTOConverter.feature_to_get(f) for f in rows]
+        return [DTOConverter.feature_to_get(f) for f in features]
+    return [DTOConverter.feature_to_get(f, counts.get(f.FeatureID, 0)) for f in features]
 
-    # Compute counts per FeatureID in one query
-    counts_rows = db.execute(
-        select(Segmentation.FeatureID, func.count()).group_by(Segmentation.FeatureID)
-    ).all()
-    counts = {fid: cnt for (fid, cnt) in counts_rows}
-
-    return [DTOConverter.feature_to_get(f, counts.get(f.FeatureID, 0)) for f in rows]
 
 @router.post("/features", response_model=FeatureGET)
-async def create_feature(dto: FeaturePUT, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    feature = Feature(FeatureName=dto.name)
-    db.add(feature); db.flush()
-    set_subfeatures(db, feature.FeatureID, dto.subfeature_ids)
-    db.commit(); db.refresh(feature)
-    
-    # Log feature creation
-    logger = get_db_logger()
-    if logger:
-        logger.log_insert(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint="POST /api/features",
-            entity="Feature",
-            entity_id=feature.FeatureID,
-            fields={
-                "name": feature.FeatureName,
-                "subfeature_ids": dto.subfeature_ids or [],
-            },
-        )
-    
+async def create_feature(
+    dto: FeaturePUT,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Create a feature and set its subfeature links."""
+    feature = service.create_feature(
+        db,
+        dto.name,
+        dto.subfeature_ids,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.feature_to_get(feature)
+
 
 @router.get("/features/{feature_id}", response_model=FeatureGET)
-async def get_feature(feature_id: int, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    feature = db.get(Feature, feature_id)
-    if not feature:
-        raise HTTPException(404, "Feature not found")
-    return DTOConverter.feature_to_get(feature)
+async def get_feature(
+    feature_id: int,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Return a single feature by id."""
+    return DTOConverter.feature_to_get(service.get_feature(db, feature_id))
+
 
 @router.patch("/features/{feature_id}", response_model=FeatureGET)
-async def patch_feature(feature_id: int, dto: FeaturePATCH, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    feature = db.get(Feature, feature_id)
-    if not feature:
-        raise HTTPException(404, "Feature not found")
-    changes = {}
-    if dto.name is not None:
-        changes["name"] = f"{feature.FeatureName} -> {dto.name}"
-        feature.FeatureName = dto.name
-    if dto.subfeature_ids is not None:
-        # Get current subfeatures for logging
-        from sqlalchemy import select
-        current_subfeatures = db.execute(
-            select(FeatureFeatureLink.ChildFeatureID)
-            .where(FeatureFeatureLink.ParentFeatureID == feature_id)
-            .order_by(FeatureFeatureLink.FeatureIndex)
-        ).scalars().all()
-        changes["subfeature_ids"] = f"{list(current_subfeatures)} -> {dto.subfeature_ids}"
-        set_subfeatures(db, feature_id, dto.subfeature_ids)
-    db.commit(); db.refresh(feature)
-    
-    # Log feature update
-    logger = get_db_logger()
-    if logger:
-        logger.log_update(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PATCH /api/features/{feature_id}",
-            entity="Feature",
-            entity_id=feature_id,
-            changes=changes if changes else None,
-        )
-    
+async def patch_feature(
+    feature_id: int,
+    dto: FeaturePATCH,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Update a feature's name and/or subfeature links."""
+    feature = service.update_feature(
+        db,
+        feature_id,
+        dto.name,
+        dto.subfeature_ids,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.feature_to_get(feature)
 
+
 @router.delete("/features/{feature_id}", status_code=204)
-async def delete_feature(feature_id: int, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    feature = db.get(Feature, feature_id)
-    if not feature:
-        raise HTTPException(404, "Feature not found")
-
-    # Block if any segmentations reference this feature
-    seg_count = db.execute(
-        select(func.count()).select_from(Segmentation).where(Segmentation.FeatureID == feature_id)
-    ).scalar_one()
-    if seg_count > 0:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "FEATURE_HAS_SEGMENTATIONS",
-                "message": f"Cannot delete feature '{feature.FeatureName}' because it has {seg_count} linked segmentation(s).",
-                "segmentation_count": seg_count,
-            },
-        )
-
-    # Block if this feature is a child in any composite link
-    parent_rows = db.execute(
-        select(Feature.FeatureName)
-        .join(FeatureFeatureLink, Feature.FeatureID == FeatureFeatureLink.ParentFeatureID)
-        .where(FeatureFeatureLink.ChildFeatureID == feature_id)
-    ).scalars().all()
-    if parent_rows:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "FEATURE_IS_CHILD",
-                "message": f"Cannot delete feature '{feature.FeatureName}' because it is a child of {len(parent_rows)} feature(s). Remove those links first.",
-                "parents": parent_rows,
-            },
-        )
-
-    # Save feature data for logging before deletion
-    deleted_data = {
-        "name": feature.FeatureName,
-    }
-    
-    # Safe to delete; ORM cascade removes parent->child links, children remain intact
-    db.delete(feature)
-    db.commit()
-    
-    # Log feature deletion
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/features/{feature_id}",
-            entity="Feature",
-            entity_id=feature_id,
-            deleted_data=deleted_data,
-        )
-    
+async def delete_feature(
+    feature_id: int,
+    db: Session = Depends(get_db),
+    service: FeatureService = Depends(get_feature_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Delete a feature (409 if it has segmentations or is a child of another)."""
+    service.delete_feature(
+        db,
+        feature_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)

--- a/server/routes/tag.py
+++ b/server/routes/tag.py
@@ -1,12 +1,11 @@
-from eyened_orm import Creator, CreatorTagLink, Tag
-from fastapi import APIRouter, Depends, HTTPException, Response
-from sqlalchemy import select
-from sqlalchemy.orm import Session, load_only, noload, selectinload
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
 
 from ..db import get_db
 from ..dtos.dto_converter import DTOConverter
 from ..dtos.dtos_aux import TagGET, TagPATCH, TagPUT
-from ..utils.db_logging import get_db_logger
+from ..services.acting_user import ActingUser
+from ..services.tag_service import TagService, get_tag_service
 from .auth import CurrentUser, get_current_user
 
 router = APIRouter()
@@ -16,65 +15,28 @@ router = APIRouter()
 async def create_tag(
     dto: TagPUT,
     db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    tag = Tag(
-        TagName=dto.name,
-        TagDescription=dto.description,
-        TagType=dto.tag_type,
-        CreatorID=current_user.id,
+    """Create a tag owned by the current user."""
+    tag = service.create_tag(
+        db,
+        dto.name,
+        dto.description,
+        dto.tag_type,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    db.add(tag)
-    db.commit()
-    db.refresh(tag)
-    
-    # Log tag creation
-    logger = get_db_logger()
-    if logger:
-        logger.log_insert(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint="POST /api/tags",
-            entity="Tag",
-            entity_id=tag.TagID,
-            fields={
-                "name": tag.TagName,
-                "description": tag.TagDescription,
-                "tag_type": str(tag.TagType),
-            },
-        )
-    
     return DTOConverter.tag_to_get(tag)
 
 
 @router.get("/tags", response_model=list[TagGET])
 async def list_tags(
-    db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
 ):
-    # Tag has several lazy="selectin" link collections; disable them here since TagGET
-    # only needs Tag columns + Creator (id, name for CreatorMeta).
-    stmt = (
-        select(Tag)
-        .options(
-            load_only(
-                Tag.TagID,
-                Tag.TagName,
-                Tag.TagType,
-                Tag.TagDescription,
-                Tag.CreatorID,
-                Tag.DateInserted,
-            ),
-            noload(Tag.CreatorTagLinks),
-            noload(Tag.StudyTagLinks),
-            noload(Tag.ImageInstanceTagLinks),
-            noload(Tag.AnnotationTagLinks),
-            noload(Tag.SegmentationTagLinks),
-            noload(Tag.FormAnnotationTagLinks),
-            selectinload(Tag.Creator).load_only(Creator.CreatorID, Creator.CreatorName),
-        )
-    )
-    rows = db.scalars(stmt).all()
-    return [DTOConverter.tag_to_get(t) for t in rows]
+    """Return all tags."""
+    return [DTOConverter.tag_to_get(t) for t in service.list_tags(db)]
 
 
 @router.patch("/tags/{tag_id}", response_model=TagGET)
@@ -82,36 +44,18 @@ async def patch_tag(
     tag_id: int,
     dto: TagPATCH,
     db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    tag = db.get(Tag, tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    changes = {}
-    if dto.name is not None:
-        changes["name"] = f"{tag.TagName} -> {dto.name}"
-        tag.TagName = dto.name
-    if dto.description is not None:
-        changes["description"] = f"{tag.TagDescription} -> {dto.description}"
-        tag.TagDescription = dto.description
-    if dto.tag_type is not None:
-        changes["tag_type"] = f"{tag.TagType} -> {dto.tag_type}"
-        tag.TagType = dto.tag_type
-    db.commit()
-    db.refresh(tag)
-    
-    # Log tag update
-    logger = get_db_logger()
-    if logger:
-        logger.log_update(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PATCH /api/tags/{tag_id}",
-            entity="Tag",
-            entity_id=tag.TagID,
-            changes=changes if changes else None,
-        )
-    
+    """Update a tag's name, description, and/or type."""
+    tag = service.update_tag(
+        db,
+        tag_id,
+        dto.name,
+        dto.description,
+        dto.tag_type,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.tag_to_get(tag)
 
 
@@ -119,34 +63,15 @@ async def patch_tag(
 async def delete_tag(
     tag_id: int,
     db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    tag = db.get(Tag, tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    
-    # Save tag data for logging before deletion
-    deleted_data = {
-        "name": tag.TagName,
-        "description": tag.TagDescription,
-        "tag_type": str(tag.TagType),
-    }
-    
-    db.delete(tag)
-    db.commit()
-    
-    # Log tag deletion
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/tags/{tag_id}",
-            entity="Tag",
-            entity_id=tag_id,
-            deleted_data=deleted_data,
-        )
-    
+    """Delete a tag."""
+    service.delete_tag(
+        db,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -154,30 +79,15 @@ async def delete_tag(
 async def star_tag(
     tag_id: int,
     db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    tag = db.get(Tag, tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    # idempotent insert
-    if not db.get(CreatorTagLink, {"TagID": tag_id, "CreatorID": current_user.id}):
-        db.add(CreatorTagLink(TagID=tag_id, CreatorID=current_user.id))
-        db.commit()
-        
-        # Log star creation
-        logger = get_db_logger()
-        if logger:
-            logger.log_insert(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"POST /api/tags/{tag_id}/star",
-                entity="CreatorTagLink",
-                fields={
-                    "tag_id": tag_id,
-                    "creator_id": current_user.id,
-                },
-            )
-    
+    """Star a tag for the current user (idempotent)."""
+    service.star_tag(
+        db,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -185,22 +95,13 @@ async def star_tag(
 async def unstar_tag(
     tag_id: int,
     db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    link = db.get(CreatorTagLink, {"TagID": tag_id, "CreatorID": current_user.id})
-    if link:
-        db.delete(link)
-        db.commit()
-        
-        # Log star deletion
-        logger = get_db_logger()
-        if logger:
-            logger.log_delete(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"DELETE /api/tags/{tag_id}/star",
-                entity="CreatorTagLink",
-                fields={"tag_id": tag_id, "creator_id": current_user.id},
-            )
-    
+    """Remove the current user's star from a tag (idempotent)."""
+    service.unstar_tag(
+        db,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)

--- a/server/routes/task.py
+++ b/server/routes/task.py
@@ -1,227 +1,122 @@
-from typing import Union, List, Optional, Dict, Tuple
-import bisect
-from fastapi import APIRouter, Depends, HTTPException, Response
-from sqlalchemy import select, func, delete, case
-from sqlalchemy.orm import Session, selectinload
-from eyened_orm import (
-    Task,
-    SubTask,
-    SubTaskImageLink,
-    ImageInstance,
-    ImageStorage,
-    SubTaskState,
-)
+from typing import List, Optional, Union
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from eyened_orm import SubTaskState
+
 from ..db import get_db
-from ..utils.db_logging import get_db_logger
-from .auth import CurrentUser, get_current_user
-from ..dtos.dtos_tasks import (
-    TaskPUT, TaskPATCH, TaskGET,
-    SubTasksResponse, SubTasksWithImagesResponse,
-    SubTaskGET, SubTaskWithImagesGET,
-)
 from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_tasks import (
+    SubTaskGET,
+    SubTasksResponse,
+    SubTasksWithImagesResponse,
+    SubTaskWithImagesGET,
+    TaskGET,
+    TaskPATCH,
+    TaskPUT,
+)
+from ..services.acting_user import ActingUser
+from ..services.task_service import TaskService, get_task_service
+from .auth import CurrentUser, get_current_user
 
 router = APIRouter()
 
 
-def _task_query_options():
-    """Load task metadata without eager-loading every SubTask row."""
-    return (
-        selectinload(Task.Creator),
-        selectinload(Task.TaskDefinition),
-    )
-
-
-def _subtask_counts_by_task_id(
-    db: Session, task_ids: List[int]
-) -> Dict[int, Tuple[int, int]]:
-    """Return ``{task_id: (num_tasks, num_tasks_ready)}`` via SQL aggregates."""
-    if not task_ids:
-        return {}
-    rows = db.execute(
-        select(
-            SubTask.TaskID,
-            func.count().label("num_tasks"),
-            func.coalesce(
-                func.sum(
-                    case((SubTask.TaskState == SubTaskState.Ready, 1), else_=0)
-                ),
-                0,
-            ).label("num_tasks_ready"),
-        )
-        .where(SubTask.TaskID.in_(task_ids))
-        .group_by(SubTask.TaskID)
-    ).all()
-    counts = {int(task_id): (int(n), int(r)) for task_id, n, r in rows}
-    return {tid: counts.get(tid, (0, 0)) for tid in task_ids}
-
-
 @router.post("/task", response_model=TaskGET)
-async def create_task(dto: TaskPUT, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    task = Task(
-        TaskName=dto.name,
-        Description=dto.description,
-        ContactID=dto.contact_id,
-        TaskDefinitionID=dto.task_definition_id,
-        CreatorID=current_user.id,
+async def create_task(
+    dto: TaskPUT,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Create a task owned by the current user."""
+    task = service.create_task(
+        db,
+        dto.name,
+        dto.description,
+        dto.contact_id,
+        dto.task_definition_id,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    db.add(task); db.commit()
-    # Reload with relationships
-    task = db.execute(
-        select(Task)
-        .options(*_task_query_options())
-        .where(Task.TaskID == task.TaskID)
-    ).scalars().first()
-    
-    # Log task creation
-    logger = get_db_logger()
-    if logger:
-        logger.log_insert(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint="POST /api/task",
-            entity="Task",
-            entity_id=task.TaskID,
-            fields={
-                "name": task.TaskName,
-                "description": task.Description,
-                "contact_id": task.ContactID,
-                "task_definition_id": task.TaskDefinitionID,
-            },
-        )
-    
     return DTOConverter.task_to_get(task, num_tasks=0, num_tasks_ready=0)
 
 
 @router.get("/task", response_model=List[TaskGET])
 async def list_tasks(
     db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
     """List all tasks (no pagination)."""
-    rows = db.execute(
-        select(Task).options(*_task_query_options()).order_by(Task.TaskID)
-    ).scalars().all()
-    counts = _subtask_counts_by_task_id(db, [t.TaskID for t in rows])
+    tasks, counts = service.list_tasks(db)
     return [
         DTOConverter.task_to_get(
             t,
             num_tasks=counts[t.TaskID][0],
             num_tasks_ready=counts[t.TaskID][1],
         )
-        for t in rows
+        for t in tasks
     ]
 
 
-
-
 @router.get("/task/{task_id}", response_model=TaskGET)
-async def get_task(task_id: int, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    task = db.execute(
-        select(Task)
-        .options(*_task_query_options())
-        .where(Task.TaskID == task_id)
-    ).scalars().first()
-    if not task:
-        raise HTTPException(404, "Task not found")
-    num_tasks, num_tasks_ready = _subtask_counts_by_task_id(db, [task_id])[task_id]
+async def get_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single task with its subtask counts."""
+    task, (num_tasks, num_tasks_ready) = service.get_task(db, task_id)
     return DTOConverter.task_to_get(
         task, num_tasks=num_tasks, num_tasks_ready=num_tasks_ready
     )
-
-
 
 
 @router.patch("/task/{task_id}", response_model=TaskGET)
-async def patch_task(task_id: int, dto: TaskPATCH, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    task = db.get(Task, task_id)
-    if not task:
-        raise HTTPException(404, "Task not found")
-    changes = {}
-    if dto.name is not None:
-        changes["name"] = f"{task.TaskName} -> {dto.name}"
-        task.TaskName = dto.name
-    if dto.description is not None:
-        changes["description"] = f"{task.Description} -> {dto.description}"
-        task.Description = dto.description
-    if dto.contact_id is not None:
-        changes["contact_id"] = f"{task.ContactID} -> {dto.contact_id}"
-        task.ContactID = dto.contact_id
-    if dto.task_definition_id is not None:
-        changes["task_definition_id"] = f"{task.TaskDefinitionID} -> {dto.task_definition_id}"
-        task.TaskDefinitionID = dto.task_definition_id
-    if dto.task_state is not None:
-        changes["task_state"] = f"{task.TaskState} -> {dto.task_state}"
-        task.TaskState = dto.task_state
-
-    db.commit(); db.refresh(task)
-    
-    task = db.execute(
-        select(Task)
-        .options(*_task_query_options())
-        .where(Task.TaskID == task_id)
-    ).scalars().first()
-    num_tasks, num_tasks_ready = _subtask_counts_by_task_id(db, [task_id])[task_id]
-    
-    # Log task update
-    logger = get_db_logger()
-    if logger:
-        logger.log_update(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PATCH /api/task/{task_id}",
-            entity="Task",
-            entity_id=task_id,
-            changes=changes if changes else None,
-        )
-    
+async def patch_task(
+    task_id: int,
+    dto: TaskPATCH,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Update a task's name/description/contact/definition/state."""
+    task, (num_tasks, num_tasks_ready) = service.update_task(
+        db,
+        task_id,
+        dto.name,
+        dto.description,
+        dto.contact_id,
+        dto.task_definition_id,
+        dto.task_state,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.task_to_get(
         task, num_tasks=num_tasks, num_tasks_ready=num_tasks_ready
     )
 
+
 @router.delete("/task/{task_id}", status_code=204)
-async def delete_task(task_id: int, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
-    # Get task data before deletion
-    task = db.get(Task, task_id)
-    if not task:
-        raise HTTPException(404, "Task not found")
-    
-    # Save task data for logging before deletion
-    deleted_data = {
-        "name": task.TaskName,
-        "description": task.Description,
-        "contact_id": task.ContactID,
-        "task_definition_id": task.TaskDefinitionID,
-        "creator_id": task.CreatorID,
-        "task_state": str(task.TaskState) if hasattr(task, 'TaskState') and task.TaskState else None,
-    }
-    
-    res = db.execute(delete(Task).where(Task.TaskID == task_id))
-    if res.rowcount == 0:
-        raise HTTPException(404, "Task not found")
-    db.commit()
-    
-    # Log task deletion
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/task/{task_id}",
-            entity="Task",
-            entity_id=task_id,
-            deleted_data=deleted_data,
-        )
-    
+async def delete_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Delete a task."""
+    service.delete_task(
+        db,
+        task_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
-
-
-
 
 
 @router.get(
     "/task/{task_id}/subtasks",
-    response_model=Union[SubTasksWithImagesResponse,SubTasksResponse],
+    response_model=Union[SubTasksWithImagesResponse, SubTasksResponse],
 )
 async def list_subtasks(
     task_id: int,
@@ -230,67 +125,31 @@ async def list_subtasks(
     page: int = 0,
     subtask_status: Optional[SubTaskState] = None,
     db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    """List subtasks of a task with optional pagination, image inclusion, and status filter.
-    
-    index is the 0-based position within all subtasks for the task ordered by SubTaskID 
-    (computed before any subtask_status filtering).
+    """List subtasks of a task (pagination, optional images, optional status filter).
+
+    ``index`` is the 0-based position within all subtasks of the task ordered by
+    SubTaskID (computed before any subtask_status filtering).
     """
-    task = db.get(Task, task_id)
-    if not task:
-        raise HTTPException(404, "Task not found")
-
-    # Build absolute index map across all subtasks (before any status filtering)
-    all_ids = db.execute(
-        select(SubTask.SubTaskID)
-        .where(SubTask.TaskID == task_id)
-        .order_by(SubTask.SubTaskID)
-    ).scalars().all()
-    id_to_abs_idx = {sid: i for i, sid in enumerate(all_ids)}
-    
-    def abs_index_for(sid: int) -> int:
-        i = id_to_abs_idx.get(sid)
-        if i is not None:
-            return i
-        i = bisect.bisect_left(all_ids, sid)
-        id_to_abs_idx[sid] = i
-        return i
-
-    offset = limit * page
-    base_q = select(SubTask).where(SubTask.TaskID == task_id)
-    if subtask_status is not None:
-        base_q = base_q.where(SubTask.TaskState == subtask_status)
-
-    q = base_q.order_by(SubTask.SubTaskID)
-    if with_images:
-        q = q.options(
-            selectinload(SubTask.SubTaskImageLinks)
-            .selectinload(SubTaskImageLink.ImageInstance)
-            .selectinload(ImageInstance.ImageStorages)
-            .selectinload(ImageStorage.StorageBackend)
-        )
-
-    rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
-
-    count_q = select(func.count()).select_from(SubTask).where(SubTask.TaskID == task_id)
-    if subtask_status is not None:
-        count_q = count_q.where(SubTask.TaskState == subtask_status)
-    count = db.scalar(count_q) or 0
-
-    if with_images:
-        subtasks = [
-            DTOConverter.subtask_with_images_to_get(st).copy(update={'index': abs_index_for(st.SubTaskID)})
-            for st in rows
-        ]
-        return {"subtasks": subtasks, "limit": limit, "page": page, "count": count}
-
+    rows_with_index, count = service.list_task_subtasks(
+        db,
+        task_id,
+        with_images=with_images,
+        limit=limit,
+        page=page,
+        status=subtask_status,
+    )
+    convert = (
+        DTOConverter.subtask_with_images_to_get
+        if with_images
+        else DTOConverter.subtask_to_get
+    )
     subtasks = [
-        DTOConverter.subtask_to_get(st).copy(update={'index': abs_index_for(st.SubTaskID)})
-        for st in rows
+        convert(st).copy(update={"index": index}) for st, index in rows_with_index
     ]
     return {"subtasks": subtasks, "limit": limit, "page": page, "count": count}
-
 
 
 @router.get(
@@ -303,35 +162,24 @@ async def get_subtask(
     with_images: bool = False,
     with_next: bool = False,
     db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    """Get a single subtask by index with optional image inclusion and next task."""
-    base_q = select(SubTask).where(SubTask.TaskID == task_id).order_by(SubTask.SubTaskID)
-    if with_images:
-        base_q = base_q.options(
-            selectinload(SubTask.SubTaskImageLinks)
-            .selectinload(SubTaskImageLink.ImageInstance)
-            .selectinload(ImageInstance.ImageStorages)
-            .selectinload(ImageStorage.StorageBackend)
-        )
-    q = base_q.offset(subtask_index).limit(2 if with_next else 1)
-    rows = db.execute(q).scalars().all()
-    if not rows:
-        raise HTTPException(404, "SubTask not found")
-
-    main = rows[0]
-    main_dto = (
-        DTOConverter.subtask_with_images_to_get(main)
-        if with_images else DTOConverter.subtask_to_get(main)
-    ).copy(update={'index': subtask_index})
-
-    if with_next and len(rows) > 1:
-        nxt = rows[1]
-        next_dto = (
-            DTOConverter.subtask_with_images_to_get(nxt)
-            if with_images else DTOConverter.subtask_to_get(nxt)
-        ).copy(update={'index': subtask_index + 1})
-        main_dto = main_dto.copy(update={'next_task': next_dto})
-
+    """Get a single subtask by index, optionally with images and the next subtask."""
+    main, nxt = service.get_task_subtask(
+        db,
+        task_id,
+        subtask_index,
+        with_images=with_images,
+        with_next=with_next,
+    )
+    convert = (
+        DTOConverter.subtask_with_images_to_get
+        if with_images
+        else DTOConverter.subtask_to_get
+    )
+    main_dto = convert(main).copy(update={"index": subtask_index})
+    if nxt is not None:
+        next_dto = convert(nxt).copy(update={"index": subtask_index + 1})
+        main_dto = main_dto.copy(update={"next_task": next_dto})
     return main_dto
-

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -1,6 +1,6 @@
 from .acting_user import ActingUser
 from .device_service import DeviceService
-from .exceptions import BadRequestError, NotFoundError, ServiceError
+from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
 from .form_schema_service import FormSchemaService
 from .patient_service import PatientService
 from .study_service import StudyService
@@ -9,6 +9,7 @@ __all__ = [
     "ServiceError",
     "NotFoundError",
     "BadRequestError",
+    "ConflictError",
     "ActingUser",
     "DeviceService",
     "PatientService",

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -1,6 +1,7 @@
 from .acting_user import ActingUser
 from .device_service import DeviceService
 from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
+from .feature_service import FeatureService
 from .form_schema_service import FormSchemaService
 from .patient_service import PatientService
 from .study_service import StudyService
@@ -15,4 +16,5 @@ __all__ = [
     "PatientService",
     "FormSchemaService",
     "StudyService",
+    "FeatureService",
 ]

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -6,6 +6,7 @@ from .form_schema_service import FormSchemaService
 from .patient_service import PatientService
 from .study_service import StudyService
 from .tag_service import TagService
+from .task_service import TaskService
 
 __all__ = [
     "ServiceError",
@@ -19,4 +20,5 @@ __all__ = [
     "StudyService",
     "FeatureService",
     "TagService",
+    "TaskService",
 ]

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -5,6 +5,7 @@ from .feature_service import FeatureService
 from .form_schema_service import FormSchemaService
 from .patient_service import PatientService
 from .study_service import StudyService
+from .tag_service import TagService
 
 __all__ = [
     "ServiceError",
@@ -17,4 +18,5 @@ __all__ = [
     "FormSchemaService",
     "StudyService",
     "FeatureService",
+    "TagService",
 ]

--- a/server/services/exceptions.py
+++ b/server/services/exceptions.py
@@ -17,7 +17,7 @@ class ServiceError(Exception):
 
     status_code: int = 500
 
-    def __init__(self, detail: str) -> None:
+    def __init__(self, detail: str | dict) -> None:
         self.detail = detail
         super().__init__(detail)
 
@@ -37,6 +37,17 @@ class BadRequestError(ServiceError):
     """
 
     status_code = 400
+
+
+class ConflictError(ServiceError):
+    """A request conflicts with the current state of a resource (maps to HTTP 409).
+
+    Its ``detail`` is a structured dict (``{"code", "message", ...}``) so the
+    client can branch on a stable ``code`` rather than parsing a message string.
+    The central handler serializes it into ``{"detail": <dict>}`` unchanged.
+    """
+
+    status_code = 409
 
 
 def service_error_to_response(exc: ServiceError) -> JSONResponse:

--- a/server/services/feature_service.py
+++ b/server/services/feature_service.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import Feature
+from eyened_orm.repositories.feature_repository import FeatureRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import ConflictError, NotFoundError
+
+
+class FeatureService:
+    """Business logic for features and their composite (parent/child) links."""
+
+    def __init__(
+        self,
+        repository: FeatureRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.logger = logger
+
+    def list_features(
+        self, session: Session, with_counts: bool
+    ) -> tuple[list[Feature], dict[int, int]]:
+        """Return all features (name-sorted); counts is {} unless with_counts."""
+        features = self.repository.list_all(session)
+        counts = self.repository.segmentation_counts(session) if with_counts else {}
+        return features, counts
+
+    def get_feature(self, session: Session, feature_id: int) -> Feature:
+        """Return a feature by id.
+
+        Raises:
+            NotFoundError: If the feature does not exist.
+        """
+        feature = self.repository.get_by_id(session, feature_id)
+        if feature is None:
+            raise NotFoundError(f"Feature {feature_id} not found")
+        return feature
+
+    def create_feature(
+        self,
+        session: Session,
+        name: str,
+        subfeature_ids: list[int] | None,
+        actor: ActingUser,
+    ) -> Feature:
+        """Create a feature and set its subfeature links."""
+        feature = Feature(FeatureName=name)
+        session.add(feature)
+        session.flush()
+        self.repository.replace_subfeatures(session, feature.FeatureID, subfeature_ids)
+        session.commit()
+        session.refresh(feature)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/features",
+                entity="Feature",
+                entity_id=feature.FeatureID,
+                fields={"name": feature.FeatureName, "subfeature_ids": subfeature_ids or []},
+            )
+        return feature
+
+    def update_feature(
+        self,
+        session: Session,
+        feature_id: int,
+        name: str | None,
+        subfeature_ids: list[int] | None,
+        actor: ActingUser,
+    ) -> Feature:
+        """Update a feature's name and/or subfeature links (each optional).
+
+        Raises:
+            NotFoundError: If the feature does not exist.
+        """
+        feature = self.repository.get_by_id(session, feature_id)
+        if feature is None:
+            raise NotFoundError(f"Feature {feature_id} not found")
+
+        changes: dict[str, str] = {}
+        if name is not None:
+            changes["name"] = f"{feature.FeatureName} -> {name}"
+            feature.FeatureName = name
+        if subfeature_ids is not None:
+            current = self.repository.list_subfeature_ids(session, feature_id)
+            changes["subfeature_ids"] = f"{current} -> {subfeature_ids}"
+            self.repository.replace_subfeatures(session, feature_id, subfeature_ids)
+
+        session.commit()
+        session.refresh(feature)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/features/{feature_id}",
+                entity="Feature",
+                entity_id=feature_id,
+                changes=changes if changes else None,
+            )
+        return feature
+
+    def delete_feature(
+        self, session: Session, feature_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a feature, unless it is referenced by segmentations or is a child.
+
+        Raises:
+            NotFoundError: If the feature does not exist.
+            ConflictError: If segmentations reference it (FEATURE_HAS_SEGMENTATIONS)
+                or it is a child of another feature (FEATURE_IS_CHILD).
+        """
+        feature = self.repository.get_by_id(session, feature_id)
+        if feature is None:
+            raise NotFoundError(f"Feature {feature_id} not found")
+
+        seg_count = self.repository.count_segmentations(session, feature_id)
+        if seg_count > 0:
+            raise ConflictError(
+                {
+                    "code": "FEATURE_HAS_SEGMENTATIONS",
+                    "message": (
+                        f"Cannot delete feature '{feature.FeatureName}' because it has "
+                        f"{seg_count} linked segmentation(s)."
+                    ),
+                    "segmentation_count": seg_count,
+                }
+            )
+
+        parents = self.repository.parent_names_of_child(session, feature_id)
+        if parents:
+            raise ConflictError(
+                {
+                    "code": "FEATURE_IS_CHILD",
+                    "message": (
+                        f"Cannot delete feature '{feature.FeatureName}' because it is a "
+                        f"child of {len(parents)} feature(s). Remove those links first."
+                    ),
+                    "parents": parents,
+                }
+            )
+
+        deleted_data = {"name": feature.FeatureName}
+        session.delete(feature)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/features/{feature_id}",
+                entity="Feature",
+                entity_id=feature_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+
+def get_feature_service() -> FeatureService:
+    """Default FeatureService wiring for FastAPI ``Depends()``."""
+    return FeatureService(FeatureRepository(), logger=get_db_logger())

--- a/server/services/tag_service.py
+++ b/server/services/tag_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import CreatorTagLink, Tag
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import NotFoundError
+
+
+class TagService:
+    """Business logic for tags and per-user tag stars."""
+
+    def __init__(
+        self,
+        repository: TagRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.logger = logger
+
+    def list_tags(self, session: Session) -> list[Tag]:
+        """Return all tags (Creator eager-loaded for TagGET)."""
+        return self.repository.list_all(session)
+
+    def create_tag(
+        self,
+        session: Session,
+        name: str,
+        description: str,
+        tag_type: TagType,
+        actor: ActingUser,
+    ) -> Tag:
+        """Create a tag owned by the acting user."""
+        tag = Tag(
+            TagName=name,
+            TagDescription=description,
+            TagType=tag_type,
+            CreatorID=actor.id,
+        )
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/tags",
+                entity="Tag",
+                entity_id=tag.TagID,
+                fields={
+                    "name": tag.TagName,
+                    "description": tag.TagDescription,
+                    "tag_type": str(tag.TagType),
+                },
+            )
+        return tag
+
+    def update_tag(
+        self,
+        session: Session,
+        tag_id: int,
+        name: str | None,
+        description: str | None,
+        tag_type: TagType | None,
+        actor: ActingUser,
+    ) -> Tag:
+        """Update a tag's name/description/type (each optional).
+
+        Raises:
+            NotFoundError: If the tag does not exist.
+        """
+        tag = self.repository.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+
+        changes: dict[str, str] = {}
+        if name is not None:
+            changes["name"] = f"{tag.TagName} -> {name}"
+            tag.TagName = name
+        if description is not None:
+            changes["description"] = f"{tag.TagDescription} -> {description}"
+            tag.TagDescription = description
+        if tag_type is not None:
+            changes["tag_type"] = f"{tag.TagType} -> {tag_type}"
+            tag.TagType = tag_type
+
+        session.commit()
+        session.refresh(tag)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/tags/{tag_id}",
+                entity="Tag",
+                entity_id=tag.TagID,
+                changes=changes if changes else None,
+            )
+        return tag
+
+    def delete_tag(
+        self, session: Session, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a tag.
+
+        Raises:
+            NotFoundError: If the tag does not exist.
+        """
+        tag = self.repository.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+
+        deleted_data = {
+            "name": tag.TagName,
+            "description": tag.TagDescription,
+            "tag_type": str(tag.TagType),
+        }
+        session.delete(tag)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/tags/{tag_id}",
+                entity="Tag",
+                entity_id=tag_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+    def star_tag(
+        self, session: Session, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Star a tag for the acting user (idempotent).
+
+        Raises:
+            NotFoundError: If the tag does not exist.
+        """
+        tag = self.repository.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+
+        if self.repository.get_star_link(session, tag_id, actor.id) is None:
+            session.add(CreatorTagLink(TagID=tag_id, CreatorID=actor.id))
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/tags/{tag_id}/star",
+                    entity="CreatorTagLink",
+                    fields={"tag_id": tag_id, "creator_id": actor.id},
+                )
+        return None
+
+    def unstar_tag(
+        self, session: Session, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Remove the acting user's star from a tag (idempotent; no error if absent)."""
+        link = self.repository.get_star_link(session, tag_id, actor.id)
+        if link is not None:
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"DELETE /api/tags/{tag_id}/star",
+                    entity="CreatorTagLink",
+                    fields={"tag_id": tag_id, "creator_id": actor.id},
+                )
+        return None
+
+
+def get_tag_service() -> TagService:
+    """Default TagService wiring for FastAPI ``Depends()``."""
+    return TagService(TagRepository(), logger=get_db_logger())

--- a/server/services/task_service.py
+++ b/server/services/task_service.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import Task
+from eyened_orm.task import TaskState
+from eyened_orm.repositories.task_repository import SubTaskRepository, TaskRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import NotFoundError
+
+
+class TaskService:
+    """Business logic for tasks and their subtask listings."""
+
+    def __init__(
+        self,
+        task_repository: TaskRepository,
+        subtask_repository: SubTaskRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.tasks = task_repository
+        self.subtasks = subtask_repository
+        self.logger = logger
+
+    def create_task(
+        self,
+        session: Session,
+        name: str,
+        description: str | None,
+        contact_id: int | None,
+        task_definition_id: int,
+        actor: ActingUser,
+    ) -> Task:
+        """Create a task owned by the acting user (TaskState.NotStarted)."""
+        task = Task(
+            TaskName=name,
+            Description=description,
+            ContactID=contact_id,
+            TaskDefinitionID=task_definition_id,
+            CreatorID=actor.id,
+            TaskState=TaskState.NotStarted,
+        )
+        session.add(task)
+        session.commit()
+        task = self.tasks.get_with_relations(session, task.TaskID)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/task",
+                entity="Task",
+                entity_id=task.TaskID,
+                fields={
+                    "name": task.TaskName,
+                    "description": task.Description,
+                    "contact_id": task.ContactID,
+                    "task_definition_id": task.TaskDefinitionID,
+                },
+            )
+        return task
+
+    def list_tasks(
+        self, session: Session
+    ) -> tuple[list[Task], dict[int, tuple[int, int]]]:
+        """Return all tasks (TaskID order) and their {id: (total, ready)} counts."""
+        tasks = self.tasks.list_all(session)
+        counts = self.tasks.subtask_counts(session, [t.TaskID for t in tasks])
+        return tasks, counts
+
+    def get_task(
+        self, session: Session, task_id: int
+    ) -> tuple[Task, tuple[int, int]]:
+        """Return a task and its (total, ready) subtask counts.
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        task = self.tasks.get_with_relations(session, task_id)
+        if task is None:
+            raise NotFoundError(f"Task {task_id} not found")
+        return task, self.tasks.subtask_counts(session, [task_id])[task_id]
+
+    def update_task(
+        self,
+        session: Session,
+        task_id: int,
+        name: str | None,
+        description: str | None,
+        contact_id: int | None,
+        task_definition_id: int | None,
+        task_state: TaskState | None,
+        actor: ActingUser,
+    ) -> tuple[Task, tuple[int, int]]:
+        """Update a task's mutable fields (each optional).
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        task = self.tasks.get_by_id(session, task_id)
+        if task is None:
+            raise NotFoundError(f"Task {task_id} not found")
+
+        changes: dict[str, str] = {}
+        if name is not None:
+            changes["name"] = f"{task.TaskName} -> {name}"
+            task.TaskName = name
+        if description is not None:
+            changes["description"] = f"{task.Description} -> {description}"
+            task.Description = description
+        if contact_id is not None:
+            changes["contact_id"] = f"{task.ContactID} -> {contact_id}"
+            task.ContactID = contact_id
+        if task_definition_id is not None:
+            changes["task_definition_id"] = (
+                f"{task.TaskDefinitionID} -> {task_definition_id}"
+            )
+            task.TaskDefinitionID = task_definition_id
+        if task_state is not None:
+            changes["task_state"] = f"{task.TaskState} -> {task_state}"
+            task.TaskState = task_state
+
+        session.commit()
+        task = self.tasks.get_with_relations(session, task_id)
+        counts = self.tasks.subtask_counts(session, [task_id])[task_id]
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/task/{task_id}",
+                entity="Task",
+                entity_id=task_id,
+                changes=changes if changes else None,
+            )
+        return task, counts
+
+    def delete_task(
+        self, session: Session, task_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a task (its subtasks cascade at the DB level).
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        task = self.tasks.get_by_id(session, task_id)
+        if task is None:
+            raise NotFoundError(f"Task {task_id} not found")
+
+        deleted_data = {
+            "name": task.TaskName,
+            "description": task.Description,
+            "contact_id": task.ContactID,
+            "task_definition_id": task.TaskDefinitionID,
+            "creator_id": task.CreatorID,
+            "task_state": str(task.TaskState) if task.TaskState else None,
+        }
+        session.delete(task)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/task/{task_id}",
+                entity="Task",
+                entity_id=task_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+
+def get_task_service() -> TaskService:
+    """Default TaskService wiring for FastAPI ``Depends()``."""
+    return TaskService(
+        TaskRepository(), SubTaskRepository(), logger=get_db_logger()
+    )

--- a/server/services/task_service.py
+++ b/server/services/task_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from eyened_orm import Task
-from eyened_orm.task import TaskState
+from eyened_orm import SubTask, Task
+from eyened_orm.task import SubTaskState, TaskState
 from eyened_orm.repositories.task_repository import SubTaskRepository, TaskRepository
 
 from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
@@ -167,6 +167,72 @@ class TaskService:
                 deleted_data=deleted_data,
             )
         return None
+
+    def list_task_subtasks(
+        self,
+        session: Session,
+        task_id: int,
+        *,
+        with_images: bool,
+        limit: int,
+        page: int,
+        status: SubTaskState | None,
+    ) -> tuple[list[tuple[SubTask, int]], int]:
+        """Return one page of a task's subtasks, each with its absolute index.
+
+        ``absolute_index`` is the subtask's 0-based position within *all* the
+        task's subtasks ordered by SubTaskID (computed before the ``status``
+        filter). The returned count honors ``status``.
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        if self.tasks.get_by_id(session, task_id) is None:
+            raise NotFoundError(f"Task {task_id} not found")
+
+        index_of = {
+            sid: i
+            for i, sid in enumerate(self.subtasks.all_ids_for_task(session, task_id))
+        }
+        rows = self.subtasks.list_for_task(
+            session,
+            task_id,
+            status=status,
+            limit=limit,
+            offset=limit * page,
+            with_images=with_images,
+        )
+        count = self.subtasks.count_for_task(session, task_id, status=status)
+        # Every returned row is one of the task's subtasks, so its id is always
+        # in index_of (rows are a subset of all_ids_for_task).
+        return [(st, index_of[st.SubTaskID]) for st in rows], count
+
+    def get_task_subtask(
+        self,
+        session: Session,
+        task_id: int,
+        subtask_index: int,
+        *,
+        with_images: bool,
+        with_next: bool,
+    ) -> tuple[SubTask, SubTask | None]:
+        """Return the subtask at ``subtask_index`` and, if asked, the next one.
+
+        Raises:
+            NotFoundError: If no subtask sits at ``subtask_index``.
+        """
+        rows = self.subtasks.list_for_task(
+            session,
+            task_id,
+            status=None,
+            limit=2 if with_next else 1,
+            offset=subtask_index,
+            with_images=with_images,
+        )
+        if not rows:
+            raise NotFoundError("SubTask not found")
+        nxt = rows[1] if (with_next and len(rows) > 1) else None
+        return rows[0], nxt
 
 
 def get_task_service() -> TaskService:

--- a/server/tests/test_device_service.py
+++ b/server/tests/test_device_service.py
@@ -5,7 +5,7 @@ from server.services.device_service import DeviceService
 
 
 def test_list_devices_returns_repository_rows_in_order(session):
-    # The service hands back exactly what the repository returns, order intact.
+    """The service hands back exactly what the repository returns, order intact."""
     session.add_all(
         [
             DeviceModel(Manufacturer="Zeiss", ManufacturerModelName="Cirrus"),

--- a/server/tests/test_feature_service.py
+++ b/server/tests/test_feature_service.py
@@ -1,0 +1,202 @@
+import pytest
+
+from eyened_orm import Feature
+from eyened_orm.repositories.feature_repository import FeatureRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import ConflictError, NotFoundError
+from server.services.feature_service import FeatureService
+
+
+def _make_feature(session, name: str) -> Feature:
+    f = Feature(FeatureName=name)
+    session.add(f)
+    session.flush()
+    return f
+
+
+def _service(logger=None) -> FeatureService:
+    return FeatureService(FeatureRepository(), logger=logger)
+
+
+def _actor() -> ActingUser:
+    return ActingUser(id=1, username="alice")
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+class _SegBlockingRepo:
+    """Hand-rolled fake forcing the 'has segmentations' guard without a real Segmentation."""
+
+    def get_by_id(self, session, feature_id):
+        f = Feature(FeatureName="Retina")
+        f.FeatureID = feature_id
+        return f
+
+    def count_segmentations(self, session, feature_id):
+        return 3
+
+
+def test_create_feature_persists_with_subfeatures(session):
+    """Creating a feature with subfeature ids writes the ordered child links."""
+    child = _make_feature(session, "child")
+
+    feature = _service().create_feature(session, "parent", [child.FeatureID], _actor())
+
+    assert feature.FeatureName == "parent"
+    assert FeatureRepository().list_subfeature_ids(session, feature.FeatureID) == [
+        child.FeatureID
+    ]
+
+
+def test_create_feature_without_subfeatures(session):
+    """Creating a feature with no subfeatures leaves it childless."""
+    feature = _service().create_feature(session, "solo", None, _actor())
+
+    assert feature.FeatureName == "solo"
+    assert FeatureRepository().list_subfeature_ids(session, feature.FeatureID) == []
+
+
+def test_create_feature_logs_insert(session):
+    """Creating a feature emits one insert audit record naming the entity and user."""
+    logger = FakeAuditLogger()
+
+    _service(logger).create_feature(session, "solo", None, _actor())
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "Feature"
+    assert logger.inserts[0]["user"] == "alice"
+
+
+def test_get_feature_returns_it(session):
+    """get_feature returns the ORM object for an existing id."""
+    feature = _make_feature(session, "x")
+    assert _service().get_feature(session, feature.FeatureID).FeatureID == feature.FeatureID
+
+
+def test_get_feature_unknown_raises_not_found(session):
+    """get_feature on a missing id is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_feature(session, 999_999)
+
+
+def test_list_features_orders_by_name_and_omits_counts(session):
+    """list_features(with_counts=False) returns name-sorted features and an empty count map."""
+    _make_feature(session, "Zeta")
+    _make_feature(session, "Alpha")
+
+    features, counts = _service().list_features(session, with_counts=False)
+
+    assert [f.FeatureName for f in features] == ["Alpha", "Zeta"]
+    assert counts == {}
+
+
+def test_update_feature_changes_name(session):
+    """Updating name overwrites FeatureName in place."""
+    feature = _make_feature(session, "old")
+
+    updated = _service().update_feature(
+        session, feature.FeatureID, "new", None, _actor()
+    )
+
+    assert updated.FeatureName == "new"
+
+
+def test_update_feature_replaces_subfeatures(session):
+    """Updating subfeature_ids replaces the child link set."""
+    parent = _make_feature(session, "parent")
+    a = _make_feature(session, "a")
+    b = _make_feature(session, "b")
+    service = _service()
+    service.update_feature(session, parent.FeatureID, None, [a.FeatureID], _actor())
+
+    service.update_feature(session, parent.FeatureID, None, [b.FeatureID], _actor())
+
+    assert FeatureRepository().list_subfeature_ids(session, parent.FeatureID) == [
+        b.FeatureID
+    ]
+
+
+def test_update_feature_unknown_raises_not_found(session):
+    """Updating a missing feature is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().update_feature(session, 999_999, "x", None, _actor())
+
+
+def test_update_feature_logs_update(session):
+    """Updating a feature emits one update audit record."""
+    feature = _make_feature(session, "old")
+    logger = FakeAuditLogger()
+
+    _service(logger).update_feature(session, feature.FeatureID, "new", None, _actor())
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "Feature"
+
+
+def test_delete_feature_removes_it(session):
+    """Deleting an unreferenced feature removes it from the database."""
+    feature = _make_feature(session, "gone")
+
+    _service().delete_feature(session, feature.FeatureID, _actor())
+
+    assert FeatureRepository().get_by_id(session, feature.FeatureID) is None
+
+
+def test_delete_feature_unknown_raises_not_found(session):
+    """Deleting a missing feature is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().delete_feature(session, 999_999, _actor())
+
+
+def test_delete_feature_blocked_by_child_link_raises_conflict(session):
+    """A feature that is a child of another cannot be deleted (409 FEATURE_IS_CHILD)."""
+    parent = _make_feature(session, "parent")
+    child = _make_feature(session, "child")
+    FeatureRepository().replace_subfeatures(session, parent.FeatureID, [child.FeatureID])
+
+    with pytest.raises(ConflictError) as exc:
+        _service().delete_feature(session, child.FeatureID, _actor())
+
+    detail = exc.value.detail
+    assert detail["code"] == "FEATURE_IS_CHILD"
+    assert detail["parents"] == ["parent"]
+
+
+def test_delete_feature_blocked_by_segmentations_raises_conflict(session):
+    """A feature with linked segmentations cannot be deleted (409 FEATURE_HAS_SEGMENTATIONS)."""
+    service = FeatureService(_SegBlockingRepo())
+
+    with pytest.raises(ConflictError) as exc:
+        service.delete_feature(session, 7, _actor())
+
+    detail = exc.value.detail
+    assert detail["code"] == "FEATURE_HAS_SEGMENTATIONS"
+    assert detail["segmentation_count"] == 3
+
+
+def test_delete_feature_logs_delete(session):
+    """Deleting a feature emits one delete audit record."""
+    feature = _make_feature(session, "gone")
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_feature(session, feature.FeatureID, _actor())
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "Feature"

--- a/server/tests/test_form_schema_service.py
+++ b/server/tests/test_form_schema_service.py
@@ -8,7 +8,7 @@ from server.services.form_schema_service import FormSchemaService
 
 
 def test_list_form_schemas_returns_rows_in_order(session):
-    # The service hands back the repository's rows, order intact.
+    """The service hands back the repository's rows, order intact."""
     session.add_all([FormSchema(SchemaName="Zeta"), FormSchema(SchemaName="Alpha")])
     session.flush()
 
@@ -19,7 +19,7 @@ def test_list_form_schemas_returns_rows_in_order(session):
 
 
 def test_get_form_schema_returns_the_schema(session):
-    # An existing schema is returned by the service unchanged.
+    """An existing schema is returned by the service unchanged."""
     schema = FormSchema(SchemaName="Alpha")
     session.add(schema)
     session.flush()
@@ -31,7 +31,7 @@ def test_get_form_schema_returns_the_schema(session):
 
 
 def test_get_form_schema_unknown_id_raises_not_found(session):
-    # A missing schema makes the service raise NotFoundError (-> 404 via handler).
+    """A missing schema makes the service raise NotFoundError (-> 404 via handler)."""
     service = FormSchemaService(FormSchemaRepository())
 
     with pytest.raises(NotFoundError):

--- a/server/tests/test_patient_service.py
+++ b/server/tests/test_patient_service.py
@@ -19,7 +19,7 @@ def _make_patient(session, identifier: str = "ID1") -> Patient:
 
 
 def test_get_patient_returns_the_patient(session):
-    # An existing patient is returned by the service unchanged.
+    """An existing patient is returned by the service unchanged."""
     patient = _make_patient(session)
 
     service = PatientService(PatientRepository())
@@ -29,7 +29,7 @@ def test_get_patient_returns_the_patient(session):
 
 
 def test_get_patient_unknown_id_raises_not_found(session):
-    # A missing patient makes the service raise NotFoundError (→ 404 via handler).
+    """A missing patient makes the service raise NotFoundError (→ 404 via handler)."""
     service = PatientService(PatientRepository())
 
     with pytest.raises(NotFoundError):

--- a/server/tests/test_services_exceptions.py
+++ b/server/tests/test_services_exceptions.py
@@ -11,23 +11,23 @@ from server.services.exceptions import (
 
 
 def test_not_found_error_maps_to_404_response():
-    # A NotFoundError should become an HTTP 404 carrying its message.
+    """A NotFoundError should become an HTTP 404 carrying its message."""
     resp = service_error_to_response(NotFoundError("Patient 5 not found"))
     assert resp.status_code == 404
     assert json.loads(resp.body) == {"detail": "Patient 5 not found"}
 
 
 def test_base_service_error_maps_to_500_response():
-    # A plain ServiceError (no status override) falls back to HTTP 500.
+    """A plain ServiceError (no status override) falls back to HTTP 500."""
     resp = service_error_to_response(ServiceError("boom"))
     assert resp.status_code == 500
     assert json.loads(resp.body) == {"detail": "boom"}
 
 
 def test_register_exception_handlers_registers_service_error_base():
-    # Registering the ServiceError base is what makes every subclass (incl.
-    # Step 2's future PermissionDeniedError) dispatch through this one handler,
-    # since Starlette resolves handlers by walking the exception's MRO.
+    """Registering the ServiceError base makes every subclass dispatch through
+    this one handler (incl. Step 2's future PermissionDeniedError), since
+    Starlette resolves handlers by walking the exception's MRO."""
     app = FastAPI()
     register_exception_handlers(app)
     assert ServiceError in app.exception_handlers

--- a/server/tests/test_services_exceptions.py
+++ b/server/tests/test_services_exceptions.py
@@ -40,3 +40,17 @@ def test_bad_request_error_maps_to_400_response():
     resp = service_error_to_response(BadRequestError("Tag type must be Study"))
     assert resp.status_code == 400
     assert json.loads(resp.body) == {"detail": "Tag type must be Study"}
+
+
+def test_conflict_error_maps_to_409_with_structured_detail():
+    """ConflictError maps to HTTP 409 and preserves a structured (dict) detail body."""
+    from server.services.exceptions import ConflictError
+
+    detail = {
+        "code": "FEATURE_HAS_SEGMENTATIONS",
+        "message": "Cannot delete feature 'X' because it has 3 linked segmentation(s).",
+        "segmentation_count": 3,
+    }
+    resp = service_error_to_response(ConflictError(detail))
+    assert resp.status_code == 409
+    assert json.loads(resp.body) == {"detail": detail}

--- a/server/tests/test_tag_service.py
+++ b/server/tests/test_tag_service.py
@@ -1,0 +1,214 @@
+import pytest
+
+from eyened_orm import Creator, Tag
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import NotFoundError
+from server.services.tag_service import TagService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _actor(session) -> ActingUser:
+    """An ActingUser backed by a real Creator row (Tag.CreatorID is a FK)."""
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _make_tag(
+    session, creator_id: int, name: str = "T1", tag_type: TagType = TagType.Study
+) -> Tag:
+    tag = Tag(
+        TagName=name, TagType=tag_type, TagDescription="", CreatorID=creator_id
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def _service(logger=None) -> TagService:
+    return TagService(TagRepository(), logger=logger)
+
+
+def test_create_tag_persists_and_returns(session):
+    """Creating a tag stores it with the acting user as owner."""
+    actor = _actor(session)
+
+    tag = _service().create_tag(session, "New", "desc", TagType.Study, actor)
+
+    assert tag.TagName == "New"
+    assert tag.TagType == TagType.Study
+    assert tag.TagDescription == "desc"
+    assert tag.CreatorID == actor.id
+
+
+def test_create_tag_logs_insert(session):
+    """Creating a tag emits one insert audit record naming the entity and user."""
+    actor = _actor(session)
+    logger = FakeAuditLogger()
+
+    _service(logger).create_tag(session, "New", "desc", TagType.Study, actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "Tag"
+    assert logger.inserts[0]["user"] == actor.username
+
+
+def test_update_tag_changes_fields(session):
+    """update_tag overwrites the provided fields in place."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id, "Old")
+
+    updated = _service().update_tag(
+        session, tag.TagID, "New", "newdesc", None, actor
+    )
+
+    assert updated.TagName == "New"
+    assert updated.TagDescription == "newdesc"
+
+
+def test_update_tag_unknown_raises_not_found(session):
+    """Updating a missing tag is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().update_tag(session, 999_999, "x", None, None, actor)
+
+
+def test_update_tag_logs_update(session):
+    """Updating a tag emits one update audit record."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id, "Old")
+    logger = FakeAuditLogger()
+
+    _service(logger).update_tag(session, tag.TagID, "New", None, None, actor)
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "Tag"
+
+
+def test_delete_tag_removes_it(session):
+    """Deleting a tag removes it from the database."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+
+    _service().delete_tag(session, tag.TagID, actor)
+
+    assert TagRepository().get_by_id(session, tag.TagID) is None
+
+
+def test_delete_tag_unknown_raises_not_found(session):
+    """Deleting a missing tag is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().delete_tag(session, 999_999, actor)
+
+
+def test_delete_tag_logs_delete(session):
+    """Deleting a tag emits one delete audit record."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_tag(session, tag.TagID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "Tag"
+
+
+def test_star_tag_creates_link(session):
+    """Starring a tag creates the CreatorTagLink for the acting user."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+
+    _service().star_tag(session, tag.TagID, actor)
+
+    assert (
+        TagRepository().get_star_link(session, tag.TagID, actor.id) is not None
+    )
+
+
+def test_star_tag_is_idempotent(session):
+    """Starring an already-starred tag adds no second link and logs nothing new."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+    service = _service(logger)
+    service.star_tag(session, tag.TagID, actor)
+
+    service.star_tag(session, tag.TagID, actor)
+
+    assert len(logger.inserts) == 1  # only the first star logged
+
+
+def test_star_tag_unknown_raises_not_found(session):
+    """Starring a missing tag is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().star_tag(session, 999_999, actor)
+
+
+def test_star_tag_logs_insert(session):
+    """Starring a tag emits one insert audit record for the link entity."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+
+    _service(logger).star_tag(session, tag.TagID, actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "CreatorTagLink"
+
+
+def test_unstar_tag_removes_link(session):
+    """Unstarring removes the acting user's CreatorTagLink."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    _service().star_tag(session, tag.TagID, actor)
+
+    _service().unstar_tag(session, tag.TagID, actor)
+
+    assert TagRepository().get_star_link(session, tag.TagID, actor.id) is None
+
+
+def test_unstar_tag_absent_is_noop(session):
+    """Unstarring a tag that was never starred is a no-op (no error, no log)."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+
+    _service(logger).unstar_tag(session, tag.TagID, actor)
+
+    assert len(logger.deletes) == 0
+
+
+def test_unstar_tag_logs_delete(session):
+    """Unstarring a starred tag emits one delete audit record for the link entity."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    _service().star_tag(session, tag.TagID, actor)
+    logger = FakeAuditLogger()
+
+    _service(logger).unstar_tag(session, tag.TagID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "CreatorTagLink"

--- a/server/tests/test_task_service.py
+++ b/server/tests/test_task_service.py
@@ -1,0 +1,201 @@
+import pytest
+
+from eyened_orm import Creator, SubTask, Task, TaskDefinition
+from eyened_orm.task import SubTaskState, TaskState
+from eyened_orm.repositories.task_repository import SubTaskRepository, TaskRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import NotFoundError
+from server.services.task_service import TaskService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _actor(session) -> ActingUser:
+    """An ActingUser backed by a real Creator row (Task.CreatorID is a FK)."""
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _task_def(session, name: str = "td") -> TaskDefinition:
+    td = TaskDefinition(TaskDefinitionName=name)
+    session.add(td)
+    session.flush()
+    return td
+
+
+def _make_task(session, td_id: int, creator_id: int, name: str = "T") -> Task:
+    task = Task(
+        TaskName=name,
+        TaskDefinitionID=td_id,
+        CreatorID=creator_id,
+        TaskState=TaskState.NotStarted,
+    )
+    session.add(task)
+    session.flush()
+    return task
+
+
+def _service(logger=None) -> TaskService:
+    return TaskService(TaskRepository(), SubTaskRepository(), logger=logger)
+
+
+def test_create_task_persists_with_defaults(session):
+    """create_task stores the task with the actor as owner and TaskState.NotStarted."""
+    actor = _actor(session)
+    td = _task_def(session)
+
+    task = _service().create_task(
+        session, "New", "desc", None, td.TaskDefinitionID, actor
+    )
+
+    assert task.TaskName == "New"
+    assert task.Description == "desc"
+    assert task.ContactID is None
+    assert task.TaskDefinitionID == td.TaskDefinitionID
+    assert task.CreatorID == actor.id
+    assert task.TaskState == TaskState.NotStarted
+
+
+def test_create_task_logs_insert(session):
+    """create_task emits one insert audit record naming the entity and user."""
+    actor = _actor(session)
+    td = _task_def(session)
+    logger = FakeAuditLogger()
+
+    _service(logger).create_task(
+        session, "New", None, None, td.TaskDefinitionID, actor
+    )
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "Task"
+    assert logger.inserts[0]["user"] == actor.username
+
+
+def test_list_tasks_returns_tasks_with_counts(session):
+    """list_tasks returns tasks in id order and a (total, ready) count per task."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.Ready))
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.NotStarted))
+    session.commit()
+
+    tasks, counts = _service().list_tasks(session)
+
+    assert [t.TaskID for t in tasks] == [task.TaskID]
+    assert counts[task.TaskID] == (2, 1)
+
+
+def test_get_task_returns_task_and_counts(session):
+    """get_task returns the task and its (total, ready) subtask counts."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.Ready))
+    session.commit()
+
+    got, counts = _service().get_task(session, task.TaskID)
+
+    assert got.TaskID == task.TaskID
+    assert counts == (1, 1)
+
+
+def test_get_task_unknown_raises_not_found(session):
+    """Getting a missing task is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_task(session, 999_999)
+
+
+def test_update_task_changes_fields(session):
+    """update_task overwrites the provided fields (name, description, task_state)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id, "Old")
+    session.commit()
+
+    updated, _counts = _service().update_task(
+        session, task.TaskID, "New", "newdesc", None, None, TaskState.Busy, actor
+    )
+
+    assert updated.TaskName == "New"
+    assert updated.Description == "newdesc"
+    assert updated.TaskState == TaskState.Busy
+
+
+def test_update_task_unknown_raises_not_found(session):
+    """Updating a missing task is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().update_task(
+            session, 999_999, "x", None, None, None, None, actor
+        )
+
+
+def test_update_task_logs_update(session):
+    """update_task emits one update audit record for the Task entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id, "Old")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).update_task(
+        session, task.TaskID, "New", None, None, None, None, actor
+    )
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "Task"
+
+
+def test_delete_task_removes_it_and_cascades_subtasks(session):
+    """delete_task removes the task and (via DB cascade) its subtasks."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.NotStarted))
+    session.commit()
+
+    _service().delete_task(session, task.TaskID, actor)
+
+    assert TaskRepository().get_by_id(session, task.TaskID) is None
+    assert SubTaskRepository().all_ids_for_task(session, task.TaskID) == []
+
+
+def test_delete_task_unknown_raises_not_found(session):
+    """Deleting a missing task is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().delete_task(session, 999_999, actor)
+
+
+def test_delete_task_logs_delete(session):
+    """delete_task emits one delete audit record for the Task entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_task(session, task.TaskID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "Task"

--- a/server/tests/test_task_service.py
+++ b/server/tests/test_task_service.py
@@ -199,3 +199,102 @@ def test_delete_task_logs_delete(session):
 
     assert len(logger.deletes) == 1
     assert logger.deletes[0]["entity"] == "Task"
+
+
+def _make_subtask(session, task_id: int, state: SubTaskState) -> SubTask:
+    st = SubTask(TaskID=task_id, TaskState=state)
+    session.add(st)
+    session.flush()
+    return st
+
+
+def test_list_task_subtasks_paginates_with_absolute_index(session):
+    """list_task_subtasks returns a page, each row tagged with its absolute index."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    made = [_make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(5)]
+    session.commit()
+
+    rows, count = _service().list_task_subtasks(
+        session, task.TaskID, with_images=False, limit=2, page=1, status=None
+    )
+
+    assert count == 5
+    assert [(st.SubTaskID, idx) for st, idx in rows] == [
+        (made[2].SubTaskID, 2),
+        (made[3].SubTaskID, 3),
+    ]
+
+
+def test_list_task_subtasks_filters_by_status_keeps_absolute_index(session):
+    """A status filter narrows rows/count but indices stay absolute (pre-filter)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)  # abs index 0
+    ready = _make_subtask(session, task.TaskID, SubTaskState.Ready)  # abs index 1
+    session.commit()
+
+    rows, count = _service().list_task_subtasks(
+        session, task.TaskID, with_images=False, limit=10, page=0,
+        status=SubTaskState.Ready,
+    )
+
+    assert count == 1
+    assert [(st.SubTaskID, idx) for st, idx in rows] == [(ready.SubTaskID, 1)]
+
+
+def test_list_task_subtasks_unknown_task_raises_not_found(session):
+    """Listing subtasks of a missing task is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().list_task_subtasks(
+            session, 999_999, with_images=False, limit=10, page=0, status=None
+        )
+
+
+def test_get_task_subtask_returns_by_index(session):
+    """get_task_subtask returns the subtask at the given absolute index."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    made = [_make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(3)]
+    session.commit()
+
+    main, nxt = _service().get_task_subtask(
+        session, task.TaskID, 1, with_images=False, with_next=False
+    )
+
+    assert main.SubTaskID == made[1].SubTaskID
+    assert nxt is None
+
+
+def test_get_task_subtask_with_next_returns_following(session):
+    """with_next also returns the subtask after the requested index."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    made = [_make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(3)]
+    session.commit()
+
+    main, nxt = _service().get_task_subtask(
+        session, task.TaskID, 1, with_images=False, with_next=True
+    )
+
+    assert main.SubTaskID == made[1].SubTaskID
+    assert nxt is not None
+    assert nxt.SubTaskID == made[2].SubTaskID
+
+
+def test_get_task_subtask_out_of_range_raises_not_found(session):
+    """An index past the last subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    session.commit()
+
+    with pytest.raises(NotFoundError):
+        _service().get_task_subtask(
+            session, task.TaskID, 5, with_images=False, with_next=False
+        )


### PR DESCRIPTION
## RBAC Step 1 — Repository/Service Layer

Tracks [`docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`](docs/superpowers/specs/2026-07-03-repository-service-layer-design.md).

Introduces a Repository + Service layering (`routes → services → repositories → DB`) so Step 2 (RBAC) has one place per entity to add authz checks. Each phase ships as its own PR: add Repository + Service for the phase's model(s), switch the route module to use them.

### Foundation (cross-cutting)
- [x] `server/services/exceptions.py` — `ServiceError` base + `NotFoundError` (also added `BadRequestError`/400 and `ConflictError`/409)
- [x] Central handler registered in `server/main.py` (`register_exception_handlers`) — maps every `ServiceError` subclass by `status_code`; single place to add Step 2 `PermissionDeniedError` → 403
- [x] `repositories/__init__.py` + `services/__init__.py` re-export public classes (`from .<model>_* import *`)

### Phase 0 — Pilot: `devices.py`
- [x] `DeviceRepository`
- [x] `DeviceService`
- [x] `devices.py` route switched to Service (thin handler, DTO at boundary)
- [x] Repository tests (`test_device_repository.py`)
- [x] Service tests (`test_device_service.py`)

### Phase 1 — `form_schema.py`, `patients.py`
- [x] `FormSchemaRepository` + `FormSchemaService` + route switch
- [x] `FormSchemaRepository`/`Service` tests
- [x] `PatientRepository` + `PatientService` + route switch (RBAC-relevant)
- [x] `PatientRepository`/`Service` tests

### Phase 2 — `studies.py`, `feature.py`, `tag.py`
- [x] `StudyRepository` + `StudyService` + `studies.py` route switch + tests
- [x] `FeatureRepository` + `FeatureService` + `feature.py` route switch + tests (`ConflictError` delete guards, injected audit logging)
- [x] `TagRepository` + `TagService` + `tag.py` route switch + tests

### Phase 3 — `subtask.py`, `task.py` (RBAC-relevant)
- [x] `TaskRepository`, `SubTaskRepository`, `TaskDefinitionRepository`
- [ ] `TaskService`, `SubTaskService`
- [ ] `subtask.py` route switch + tests
- [ ] `task.py` route switch (calls multiple Services directly, no facade) + tests

### Phase 4 — `import_api.py`, `instances.py`, `form_annotations.py`, `segmentations.py`
- [ ] `import_api.py` — Repository + Service + route switch + tests
- [ ] `instances.py` — Repository + Service + route switch + tests
- [ ] `form_annotations.py` — Repository + Service + route switch + tests (RBAC-relevant: `FormAnnotation`)
- [ ] `segmentations.py` — Repository + Service + route switch + tests (RBAC-relevant: `Segmentation`)

### Conventions checklist (apply to every phase)
- [ ] Repositories are framework-agnostic (no FastAPI/HTTP imports), take `Session` as an arg, return `None`/`[]` for not-found — never raise HTTP-shaped errors
- [ ] Services take their Repository via constructor injection; a `Depends()` factory wires the default at the route layer
- [ ] Services translate `None`/empty + business-rule violations into domain exceptions — never raise `HTTPException` directly
- [ ] Routes are thin (parse → Service → `DTOConverter` → return); no `if not X: raise HTTPException(...)` left in handlers
- [ ] DTO shapes unchanged (no frontend/API changes)

### Out of scope (not this spec)
- `search.py` (1257 lines) and `auth.py` (831 lines) — see Non-goals
- CLI/worker code in `orm/eyened_orm/commands/` stays on today's classmethods
- Step 2: RBAC itself (roles, permissions, membership, `PermissionDeniedError` → 403)
- **Transaction ownership** — revisit across all Services once every phase has migrated; mutating Services currently `commit()`/`refresh()` inline (carried over from route behavior). Pick one consistent model (e.g. commit boundary in `get_db`/unit-of-work). Check for double-commit first: `grep -rn "\.commit()" server/services server/routes server/db.py`
