### PR TITLE
Extract copy-to-clipboard and add top viewer copy bar

### DIFF
--- a/client/src/lib/browser/InstanceComponent.svelte
+++ b/client/src/lib/browser/InstanceComponent.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Dialog from "$lib/components/ui/dialog";
+	import CopyIconButton from "$lib/components/CopyIconButton.svelte";
 	import { getThumbUrl } from "$lib/data-loading/utils";
-	import CopyIcon from "@lucide/svelte/icons/copy";
 
 	import { getContext } from "svelte";
 	import type { ImageGET } from "../../types/openapi_types";
@@ -60,12 +60,6 @@
 	function openInfoPanel() {
 		popupOpen = true;
 	}
-
-	function copyPublicId(event: MouseEvent) {
-		event.stopPropagation();
-		event.preventDefault();
-		void navigator.clipboard.writeText(publicId);
-	}
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -82,16 +76,12 @@
 	>
 		<div class="title-flip">
 			<div class="title-face title-face-default text-xs">{name}</div>
-			<div class="title-face title-face-hover text-xs">
+			<div
+				class="title-face title-face-hover text-xs"
+				onclick={(event) => event.stopPropagation()}
+			>
 				<span class="public-id truncate">{publicId}</span>
-				<button
-					type="button"
-					class="copy-btn shrink-0"
-					aria-label="Copy public ID"
-					onclick={copyPublicId}
-				>
-					<CopyIcon class="size-3" />
-				</button>
+				<CopyIconButton text={publicId} ariaLabel="Copy public ID" class="shrink-0" />
 			</div>
 		</div>
 	</div>
@@ -151,7 +141,7 @@
 		inset: 0;
 		gap: 0.15rem;
 		padding-inline: 0.1rem;
-		transform: rotateX(180deg);
+		transform: rotateX(180deg) translateZ(1px);
 		pointer-events: none;
 	}
 
@@ -165,21 +155,6 @@
 
 	.public-id {
 		min-width: 0;
-	}
-
-	.copy-btn {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		padding: 0.1rem;
-		border-radius: 0.15rem;
-		color: inherit;
-		opacity: 0.7;
-	}
-
-	.copy-btn:hover {
-		opacity: 1;
-		background-color: rgb(0 0 0 / 0.06);
 	}
 
 	.thumbnail-container {

--- a/client/src/lib/browser/InstanceComponent.svelte
+++ b/client/src/lib/browser/InstanceComponent.svelte
@@ -76,10 +76,7 @@
 	>
 		<div class="title-flip">
 			<div class="title-face title-face-default text-xs">{name}</div>
-			<div
-				class="title-face title-face-hover text-xs"
-				onclick={(event) => event.stopPropagation()}
-			>
+			<div class="title-face title-face-hover text-xs">
 				<span class="public-id truncate">{publicId}</span>
 				<CopyIconButton text={publicId} ariaLabel="Copy public ID" class="shrink-0" />
 			</div>

--- a/client/src/lib/components/CopyIconButton.svelte
+++ b/client/src/lib/components/CopyIconButton.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import CopyIcon from "@lucide/svelte/icons/copy";
+	import { cn } from "$lib/utils";
+	import { copyToClipboard } from "$lib/utils/copyToClipboard";
+	import type { HTMLButtonAttributes } from "svelte/elements";
+
+	interface Props extends HTMLButtonAttributes {
+		text: string;
+		ariaLabel?: string;
+		iconClass?: string;
+		stopPropagation?: boolean;
+	}
+
+	let {
+		text,
+		ariaLabel = "Copy to clipboard",
+		iconClass = "size-3",
+		stopPropagation = true,
+		class: className,
+		onclick,
+		...restProps
+	}: Props = $props();
+
+	async function handleClick(event: MouseEvent) {
+		if (stopPropagation) {
+			event.stopPropagation();
+		}
+		await copyToClipboard(text);
+		onclick?.(event);
+	}
+
+	function handlePointerDown(event: PointerEvent) {
+		if (stopPropagation) {
+			event.stopPropagation();
+		}
+	}
+</script>
+
+<button
+	type="button"
+	class={cn("copy-btn", className)}
+	aria-label={ariaLabel}
+	onclick={handleClick}
+	onpointerdown={handlePointerDown}
+	{...restProps}
+>
+	<CopyIcon class={iconClass} />
+</button>
+
+<style>
+	.copy-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.1rem;
+		border-radius: 0.15rem;
+		color: inherit;
+		opacity: 0.7;
+	}
+
+	.copy-btn:hover {
+		opacity: 1;
+		background-color: rgb(0 0 0 / 0.06);
+	}
+</style>

--- a/client/src/lib/utils/copyToClipboard.ts
+++ b/client/src/lib/utils/copyToClipboard.ts
@@ -1,0 +1,35 @@
+/**
+ * Legacy fallback for non-secure contexts (e.g. HTTP on a LAN hostname).
+ * execCommand is deprecated but remains the only widely supported alternative
+ * when navigator.clipboard is unavailable.
+ */
+function copyViaExecCommand(text: string): boolean {
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.setAttribute("readonly", "");
+	textarea.style.position = "fixed";
+	textarea.style.top = "0";
+	textarea.style.left = "0";
+	textarea.style.opacity = "0";
+	document.body.appendChild(textarea);
+	textarea.focus();
+	textarea.select();
+	const copied = document.execCommand("copy");
+	document.body.removeChild(textarea);
+	return copied;
+}
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+	const value = String(text);
+
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(value);
+			return true;
+		} catch {
+			// Fall through to execCommand below.
+		}
+	}
+
+	return copyViaExecCommand(value);
+}

--- a/client/src/lib/viewer-window/TopViewer.svelte
+++ b/client/src/lib/viewer-window/TopViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import CopyIconButton from "$lib/components/CopyIconButton.svelte";
 	import Viewer from "$lib/viewer/Viewer.svelte";
 	import { getContext, setContext } from "svelte";
 	import type { ViewerWindowContext } from "./viewerWindowContext.svelte";
@@ -12,6 +13,8 @@
 	}
 
 	let { image }: Props = $props();
+
+	const publicId = image.instance.id;
 
 	const viewerWindowContext = getContext<ViewerWindowContext>(
 		"viewerWindowContext",
@@ -61,6 +64,10 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="item" class:wide={image.is3D} onclick={(e) => selectImage(e)}>
 	<Viewer showInfo={false} />
+	<div class="copy-bar">
+		<span class="public-id">{publicId}</span>
+		<CopyIconButton text={publicId} ariaLabel="Copy public ID" />
+	</div>
 	{#if hasLocators}
 		<div class="header overlay">
 			<div class="content outer">
@@ -112,5 +119,33 @@
 		color: white;
 		display: flex;
 		margin: 0.5em;
+	}
+	.copy-bar {
+		position: absolute;
+		top: 0.5em;
+		right: 0.5em;
+		z-index: 3;
+		display: flex;
+		align-items: center;
+		gap: 0.15rem;
+		max-width: calc(100% - 1em);
+		padding: 0.1rem 0.35rem;
+		border-radius: 0.15rem;
+		background-color: rgb(0 0 0 / 0.55);
+		color: rgb(255 255 255 / 0.85);
+		font-size: 0.75rem;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.15s ease;
+	}
+	.item:hover .copy-bar {
+		opacity: 1;
+		pointer-events: auto;
+	}
+	.public-id {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Extract reusable `CopyIconButton` and `copyToClipboard` utility, with an `execCommand` fallback for non-secure HTTP contexts
- Refactor browser instance tiles to use the shared copy component
- Add a hover-only copy bar to top viewer thumbnails (top-right), showing the image public ID

## Test plan
- [ ] Hover a browser instance tile, click copy — public ID is copied to clipboard
- [ ] Hover a top viewer thumbnail, click copy — public ID is copied to clipboard
- [ ] Verify copy works over plain HTTP (non-localhost) via the fallback path
- [ ] Verify copy still works on HTTPS / localhost via the Clipboard API
- [ ] Confirm clicking copy does not open the instance info dialog or change viewer selection


Made with [Cursor](https://cursor.com)