### PR TITLE
Fix patient registration loading on task viewer route.

### DIFF
--- a/client/src/lib/viewer-window/ViewerWindow.svelte
+++ b/client/src/lib/viewer-window/ViewerWindow.svelte
@@ -42,9 +42,11 @@ Keeps track of the main panels and the top row of images.
 	let isResizing = false;
 	let registrationSet: RegistrationSet[] = $derived.by(() => {
 		const result: RegistrationSet[] = [];
-		const patientIds = new Set<number>([
-			...instanceIds.map((id) => instances.get(id)?.patient.id),
-		]);
+		const patientIds = new Set<number>(
+			viewerWindowContext.instanceIds
+				.map((id) => instances.get(id)?.patient.id)
+				.filter((pid): pid is number => typeof pid === "number"),
+		);
 		// TODO: check if patient can be fetched with promise directly?
 		for (const patientId of patientIds) {
 			const patient = patients.get(patientId);


### PR DESCRIPTION
registrationSet was derived from a one-time snapshot of instanceIds taken at component init. On the task route, instances load asynchronously, so the snapshot stayed empty and patient Registration attrs were never read from the patients store.

Derive patient IDs reactively from viewerWindowContext.instanceIds and filter undefined values before building the set.

Fixes #142

Test plan:
- [ ] Open a task with images for a patient that has Registration attrs
- [ ] Confirm cursor sync works between linked images
- [ ] Confirm registration still works on the /view route