### PR TITLE
Feature/rbac step1 service layer

### DIFF
--- a/docs/backlog/2026-07-16-pr145-rbac-step1-review.md
+++ b/docs/backlog/2026-07-16-pr145-rbac-step1-review.md
@@ -1,0 +1,56 @@
+# Follow-ups from PR #145 — RBAC Step 1 service layer
+
+- **Source:** [PR #145 review by @bjliefers](https://github.com/Eyened/eyened-platform/pull/145#pullrequestreview-4712228703) (Approved with follow-ups, 2026-07-16)
+- **Verdict:** Approve with follow-ups. "Solid migration — thin routes, injected services, testable repositories. Matches the Step 1 spec."
+- **Related spec:** [Repository / service layer design](../superpowers/specs/2026-07-03-repository-service-layer-design.md)
+
+The reviewer flagged these as optimization follow-ups to handle in a **separate round**,
+not blockers for merge. They are related and worth tackling together, ideally **before
+Step 2 adds more call sites**.
+
+---
+
+## 1. Repository eager-loading convention
+
+**Status:** open
+
+**What:** Pick one convention for eager loading in repositories. Several repos bake in
+`selectinload` graphs copied from the old route handlers
+(`FormAnnotationRepository.list_active`, `SegmentationRepository.get_with_tag_links`, etc.),
+while others expose flags (`ImageInstanceRepository`, `PatientRepository.get_with_attributes`).
+
+**Why:** Establish one convention before Step 2 adds more call sites. Baked-in
+`selectinload` may not be sustainable once we want advanced access-control filtering
+(e.g. only Tags exposed to the requesting user, not all tags in the database) — a blanket
+`selectinload` just selects all related entities.
+
+> Verbatim: "Several repos bake in `selectinload` graphs copied from old route handlers
+> (`FormAnnotationRepository.list_active`, `SegmentationRepository.get_with_tag_links`,
+> etc.), while others expose flags (`ImageInstanceRepository`,
+> `PatientRepository.get_with_attributes`). Worth picking one convention before Step 2
+> adds more call sites. If we want to do advanced filtering in the future (e.g. only Tags
+> exposed to the user that does the fetch, not all tags in the database) the selectinload
+> may not be sustainable (that will just select all related entities I think)."
+
+---
+
+## 2. Dead eager loads
+
+**Status:** open
+
+**What:** Remove eager loads whose results are never used. Form-annotation and
+segmentation GET/list still call the DTO converter with `with_tag_metadata=False`, so
+tag links are fetched but `tags` stays `[]`.
+
+**Why:** Wasted queries. Related to how DTO converters map ORM objects to API responses —
+their input should be **explicit**, not derived by iterating through ORM relationships.
+
+> Verbatim: "In a few places the loaded associations are not used: form-annotation and
+> segmentation GET/list still call the DTO converter with `with_tag_metadata=False`, so
+> tag links are fetched but `tags` stays `[]`."
+>
+> "Perhaps follow up on those in a separate round. This is mainly about optimization, but
+> we may need to evaluate again how to formulate the queries in the repository layer,
+> perhaps the selectinload is not (or not always) appropriate. Related to how the
+> DTO-converters convert ORM objects to API responses: their input should be explicit,
+> not by iterating through ORM relationships."

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -1,0 +1,15 @@
+# Backlog
+
+Tracks important follow-up work surfaced during reviews, planning, and implementation
+that is intentionally deferred rather than done inline. Each item should capture:
+
+- **Source** — where it came from (PR review, spec, discussion) with a link.
+- **What** — the concrete change.
+- **Why** — the motivation / risk if left undone.
+- **Status** — `open`, `in progress`, or `done`.
+
+Keep entries short. When an item is picked up, link the PR/commit and mark it done.
+
+## Index
+
+- [PR #145 — RBAC Step 1 service layer](2026-07-16-pr145-rbac-step1-review.md)

--- a/docs/superpowers/plans/2026-07-09-tag-phase2c.md
+++ b/docs/superpowers/plans/2026-07-09-tag-phase2c.md
@@ -1,0 +1,851 @@
+# tag Repository/Service Migration (RBAC Step 1, Phase 2c) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the six `tags` endpoints (`POST /tags`, `GET /tags`, `PATCH /tags/{id}`, `DELETE /tags/{id}`, `POST /tags/{id}/star`, `DELETE /tags/{id}/star`) through a `TagService`/`TagRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as the reviewed Device/Patient/FormSchema/Study/Feature slices — thin route (parse → Service → `DTOConverter` → return), Service with a constructor-injected Repository raising domain exceptions and owning the commit, framework-agnostic Repository taking a `Session`. This phase **adds nothing new** to the shared scaffolding: it reuses the existing `NotFoundError`, the injected-audit-logger convention, and the `ActingUser` value object. Its one distinguishing element is that `star`/`unstar` mutate the `CreatorTagLink` **link table** (a per-user "star"), owned by `TagRepository` the same way `FeatureRepository` owned `FeatureFeatureLink`.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model — `tag_repository.py`, `tag_service.py`.
+- **Class names:** `TagRepository` / `TagService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repository via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by the foundation's `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `Base`'s generic classmethods, or the pre-existing Device/Patient/FormSchema/Study/Feature slices.
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions reused from the `studies`/`feature` phases
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session that is only *closed*, never committed, by its context manager. Every mutating Service method calls `session.commit()` itself — the Service is the transaction boundary.
+- **Audit logging is injected, not global-reached.** The Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the mutating method. `get_tag_service()` wires the real logger via `get_db_logger()`; Service tests inject `None` or a small hand-rolled fake. Every logging call stays guarded by `if self.logger is not None:` (matching today's `if logger:` guard, since `get_db_logger()` returns `None` when DB logging is disabled).
+- **Acting user:** routes map their handler-layer `CurrentUser` onto the framework-agnostic `ActingUser(id, username)` value object (`server/services/acting_user.py`, already exists) before calling a Service.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`. The two commands that import `server.*` (router-introspection / app-boot checks) need dummy DB env vars, mirroring `server/tests/conftest.py`: prefix them with `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer`:** `NotFoundError` and the central handler (`server/services/exceptions.py`, registered in `server/main.py` via `register_exception_handlers` — the handler dispatches every `ServiceError` subclass by MRO, so this phase needs **no** `main.py` change); the `session` fixture already imported in `server/tests/conftest.py`; the `ActingUser` value object; both `repositories/` and `services/` packages with their `__init__.py` re-exports. **`tag.router` is already registered** in `server/main.py` (`app_api.include_router(tag.router)`), so no registration change is needed either. This phase introduces **no new exception type** (tag has only 404 paths — `PATCH`/`DELETE`/`star` on a missing tag; no delete-guard, so no `ConflictError`; no domain-precondition, so no `BadRequestError`).
+
+> **Existing ORM/DTO facts confirmed for this plan:**
+> - `Tag` (`orm/eyened_orm/tag.py`): `TagID` (PK), `TagName` (`String(256)`), `TagType` (`SAEnum(TagType)`), `TagDescription` (`String(256)`), `CreatorID` (**FK → `Creator.CreatorID`, not nullable, no `ondelete`**), `DateInserted` (server default). Composite-unique `(TagName, TagType)`. Six `lazy="selectin"` link collections (`CreatorTagLinks`, `StudyTagLinks`, `ImageInstanceTagLinks`, `AnnotationTagLinks`, `SegmentationTagLinks`, `FormAnnotationTagLinks`) and a `Creator` relationship (default lazy).
+> - `TagType` is an `enum.Enum` (`orm/eyened_orm/tag.py`) with members `Study`, `ImageInstance`, `Annotation`, `Segmentation`, `FormAnnotation`.
+> - `CreatorTagLink` (`orm/eyened_orm/tag.py`, table `CreatorTag`): composite PK `(TagID, CreatorID)`; both FKs `ON DELETE CASCADE`; `DateInserted` server default. This is the per-user "star". `session.get(CreatorTagLink, {"TagID": ..., "CreatorID": ...})` looks one up by composite PK.
+> - `Creator` (`orm/eyened_orm/creator.py`): to persist a `Tag` its `CreatorID` FK must reference a real row; a minimal creator is `Creator(CreatorName="...", IsHuman=True)`.
+> - DTOs (`server/dtos/dtos_aux.py`): `TagPUT(name: str, tag_type: TagType, description: str)`, `TagPATCH(name: str | None, tag_type: TagType | None, description: str | None)`, `TagGET(...)`. `DTOConverter.tag_to_get(tag)` (`server/dtos/dto_converter.py:354`) reads `tag.TagID/TagName/TagType/TagDescription/tag.Creator/tag.DateInserted` and stays at the route boundary unchanged.
+> - The in-memory SQLite test DB runs with `PRAGMA foreign_keys=ON`, so every FK (a `Tag`'s `CreatorID`, a `CreatorTagLink`'s `TagID`/`CreatorID`) must reference a real row.
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: the existing suite (foundation + Device/Patient/FormSchema/Study/Feature slices) collects and passes (baseline: **149 passed**). **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+## Task 1: TagRepository
+
+Named read/query methods for the lookups the `tags` handlers perform inline today. The one endpoint-shaped query worth extracting is `list_all` — the `GET /tags` handler builds a hand-tuned `select` that `noload`s all six `lazy="selectin"` link collections and `selectinload`s only the `Creator` (the sole relationship `TagGET` needs). The simple single-row lookups (`get_by_id`, `get_star_link`) round out the reads but are thin `session.get(...)` wrappers, so — following the `devices`/`feature` precedent — they get no dedicated Repository tests (they are exercised through the Task 2 Service tests; see the note below). No method commits; the Service owns the transaction boundary.
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/tag_repository.py`
+- Modify: `orm/eyened_orm/repositories/__init__.py` (add `TagRepository`)
+- Test: `orm/eyened_orm/tests/test_tag_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm.Tag`, `eyened_orm.Creator`, `eyened_orm.CreatorTagLink`.
+- Produces (all take `session: Session` first):
+  - `get_by_id(session, tag_id: int) -> Tag | None`
+  - `list_all(session) -> list[Tag]` — every tag, with only `TagGET`'s columns + `Creator` loaded (mirrors the route's hand-tuned query); ordering is unspecified (DB order), matching today's handler.
+  - `get_star_link(session, tag_id: int, creator_id: int) -> CreatorTagLink | None` — the `(tag, creator)` star link by composite PK.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_tag_repository.py`:
+
+```python
+from eyened_orm import Creator, Tag
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.tag_repository import TagRepository
+
+
+def _make_creator(session, name: str = "tester") -> Creator:
+    creator = Creator(CreatorName=name, IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return creator
+
+
+def _make_tag(
+    session, creator_id: int, name: str, tag_type: TagType = TagType.Study
+) -> Tag:
+    tag = Tag(
+        TagName=name, TagType=tag_type, TagDescription="", CreatorID=creator_id
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_list_all_returns_all_tags_with_creator(session):
+    """list_all returns every tag with its Creator eager-loaded (no lazy fan-out)."""
+    creator = _make_creator(session)
+    _make_tag(session, creator.CreatorID, "Beta")
+    _make_tag(session, creator.CreatorID, "Alpha", TagType.ImageInstance)
+
+    tags = TagRepository().list_all(session)
+
+    assert sorted(t.TagName for t in tags) == ["Alpha", "Beta"]
+    # Creator was selectinload-ed, so reading it needs no extra lazy query.
+    assert tags[0].Creator.CreatorName == "tester"
+```
+
+> **Note — why only `list_all` is tested here:** `get_by_id` and `get_star_link` are thin `session.get(...)` wrappers (the latter by composite PK). Their happy and not-found paths are covered by the Task 2 Service tests — `get_by_id` via the `update`/`delete`/`star` success tests and the three `*_unknown_raises_not_found` tests; `get_star_link` via `test_star_tag_creates_link`, `test_unstar_tag_removes_link`, and `test_star_tag_is_idempotent` (a broken composite-PK lookup would turn the second star into a duplicate-PK insert and fail that test). Only `list_all` — which encodes real query shape (the `load_only`/`noload`/`selectinload` optimization) — earns a dedicated Repository test, matching the `devices`/`feature` precedent.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_tag_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.tag_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `orm/eyened_orm/repositories/tag_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, load_only, noload, selectinload
+
+from eyened_orm import Creator, CreatorTagLink, Tag
+
+
+class TagRepository:
+    """Data access for Tag rows and their per-user 'star' links."""
+
+    def get_by_id(self, session: Session, tag_id: int) -> Tag | None:
+        """Return the tag with the given id, or None if absent."""
+        return session.get(Tag, tag_id)
+
+    def list_all(self, session: Session) -> list[Tag]:
+        """Return all tags, loading only what TagGET needs.
+
+        Tag has six ``lazy="selectin"`` link collections; TagGET only needs the
+        Tag columns plus its Creator (id, name). We ``noload`` those collections
+        and ``selectinload`` just the Creator so listing tags does not fan out
+        into six extra per-tag queries. (Mirrors the query previously inline in
+        the ``GET /tags`` handler.) Ordering is unspecified (DB order), as today.
+        """
+        stmt = select(Tag).options(
+            load_only(
+                Tag.TagID,
+                Tag.TagName,
+                Tag.TagType,
+                Tag.TagDescription,
+                Tag.CreatorID,
+                Tag.DateInserted,
+            ),
+            noload(Tag.CreatorTagLinks),
+            noload(Tag.StudyTagLinks),
+            noload(Tag.ImageInstanceTagLinks),
+            noload(Tag.AnnotationTagLinks),
+            noload(Tag.SegmentationTagLinks),
+            noload(Tag.FormAnnotationTagLinks),
+            selectinload(Tag.Creator).load_only(
+                Creator.CreatorID, Creator.CreatorName
+            ),
+        )
+        return list(session.scalars(stmt).all())
+
+    def get_star_link(
+        self, session: Session, tag_id: int, creator_id: int
+    ) -> CreatorTagLink | None:
+        """Return the star link for (tag, creator), or None if not starred."""
+        return session.get(
+            CreatorTagLink, {"TagID": tag_id, "CreatorID": creator_id}
+        )
+```
+
+Update `orm/eyened_orm/repositories/__init__.py`:
+
+```python
+from .device_repository import DeviceRepository
+from .feature_repository import FeatureRepository
+from .form_schema_repository import FormSchemaRepository
+from .patient_repository import PatientRepository
+from .study_repository import StudyRepository
+from .tag_repository import TagRepository
+
+__all__ = [
+    "DeviceRepository",
+    "PatientRepository",
+    "FormSchemaRepository",
+    "StudyRepository",
+    "FeatureRepository",
+    "TagRepository",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_tag_repository.py -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/tag_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_tag_repository.py
+git commit -m "feat(repositories): add TagRepository"
+```
+
+---
+
+## Task 2: TagService
+
+Holds the business rules the `tags` handlers encode today (create; list; update name/description/type; delete; idempotent star/unstar of the `CreatorTagLink` link table), owns the commit, and emits audit logging via an injected logger. Only the missing-tag paths raise (`NotFoundError` → 404): `PATCH`, `DELETE`, and `star` on an unknown tag. `unstar` matches today's handler — it never checks tag existence and is a silent no-op when the link is absent.
+
+**Files:**
+- Create: `server/services/tag_service.py`
+- Modify: `server/services/__init__.py` (re-export `TagService`)
+- Test: `server/tests/test_tag_service.py`
+
+**Interfaces:**
+- Consumes: `TagRepository` (Task 1); `NotFoundError` (existing); `ActingUser`; `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.Tag`, `eyened_orm.CreatorTagLink`, `eyened_orm.tag.TagType`.
+- Produces:
+  - `TagService(repository: TagRepository, logger: DatabaseModificationLogger | None = None)`.
+  - `list_tags(session) -> list[Tag]`.
+  - `create_tag(session, name: str, description: str, tag_type: TagType, actor: ActingUser) -> Tag`.
+  - `update_tag(session, tag_id: int, name: str | None, description: str | None, tag_type: TagType | None, actor: ActingUser) -> Tag` — 404 if absent; each field optional.
+  - `delete_tag(session, tag_id: int, actor: ActingUser) -> None` — 404 if absent.
+  - `star_tag(session, tag_id: int, actor: ActingUser) -> None` — 404 if absent; idempotent insert.
+  - `unstar_tag(session, tag_id: int, actor: ActingUser) -> None` — idempotent delete; no 404.
+  - `get_tag_service() -> TagService` — default-wiring factory (`TagRepository()` + `get_db_logger()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_tag_service.py`:
+
+```python
+import pytest
+
+from eyened_orm import Creator, Tag
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import NotFoundError
+from server.services.tag_service import TagService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _actor(session) -> ActingUser:
+    """An ActingUser backed by a real Creator row (Tag.CreatorID is a FK)."""
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _make_tag(
+    session, creator_id: int, name: str = "T1", tag_type: TagType = TagType.Study
+) -> Tag:
+    tag = Tag(
+        TagName=name, TagType=tag_type, TagDescription="", CreatorID=creator_id
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def _service(logger=None) -> TagService:
+    return TagService(TagRepository(), logger=logger)
+
+
+def test_create_tag_persists_and_returns(session):
+    """Creating a tag stores it with the acting user as owner."""
+    actor = _actor(session)
+
+    tag = _service().create_tag(session, "New", "desc", TagType.Study, actor)
+
+    assert tag.TagName == "New"
+    assert tag.TagType == TagType.Study
+    assert tag.TagDescription == "desc"
+    assert tag.CreatorID == actor.id
+
+
+def test_create_tag_logs_insert(session):
+    """Creating a tag emits one insert audit record naming the entity and user."""
+    actor = _actor(session)
+    logger = FakeAuditLogger()
+
+    _service(logger).create_tag(session, "New", "desc", TagType.Study, actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "Tag"
+    assert logger.inserts[0]["user"] == actor.username
+
+
+def test_update_tag_changes_fields(session):
+    """update_tag overwrites the provided fields in place."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id, "Old")
+
+    updated = _service().update_tag(
+        session, tag.TagID, "New", "newdesc", None, actor
+    )
+
+    assert updated.TagName == "New"
+    assert updated.TagDescription == "newdesc"
+
+
+def test_update_tag_unknown_raises_not_found(session):
+    """Updating a missing tag is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().update_tag(session, 999_999, "x", None, None, actor)
+
+
+def test_update_tag_logs_update(session):
+    """Updating a tag emits one update audit record."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id, "Old")
+    logger = FakeAuditLogger()
+
+    _service(logger).update_tag(session, tag.TagID, "New", None, None, actor)
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "Tag"
+
+
+def test_delete_tag_removes_it(session):
+    """Deleting a tag removes it from the database."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+
+    _service().delete_tag(session, tag.TagID, actor)
+
+    assert TagRepository().get_by_id(session, tag.TagID) is None
+
+
+def test_delete_tag_unknown_raises_not_found(session):
+    """Deleting a missing tag is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().delete_tag(session, 999_999, actor)
+
+
+def test_delete_tag_logs_delete(session):
+    """Deleting a tag emits one delete audit record."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_tag(session, tag.TagID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "Tag"
+
+
+def test_star_tag_creates_link(session):
+    """Starring a tag creates the CreatorTagLink for the acting user."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+
+    _service().star_tag(session, tag.TagID, actor)
+
+    assert (
+        TagRepository().get_star_link(session, tag.TagID, actor.id) is not None
+    )
+
+
+def test_star_tag_is_idempotent(session):
+    """Starring an already-starred tag adds no second link and logs nothing new."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+    service = _service(logger)
+    service.star_tag(session, tag.TagID, actor)
+
+    service.star_tag(session, tag.TagID, actor)
+
+    assert len(logger.inserts) == 1  # only the first star logged
+
+
+def test_star_tag_unknown_raises_not_found(session):
+    """Starring a missing tag is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().star_tag(session, 999_999, actor)
+
+
+def test_star_tag_logs_insert(session):
+    """Starring a tag emits one insert audit record for the link entity."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+
+    _service(logger).star_tag(session, tag.TagID, actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "CreatorTagLink"
+
+
+def test_unstar_tag_removes_link(session):
+    """Unstarring removes the acting user's CreatorTagLink."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    _service().star_tag(session, tag.TagID, actor)
+
+    _service().unstar_tag(session, tag.TagID, actor)
+
+    assert TagRepository().get_star_link(session, tag.TagID, actor.id) is None
+
+
+def test_unstar_tag_absent_is_noop(session):
+    """Unstarring a tag that was never starred is a no-op (no error, no log)."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    logger = FakeAuditLogger()
+
+    _service(logger).unstar_tag(session, tag.TagID, actor)
+
+    assert len(logger.deletes) == 0
+
+
+def test_unstar_tag_logs_delete(session):
+    """Unstarring a starred tag emits one delete audit record for the link entity."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    _service().star_tag(session, tag.TagID, actor)
+    logger = FakeAuditLogger()
+
+    _service(logger).unstar_tag(session, tag.TagID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "CreatorTagLink"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_tag_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.tag_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/tag_service.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import CreatorTagLink, Tag
+from eyened_orm.tag import TagType
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import NotFoundError
+
+
+class TagService:
+    """Business logic for tags and per-user tag stars."""
+
+    def __init__(
+        self,
+        repository: TagRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.logger = logger
+
+    def list_tags(self, session: Session) -> list[Tag]:
+        """Return all tags (Creator eager-loaded for TagGET)."""
+        return self.repository.list_all(session)
+
+    def create_tag(
+        self,
+        session: Session,
+        name: str,
+        description: str,
+        tag_type: TagType,
+        actor: ActingUser,
+    ) -> Tag:
+        """Create a tag owned by the acting user."""
+        tag = Tag(
+            TagName=name,
+            TagDescription=description,
+            TagType=tag_type,
+            CreatorID=actor.id,
+        )
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/tags",
+                entity="Tag",
+                entity_id=tag.TagID,
+                fields={
+                    "name": tag.TagName,
+                    "description": tag.TagDescription,
+                    "tag_type": str(tag.TagType),
+                },
+            )
+        return tag
+
+    def update_tag(
+        self,
+        session: Session,
+        tag_id: int,
+        name: str | None,
+        description: str | None,
+        tag_type: TagType | None,
+        actor: ActingUser,
+    ) -> Tag:
+        """Update a tag's name/description/type (each optional).
+
+        Raises:
+            NotFoundError: If the tag does not exist.
+        """
+        tag = self.repository.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+
+        changes: dict[str, str] = {}
+        if name is not None:
+            changes["name"] = f"{tag.TagName} -> {name}"
+            tag.TagName = name
+        if description is not None:
+            changes["description"] = f"{tag.TagDescription} -> {description}"
+            tag.TagDescription = description
+        if tag_type is not None:
+            changes["tag_type"] = f"{tag.TagType} -> {tag_type}"
+            tag.TagType = tag_type
+
+        session.commit()
+        session.refresh(tag)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/tags/{tag_id}",
+                entity="Tag",
+                entity_id=tag.TagID,
+                changes=changes if changes else None,
+            )
+        return tag
+
+    def delete_tag(
+        self, session: Session, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a tag.
+
+        Raises:
+            NotFoundError: If the tag does not exist.
+        """
+        tag = self.repository.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+
+        deleted_data = {
+            "name": tag.TagName,
+            "description": tag.TagDescription,
+            "tag_type": str(tag.TagType),
+        }
+        session.delete(tag)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/tags/{tag_id}",
+                entity="Tag",
+                entity_id=tag_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+    def star_tag(
+        self, session: Session, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Star a tag for the acting user (idempotent).
+
+        Raises:
+            NotFoundError: If the tag does not exist.
+        """
+        tag = self.repository.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError(f"Tag {tag_id} not found")
+
+        if self.repository.get_star_link(session, tag_id, actor.id) is None:
+            session.add(CreatorTagLink(TagID=tag_id, CreatorID=actor.id))
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/tags/{tag_id}/star",
+                    entity="CreatorTagLink",
+                    fields={"tag_id": tag_id, "creator_id": actor.id},
+                )
+        return None
+
+    def unstar_tag(
+        self, session: Session, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Remove the acting user's star from a tag (idempotent; no error if absent)."""
+        link = self.repository.get_star_link(session, tag_id, actor.id)
+        if link is not None:
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"DELETE /api/tags/{tag_id}/star",
+                    entity="CreatorTagLink",
+                    fields={"tag_id": tag_id, "creator_id": actor.id},
+                )
+        return None
+
+
+def get_tag_service() -> TagService:
+    """Default TagService wiring for FastAPI ``Depends()``."""
+    return TagService(TagRepository(), logger=get_db_logger())
+```
+
+Update `server/services/__init__.py`:
+
+```python
+from .acting_user import ActingUser
+from .device_service import DeviceService
+from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
+from .feature_service import FeatureService
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+from .study_service import StudyService
+from .tag_service import TagService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "ConflictError",
+    "ActingUser",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+    "StudyService",
+    "FeatureService",
+    "TagService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_tag_service.py -v`
+Expected: PASS (15 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/tag_service.py server/services/__init__.py server/tests/test_tag_service.py
+git commit -m "feat(services): add TagService with injected audit logging and idempotent star/unstar"
+```
+
+---
+
+## Task 3: Rewire `routes/tag.py` to use TagService
+
+**Files:**
+- Modify: `server/routes/tag.py`
+
+**Interfaces:**
+- Consumes: `TagService` + `get_tag_service` (Task 2); `ActingUser`; existing `DTOConverter.tag_to_get`, `TagGET`/`TagPUT`/`TagPATCH`, `get_db`, `get_current_user`. All inline `db.get(...)`/`select(...)` queries, `raise HTTPException(...)`, `db.commit()`/`db.refresh()`, and `get_db_logger()` calls are removed — they now live in the Repository/Service.
+- Produces: unchanged HTTP contract — `POST /tags` → `TagGET`; `GET /tags` → `list[TagGET]`; `PATCH /tags/{id}` → `TagGET`; `DELETE /tags/{id}` → 204; `POST /tags/{id}/star` → 204; `DELETE /tags/{id}/star` → 204. Same 404 for an unknown tag on `PATCH`/`DELETE`/`star` (now flowing through the central handler).
+
+- [ ] **Step 1: Replace the module contents with thin Service-backed handlers**
+
+Replace the entire contents of `server/routes/tag.py` with:
+
+```python
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_aux import TagGET, TagPATCH, TagPUT
+from ..services.acting_user import ActingUser
+from ..services.tag_service import TagService, get_tag_service
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/tags", response_model=TagGET)
+async def create_tag(
+    dto: TagPUT,
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Create a tag owned by the current user."""
+    tag = service.create_tag(
+        db,
+        dto.name,
+        dto.description,
+        dto.tag_type,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.tag_to_get(tag)
+
+
+@router.get("/tags", response_model=list[TagGET])
+async def list_tags(
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Return all tags."""
+    return [DTOConverter.tag_to_get(t) for t in service.list_tags(db)]
+
+
+@router.patch("/tags/{tag_id}", response_model=TagGET)
+async def patch_tag(
+    tag_id: int,
+    dto: TagPATCH,
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Update a tag's name, description, and/or type."""
+    tag = service.update_tag(
+        db,
+        tag_id,
+        dto.name,
+        dto.description,
+        dto.tag_type,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.tag_to_get(tag)
+
+
+@router.delete("/tags/{tag_id}", status_code=204)
+async def delete_tag(
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Delete a tag."""
+    service.delete_tag(
+        db,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.post("/tags/{tag_id}/star", status_code=204)
+async def star_tag(
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Star a tag for the current user (idempotent)."""
+    service.star_tag(
+        db,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.delete("/tags/{tag_id}/star", status_code=204)
+async def unstar_tag(
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: TagService = Depends(get_tag_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Remove the current user's star from a tag (idempotent)."""
+    service.unstar_tag(
+        db,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+```
+
+- [ ] **Step 2: Verify the router imports and exposes all six routes**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "from server.routes import tag; print(sorted((r.path, tuple(sorted(r.methods))) for r in tag.router.routes))"`
+Expected: prints the routes — `/tags` (GET and POST), `/tags/{tag_id}` (PATCH, DELETE), `/tags/{tag_id}/star` (POST, DELETE) — with no traceback.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: all tests pass (prior 149 + the new Task 1–2 tests: 1 Repository + 15 Service = **165 passed**); no import/collection errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/tag.py
+git commit -m "refactor(routes): route tag endpoints through TagService"
+```
+
+---
+
+## Verification (end-to-end, on `feature/rbac-step1-service-layer`)
+
+1. **Full suite green:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q` — prior suite plus the new TagRepository/TagService tests pass (165 passed).
+2. **All six routes exposed:** the Task 3 Step 2 command prints GET/POST `/tags`, PATCH/DELETE `/tags/{tag_id}`, and POST/DELETE `/tags/{tag_id}/star`.
+3. **App boots:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "import server.main; print('ok')"` → `ok`.
+4. **Manual smoke (optional, real dev DB + server):**
+   - `POST /api/tags` with `{"name": "X", "tag_type": "Study", "description": "d"}` → 200 `TagGET`; `PATCH` its name → 200; `DELETE` it → 204.
+   - `PATCH`/`DELETE`/`POST .../star` on `/api/tags/999999` → HTTP 404 `{"detail": "Tag 999999 not found"}` (proves the `NotFoundError` → central-handler path is live).
+   - `POST /api/tags/{id}/star` twice → both 204, exactly one `CreatorTag` row; `DELETE /api/tags/{id}/star` → 204; `DELETE` again → 204 (idempotent no-op).
+5. **Branch isolation:** `git log development..HEAD` shows only the RBAC-step1 commits; `development` has not moved.
+
+## Out of scope / follow-up
+
+- Phase 3 (`subtask`, `task`), Phase 4 (`import_api`, `instances`, `form_annotations`, `segmentations`) — each its own plan/PR on this branch, same pattern.
+- Transaction-ownership review across all Services (spec "Follow-up work") once every phase has migrated.
+- RBAC enforcement itself is **Step 2** (`PermissionDeniedError` + per-method authz checks that read `ActingUser`).

--- a/docs/superpowers/plans/2026-07-09-task-phase3a.md
+++ b/docs/superpowers/plans/2026-07-09-task-phase3a.md
@@ -1,0 +1,1483 @@
+# task Repository/Service Migration (RBAC Step 1, Phase 3a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the `task.py` endpoints — task CRUD (`POST/GET/GET{id}/PATCH{id}/DELETE{id} /task`) plus the task-rooted subtask reads (`GET /task/{id}/subtasks`, `GET /task/{id}/subtask/{index}`) — through a `TaskService` backed by a `TaskRepository` + `SubTaskRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as the reviewed Device/Patient/FormSchema/Study/Feature/Tag slices — thin route (parse → Service → `DTOConverter` → return), a Service with constructor-injected Repositories that raises domain exceptions and owns the commit, and framework-agnostic Repositories that take a `Session`. This phase splits the spec's "Phase 3" (which groups `task.py` + `subtask.py`) into **3a (`task.py`, this plan)** and **3b (`subtask.py`, a later plan)**, mirroring how Phase 2 was executed as 2a/2b/2c for reviewability. To keep a class from being split across two PRs, the **task-rooted subtask reads live in `TaskService`** (they hang off a `task_id` and are served by `task.py`); **`SubTaskService`** — the by-id subtask CRUD and image-link mutations under `/subtasks/...` — is introduced wholly in **3b**.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model module — `task_repository.py`, `task_service.py`. Per the spec's directory table, `task_repository.py` holds `TaskRepository`, `SubTaskRepository` (and `TaskDefinitionRepository` *if needed* — it is **not** needed here: no endpoint does TaskDefinition CRUD, so YAGNI); `task_service.py` holds `TaskService` (and `SubTaskService`, added in 3b).
+- **Class names:** `TaskRepository` / `SubTaskRepository` / `TaskService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repositories via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by the foundation's `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `Base`'s generic classmethods, `subtask.py` (that is 3b), or the pre-existing Device/Patient/FormSchema/Study/Feature/Tag slices.
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions reused from the `studies`/`feature`/`tag` phases
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session that is only *closed*, never committed, by its context manager. Every mutating Service method calls `session.commit()` itself — the Service is the transaction boundary.
+- **Audit logging is injected, not global-reached.** The Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the mutating method. `get_task_service()` wires the real logger via `get_db_logger()`; Service tests inject `None` or a small hand-rolled fake. Every logging call stays guarded by `if self.logger is not None:` (matching today's `if logger:` guard, since `get_db_logger()` returns `None` when DB logging is disabled).
+- **Acting user:** routes map their handler-layer `CurrentUser` onto the framework-agnostic `ActingUser(id, username)` value object (`server/services/acting_user.py`, already exists) before calling a Service.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`. The two commands that import `server.*` (router-introspection / app-boot checks) need dummy DB env vars, mirroring `server/tests/conftest.py`: prefix them with `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer`:** `NotFoundError` and the central handler (`server/services/exceptions.py`, registered in `server/main.py` via `register_exception_handlers` — the handler dispatches every `ServiceError` subclass by MRO, so this phase needs **no** `main.py` change); the `session` fixture already imported in `server/tests/conftest.py`; the `ActingUser` value object; both `repositories/` and `services/` packages with their `__init__.py` re-exports. **`task.router` is already registered** in `server/main.py` (`app_api.include_router(task.router)`), so no registration change is needed either. This phase introduces **no new exception type**: every `task.py` failure path today is a 404 (`GET`/`PATCH`/`DELETE` on a missing task; `GET /task/{id}/subtask/{index}` out of range), all served by the existing `NotFoundError`.
+
+> **Existing ORM facts confirmed for this plan** (verified against the in-memory SQLite test DB, `PRAGMA foreign_keys=ON`):
+> - `Task` (`orm/eyened_orm/task.py`): `TaskID` (PK); `TaskName` (`String(256)`, NOT NULL); `Description` (`Text`, nullable); `CreatorID` (**nullable FK → `Creator.CreatorID`**); `ContactID` (**nullable FK → `Contact.ContactID`**); `TaskDefinitionID` (**NOT NULL FK → `TaskDefinition.TaskDefinitionID`**); `TaskState` (`Mapped["TaskState"]`, **NOT NULL, no column/server default**); `DateInserted` (server default). Relationships `Creator`, `TaskDefinition`, `Contact`, and `SubTasks` (`passive_deletes=True`).
+> - **`TaskState` is NOT NULL with no default.** Today's `POST /task` handler does *not* set it, relying on MySQL's implicit enum default (the first member, `NotStarted`). SQLite rejects that insert. `create_from_imagesets` (`task.py`) sets `TaskState=TaskState.NotStarted` explicitly. So `TaskService.create_task` **sets `TaskState.NotStarted` explicitly** — behavior-preserving (same value MySQL implicitly picks) and portable to SQLite. `TaskState` enum members: `NotStarted`, `Busy`, `Finished`, `Aborted`, `Archived`.
+> - `SubTask` (`orm/eyened_orm/task.py`): `SubTaskID` (PK); `TaskID` (**NOT NULL FK → `Task.TaskID`, `ondelete="CASCADE"`**); `CreatorID` (nullable FK); `Comments` (`Text`, nullable); `TaskState` (`Mapped["SubTaskState"]`, **column default `SubTaskState.NotStarted`** — a minimal `SubTask(TaskID=...)` inserts fine). `SubTaskState` members: `NotStarted`, `Busy`, `Ready`. `SubTaskImageLinks` relationship ordered by `ImageIndex`.
+> - **`session.delete(task)` cascades** to the task's `SubTask` rows via the DB-level `ON DELETE CASCADE` + `passive_deletes=True` (verified: task gone, subtasks gone, no FK error). So `delete_task` uses ORM `session.delete`, not a Core `delete()` statement.
+> - The `with_images` eager-load chain `selectinload(SubTask.SubTaskImageLinks).selectinload(SubTaskImageLink.ImageInstance).selectinload(ImageInstance.ImageStorages).selectinload(ImageStorage.StorageBackend)` is valid and populates links. A real `ImageInstance` row requires a `Series`→`Study`→`Patient`→`Project` chain **and** a `DeviceInstance`→`DeviceModel`; the Task 2 test helper builds exactly that minimal graph. (DTO conversion of images — `image_instance_to_get` — stays at the route boundary and is covered by route-level smoke tests, not here.)
+
+> **DTO facts confirmed:** `DTOConverter.task_to_get(task, *, num_tasks, num_tasks_ready)` (`dto_converter.py:619`) reads `TaskID/TaskName/Description/ContactID/TaskDefinitionID/DateInserted/Creator/TaskState/TaskDefinition`; `subtask_to_get` / `subtask_with_images_to_get` (`dto_converter.py:654`/`:665`) build `SubTaskGET`/`SubTaskWithImagesGET`. `TaskPUT(name, description, contact_id, task_definition_id)`, `TaskPATCH(name?, description?, contact_id?, task_definition_id?, task_state?: TaskState)`, and the `SubTasksResponse`/`SubTasksWithImagesResponse` envelopes all live in `server/dtos/dtos_tasks.py`. All DTO calls stay in the route.
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: the existing suite (foundation + Device/Patient/FormSchema/Study/Feature/Tag slices) collects and passes (baseline: **165 passed**). **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+## Task 1: TaskRepository
+
+Named read/query methods for the task lookups the `task.py` handlers perform inline today. Extracts the `_task_query_options()` eager-load (`Creator` + `TaskDefinition`, avoiding a fan-out over every `SubTask`) into `get_with_relations`/`list_all`, and the `_subtask_counts_by_task_id` aggregate into `subtask_counts`. `get_by_id` is a thin `session.get(...)` wrapper (existence lookup for update/delete/subtask-route checks), so — following the `devices`/`feature`/`tag` precedent — it gets no dedicated Repository test (it is exercised through the Task 3/4 Service tests). No method commits; the Service owns the transaction boundary.
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/task_repository.py`
+- Modify: `orm/eyened_orm/repositories/__init__.py` (add `TaskRepository`)
+- Test: `orm/eyened_orm/tests/test_task_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm.Task`, `eyened_orm.SubTask`, `eyened_orm.task.SubTaskState`.
+- Produces (all take `session: Session` first):
+  - `get_by_id(session, task_id: int) -> Task | None`
+  - `get_with_relations(session, task_id: int) -> Task | None` — one task with `Creator` + `TaskDefinition` eager-loaded, or `None`.
+  - `list_all(session) -> list[Task]` — every task ordered by `TaskID`, with `Creator` + `TaskDefinition` eager-loaded.
+  - `subtask_counts(session, task_ids: list[int]) -> dict[int, tuple[int, int]]` — `{task_id: (num_subtasks, num_ready)}`, filling `(0, 0)` for every requested id with no subtasks; `{}` for an empty `task_ids`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_task_repository.py`:
+
+```python
+from eyened_orm import Creator, SubTask, Task, TaskDefinition
+from eyened_orm.task import SubTaskState, TaskState
+from eyened_orm.repositories.task_repository import TaskRepository
+
+
+def _creator(session, name: str = "tester") -> Creator:
+    creator = Creator(CreatorName=name, IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return creator
+
+
+def _task_def(session, name: str = "td") -> TaskDefinition:
+    td = TaskDefinition(TaskDefinitionName=name)
+    session.add(td)
+    session.flush()
+    return td
+
+
+def _make_task(session, td_id: int, creator_id: int, name: str = "T") -> Task:
+    task = Task(
+        TaskName=name,
+        TaskDefinitionID=td_id,
+        CreatorID=creator_id,
+        TaskState=TaskState.NotStarted,
+    )
+    session.add(task)
+    session.flush()
+    return task
+
+
+def _make_subtask(session, task_id: int, state: SubTaskState) -> SubTask:
+    st = SubTask(TaskID=task_id, TaskState=state)
+    session.add(st)
+    session.flush()
+    return st
+
+
+def test_list_all_orders_by_id_with_relations(session):
+    """list_all returns every task in TaskID order, Creator/TaskDefinition eager."""
+    creator = _creator(session)
+    td = _task_def(session)
+    _make_task(session, td.TaskDefinitionID, creator.CreatorID, "A")
+    _make_task(session, td.TaskDefinitionID, creator.CreatorID, "B")
+
+    tasks = TaskRepository().list_all(session)
+
+    assert [t.TaskName for t in tasks] == ["A", "B"]
+    # Eager-loaded: reading these needs no extra lazy query.
+    assert tasks[0].Creator.CreatorName == "tester"
+    assert tasks[0].TaskDefinition.TaskDefinitionName == "td"
+
+
+def test_get_with_relations_eager_loads_creator_and_definition(session):
+    """get_with_relations returns the task with Creator + TaskDefinition loaded."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+
+    loaded = TaskRepository().get_with_relations(session, task.TaskID)
+
+    assert loaded is not None
+    assert loaded.Creator.CreatorName == "tester"
+    assert loaded.TaskDefinition.TaskDefinitionName == "td"
+
+
+def test_subtask_counts_totals_and_ready(session):
+    """subtask_counts returns (total, ready) per task id."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+
+    counts = TaskRepository().subtask_counts(session, [task.TaskID])
+
+    assert counts[task.TaskID] == (3, 2)
+
+
+def test_subtask_counts_fills_zero_for_task_without_subtasks(session):
+    """A requested task id with no subtasks maps to (0, 0), not a missing key."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+
+    counts = TaskRepository().subtask_counts(session, [task.TaskID])
+
+    assert counts == {task.TaskID: (0, 0)}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_task_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.task_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `orm/eyened_orm/repositories/task_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import (
+    ImageInstance,
+    ImageStorage,
+    SubTask,
+    SubTaskImageLink,
+    Task,
+)
+from eyened_orm.task import SubTaskState
+
+# Load task metadata without eager-loading every SubTask row (mirrors the
+# route's former ``_task_query_options``).
+_TASK_RELATIONS = (
+    selectinload(Task.Creator),
+    selectinload(Task.TaskDefinition),
+)
+
+
+class TaskRepository:
+    """Data access for Task rows and their subtask counts."""
+
+    def get_by_id(self, session: Session, task_id: int) -> Task | None:
+        """Return the task with the given id, or None if absent."""
+        return session.get(Task, task_id)
+
+    def get_with_relations(self, session: Session, task_id: int) -> Task | None:
+        """Return the task with Creator + TaskDefinition eager-loaded, or None."""
+        return (
+            session.execute(
+                select(Task).options(*_TASK_RELATIONS).where(Task.TaskID == task_id)
+            )
+            .scalars()
+            .first()
+        )
+
+    def list_all(self, session: Session) -> list[Task]:
+        """Return all tasks (TaskID order) with Creator + TaskDefinition loaded."""
+        return list(
+            session.execute(
+                select(Task).options(*_TASK_RELATIONS).order_by(Task.TaskID)
+            )
+            .scalars()
+            .all()
+        )
+
+    def subtask_counts(
+        self, session: Session, task_ids: list[int]
+    ) -> dict[int, tuple[int, int]]:
+        """Return {task_id: (num_subtasks, num_ready)} for the given task ids.
+
+        One grouped aggregate over ``SubTask`` (mirrors the route's former
+        ``_subtask_counts_by_task_id``). Every requested id is present in the
+        result: ids with no subtasks map to ``(0, 0)``.
+        """
+        if not task_ids:
+            return {}
+        rows = session.execute(
+            select(
+                SubTask.TaskID,
+                func.count().label("num"),
+                func.coalesce(
+                    func.sum(
+                        case((SubTask.TaskState == SubTaskState.Ready, 1), else_=0)
+                    ),
+                    0,
+                ).label("ready"),
+            )
+            .where(SubTask.TaskID.in_(task_ids))
+            .group_by(SubTask.TaskID)
+        ).all()
+        counts = {int(tid): (int(n), int(r)) for tid, n, r in rows}
+        return {tid: counts.get(tid, (0, 0)) for tid in task_ids}
+```
+
+Update `orm/eyened_orm/repositories/__init__.py` (add the new import + `__all__` entry, keeping all existing exports):
+
+```python
+from .device_repository import DeviceRepository
+from .feature_repository import FeatureRepository
+from .form_schema_repository import FormSchemaRepository
+from .patient_repository import PatientRepository
+from .study_repository import StudyRepository
+from .tag_repository import TagRepository
+from .task_repository import TaskRepository
+
+__all__ = [
+    "DeviceRepository",
+    "PatientRepository",
+    "FormSchemaRepository",
+    "StudyRepository",
+    "FeatureRepository",
+    "TagRepository",
+    "TaskRepository",
+]
+```
+
+> **Note:** the `ImageInstance`, `ImageStorage`, `SubTaskImageLink` imports are unused by `TaskRepository` but are consumed by `SubTaskRepository`, added to this same module in Task 2. Leaving them in now keeps Task 2 to a pure append; if a linter flags them between tasks, that resolves the moment Task 2 lands. (If you prefer zero interim warnings, add them in Task 2 instead — either is fine.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_task_repository.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/task_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_task_repository.py
+git commit -m "feat(repositories): add TaskRepository"
+```
+
+---
+
+## Task 2: SubTaskRepository
+
+The subtask read/query methods `task.py` needs for its two task-rooted subtask endpoints: the ordered id list backing the "absolute index" (`GET /task/{id}/subtasks`), the paginated/filtered/optionally-image-loaded row fetch (shared by both endpoints), and the matching count. Lives in `task_repository.py` alongside `TaskRepository` (per the spec's directory table). The by-id and image-link mutation methods are **3b** (`subtask.py`), not here.
+
+**Files:**
+- Modify: `orm/eyened_orm/repositories/task_repository.py` (add `SubTaskRepository`)
+- Modify: `orm/eyened_orm/repositories/__init__.py` (add `SubTaskRepository`)
+- Modify: `orm/eyened_orm/tests/test_task_repository.py` (append `SubTaskRepository` tests + the image-graph helper)
+
+**Interfaces:**
+- Consumes: `eyened_orm.SubTask`, `eyened_orm.SubTaskImageLink`, `eyened_orm.ImageInstance`, `eyened_orm.ImageStorage`, `eyened_orm.task.SubTaskState`.
+- Produces (all take `session: Session` first):
+  - `all_ids_for_task(session, task_id: int) -> list[int]` — every `SubTaskID` for the task, ordered by `SubTaskID`.
+  - `count_for_task(session, task_id: int, *, status: SubTaskState | None = None) -> int` — subtask count, optionally filtered by state.
+  - `list_for_task(session, task_id: int, *, status: SubTaskState | None = None, limit: int, offset: int, with_images: bool = False) -> list[SubTask]` — subtasks for the task ordered by `SubTaskID`, optional state filter, `limit`/`offset` window, optional image eager-load chain.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `orm/eyened_orm/tests/test_task_repository.py` (add the import to the existing top-of-file import line, then the helper and tests):
+
+```python
+# add to the existing imports at the top of the file:
+from eyened_orm.repositories.task_repository import SubTaskRepository
+```
+
+```python
+def _make_image(session, public_id: str) -> "int":
+    """Build the minimal Series/Device graph an ImageInstance FK-requires.
+
+    Returns the new ImageInstanceID. Mirrors the smallest row set that
+    satisfies ImageInstance's NOT NULL FKs under PRAGMA foreign_keys=ON.
+    """
+    import datetime
+
+    from eyened_orm import (
+        DeviceInstance,
+        DeviceModel,
+        ImageInstance,
+        Patient,
+        Project,
+        Series,
+        Study,
+    )
+    from eyened_orm.project import ExternalEnum
+
+    project = Project(ProjectName="P", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier="ID1", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier="ds",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_all_ids_for_task_ordered(session):
+    """all_ids_for_task returns the task's SubTaskIDs ascending."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    a = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    b = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+
+    ids = SubTaskRepository().all_ids_for_task(session, task.TaskID)
+
+    assert ids == [a.SubTaskID, b.SubTaskID]
+
+
+def test_count_for_task_with_and_without_status(session):
+    """count_for_task counts all subtasks, or only those in the given state."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+    _make_subtask(session, task.TaskID, SubTaskState.Ready)
+    repo = SubTaskRepository()
+
+    assert repo.count_for_task(session, task.TaskID) == 3
+    assert repo.count_for_task(session, task.TaskID, status=SubTaskState.Ready) == 2
+
+
+def test_list_for_task_paginates_in_id_order(session):
+    """list_for_task returns a limit/offset window ordered by SubTaskID."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    made = [
+        _make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(5)
+    ]
+
+    rows = SubTaskRepository().list_for_task(
+        session, task.TaskID, limit=2, offset=1
+    )
+
+    assert [r.SubTaskID for r in rows] == [made[1].SubTaskID, made[2].SubTaskID]
+
+
+def test_list_for_task_filters_by_status(session):
+    """list_for_task with a status returns only subtasks in that state."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    ready = _make_subtask(session, task.TaskID, SubTaskState.Ready)
+
+    rows = SubTaskRepository().list_for_task(
+        session, task.TaskID, status=SubTaskState.Ready, limit=10, offset=0
+    )
+
+    assert [r.SubTaskID for r in rows] == [ready.SubTaskID]
+
+
+def test_list_for_task_with_images_loads_links(session):
+    """with_images eager-loads the SubTaskImageLinks -> ImageInstance chain."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    st = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    image_id = _make_image(session, "pub-1")
+    from eyened_orm import SubTaskImageLink
+
+    session.add(
+        SubTaskImageLink(
+            SubTaskID=st.SubTaskID, ImageInstanceID=image_id, ImageIndex=0
+        )
+    )
+    session.flush()
+
+    rows = SubTaskRepository().list_for_task(
+        session, task.TaskID, limit=10, offset=0, with_images=True
+    )
+
+    assert len(rows) == 1
+    assert [link.ImageInstance.PublicID for link in rows[0].SubTaskImageLinks] == [
+        "pub-1"
+    ]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_task_repository.py -v`
+Expected: FAIL — `ImportError: cannot import name 'SubTaskRepository' from 'eyened_orm.repositories.task_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Append to `orm/eyened_orm/repositories/task_repository.py` (module-level loader constant + class):
+
+```python
+# Eager-load the subtask's images down to their storage backend (mirrors the
+# route's former with_images option chain).
+_SUBTASK_IMAGE_LOADER = (
+    selectinload(SubTask.SubTaskImageLinks)
+    .selectinload(SubTaskImageLink.ImageInstance)
+    .selectinload(ImageInstance.ImageStorages)
+    .selectinload(ImageStorage.StorageBackend)
+)
+
+
+class SubTaskRepository:
+    """Data access for a task's SubTask rows (reads used by task.py)."""
+
+    def all_ids_for_task(self, session: Session, task_id: int) -> list[int]:
+        """Return the task's SubTaskIDs ordered ascending (backs absolute index)."""
+        return list(
+            session.execute(
+                select(SubTask.SubTaskID)
+                .where(SubTask.TaskID == task_id)
+                .order_by(SubTask.SubTaskID)
+            )
+            .scalars()
+            .all()
+        )
+
+    def count_for_task(
+        self,
+        session: Session,
+        task_id: int,
+        *,
+        status: SubTaskState | None = None,
+    ) -> int:
+        """Return the task's subtask count, optionally filtered by state."""
+        stmt = select(func.count()).select_from(SubTask).where(
+            SubTask.TaskID == task_id
+        )
+        if status is not None:
+            stmt = stmt.where(SubTask.TaskState == status)
+        return session.scalar(stmt) or 0
+
+    def list_for_task(
+        self,
+        session: Session,
+        task_id: int,
+        *,
+        status: SubTaskState | None = None,
+        limit: int,
+        offset: int,
+        with_images: bool = False,
+    ) -> list[SubTask]:
+        """Return a limit/offset window of the task's subtasks (SubTaskID order).
+
+        Optionally filters by ``status`` and eager-loads each subtask's images.
+        """
+        stmt = select(SubTask).where(SubTask.TaskID == task_id)
+        if status is not None:
+            stmt = stmt.where(SubTask.TaskState == status)
+        stmt = stmt.order_by(SubTask.SubTaskID)
+        if with_images:
+            stmt = stmt.options(_SUBTASK_IMAGE_LOADER)
+        return list(
+            session.execute(stmt.limit(limit).offset(offset)).scalars().all()
+        )
+```
+
+Update `orm/eyened_orm/repositories/__init__.py` (add `SubTaskRepository` to the `task_repository` import and to `__all__`):
+
+```python
+from .task_repository import SubTaskRepository, TaskRepository
+```
+
+```python
+    "TaskRepository",
+    "SubTaskRepository",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_task_repository.py -v`
+Expected: PASS (9 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/task_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_task_repository.py
+git commit -m "feat(repositories): add SubTaskRepository read methods"
+```
+
+---
+
+## Task 3: TaskService (task CRUD)
+
+Holds the task business rules the `task.py` handlers encode today (create with `TaskState.NotStarted`; list with per-task subtask counts; get; update the mutable fields; delete with cascade), owns the commit, and emits audit logging via an injected logger. The only failure path is a missing task (`NotFoundError` → 404) on `get`/`update`/`delete`. The constructor takes **both** repositories (`TaskRepository` for tasks/counts, `SubTaskRepository` for the Task 4 subtask reads); the default factory wires both.
+
+**Files:**
+- Create: `server/services/task_service.py`
+- Modify: `server/services/__init__.py` (re-export `TaskService`)
+- Test: `server/tests/test_task_service.py`
+
+**Interfaces:**
+- Consumes: `TaskRepository`, `SubTaskRepository` (Tasks 1–2); `NotFoundError` (existing); `ActingUser`; `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.Task`, `eyened_orm.task.TaskState`.
+- Produces:
+  - `TaskService(task_repository: TaskRepository, subtask_repository: SubTaskRepository, logger: DatabaseModificationLogger | None = None)`.
+  - `create_task(session, name: str, description: str | None, contact_id: int | None, task_definition_id: int, actor: ActingUser) -> Task` — new task (reloaded with relations); `TaskState.NotStarted`.
+  - `list_tasks(session) -> tuple[list[Task], dict[int, tuple[int, int]]]` — tasks (TaskID order) + `{task_id: (num, ready)}`.
+  - `get_task(session, task_id: int) -> tuple[Task, tuple[int, int]]` — task + its `(num, ready)`; 404 if absent.
+  - `update_task(session, task_id: int, name, description, contact_id, task_definition_id, task_state, actor) -> tuple[Task, tuple[int, int]]` — each field optional; 404 if absent.
+  - `delete_task(session, task_id: int, actor: ActingUser) -> None` — 404 if absent.
+  - `get_task_service() -> TaskService` — default-wiring factory (`TaskRepository()` + `SubTaskRepository()` + `get_db_logger()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_task_service.py`:
+
+```python
+import pytest
+
+from eyened_orm import Creator, SubTask, Task, TaskDefinition
+from eyened_orm.task import SubTaskState, TaskState
+from eyened_orm.repositories.task_repository import SubTaskRepository, TaskRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import NotFoundError
+from server.services.task_service import TaskService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _actor(session) -> ActingUser:
+    """An ActingUser backed by a real Creator row (Task.CreatorID is a FK)."""
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _task_def(session, name: str = "td") -> TaskDefinition:
+    td = TaskDefinition(TaskDefinitionName=name)
+    session.add(td)
+    session.flush()
+    return td
+
+
+def _make_task(session, td_id: int, creator_id: int, name: str = "T") -> Task:
+    task = Task(
+        TaskName=name,
+        TaskDefinitionID=td_id,
+        CreatorID=creator_id,
+        TaskState=TaskState.NotStarted,
+    )
+    session.add(task)
+    session.flush()
+    return task
+
+
+def _service(logger=None) -> TaskService:
+    return TaskService(TaskRepository(), SubTaskRepository(), logger=logger)
+
+
+def test_create_task_persists_with_defaults(session):
+    """create_task stores the task with the actor as owner and TaskState.NotStarted."""
+    actor = _actor(session)
+    td = _task_def(session)
+
+    task = _service().create_task(
+        session, "New", "desc", None, td.TaskDefinitionID, actor
+    )
+
+    assert task.TaskName == "New"
+    assert task.Description == "desc"
+    assert task.ContactID is None
+    assert task.TaskDefinitionID == td.TaskDefinitionID
+    assert task.CreatorID == actor.id
+    assert task.TaskState == TaskState.NotStarted
+
+
+def test_create_task_logs_insert(session):
+    """create_task emits one insert audit record naming the entity and user."""
+    actor = _actor(session)
+    td = _task_def(session)
+    logger = FakeAuditLogger()
+
+    _service(logger).create_task(
+        session, "New", None, None, td.TaskDefinitionID, actor
+    )
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "Task"
+    assert logger.inserts[0]["user"] == actor.username
+
+
+def test_list_tasks_returns_tasks_with_counts(session):
+    """list_tasks returns tasks in id order and a (total, ready) count per task."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.Ready))
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.NotStarted))
+    session.commit()
+
+    tasks, counts = _service().list_tasks(session)
+
+    assert [t.TaskID for t in tasks] == [task.TaskID]
+    assert counts[task.TaskID] == (2, 1)
+
+
+def test_get_task_returns_task_and_counts(session):
+    """get_task returns the task and its (total, ready) subtask counts."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.Ready))
+    session.commit()
+
+    got, counts = _service().get_task(session, task.TaskID)
+
+    assert got.TaskID == task.TaskID
+    assert counts == (1, 1)
+
+
+def test_get_task_unknown_raises_not_found(session):
+    """Getting a missing task is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_task(session, 999_999)
+
+
+def test_update_task_changes_fields(session):
+    """update_task overwrites the provided fields (name, description, task_state)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id, "Old")
+    session.commit()
+
+    updated, _counts = _service().update_task(
+        session, task.TaskID, "New", "newdesc", None, None, TaskState.Busy, actor
+    )
+
+    assert updated.TaskName == "New"
+    assert updated.Description == "newdesc"
+    assert updated.TaskState == TaskState.Busy
+
+
+def test_update_task_unknown_raises_not_found(session):
+    """Updating a missing task is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().update_task(
+            session, 999_999, "x", None, None, None, None, actor
+        )
+
+
+def test_update_task_logs_update(session):
+    """update_task emits one update audit record for the Task entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id, "Old")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).update_task(
+        session, task.TaskID, "New", None, None, None, None, actor
+    )
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "Task"
+
+
+def test_delete_task_removes_it_and_cascades_subtasks(session):
+    """delete_task removes the task and (via DB cascade) its subtasks."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.add(SubTask(TaskID=task.TaskID, TaskState=SubTaskState.NotStarted))
+    session.commit()
+
+    _service().delete_task(session, task.TaskID, actor)
+
+    assert TaskRepository().get_by_id(session, task.TaskID) is None
+    assert SubTaskRepository().all_ids_for_task(session, task.TaskID) == []
+
+
+def test_delete_task_unknown_raises_not_found(session):
+    """Deleting a missing task is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().delete_task(session, 999_999, actor)
+
+
+def test_delete_task_logs_delete(session):
+    """delete_task emits one delete audit record for the Task entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_task(session, task.TaskID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "Task"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_task_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.task_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/task_service.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import Task
+from eyened_orm.task import TaskState
+from eyened_orm.repositories.task_repository import SubTaskRepository, TaskRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import NotFoundError
+
+
+class TaskService:
+    """Business logic for tasks and their subtask listings."""
+
+    def __init__(
+        self,
+        task_repository: TaskRepository,
+        subtask_repository: SubTaskRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.tasks = task_repository
+        self.subtasks = subtask_repository
+        self.logger = logger
+
+    def create_task(
+        self,
+        session: Session,
+        name: str,
+        description: str | None,
+        contact_id: int | None,
+        task_definition_id: int,
+        actor: ActingUser,
+    ) -> Task:
+        """Create a task owned by the acting user (TaskState.NotStarted)."""
+        task = Task(
+            TaskName=name,
+            Description=description,
+            ContactID=contact_id,
+            TaskDefinitionID=task_definition_id,
+            CreatorID=actor.id,
+            TaskState=TaskState.NotStarted,
+        )
+        session.add(task)
+        session.commit()
+        task = self.tasks.get_with_relations(session, task.TaskID)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/task",
+                entity="Task",
+                entity_id=task.TaskID,
+                fields={
+                    "name": task.TaskName,
+                    "description": task.Description,
+                    "contact_id": task.ContactID,
+                    "task_definition_id": task.TaskDefinitionID,
+                },
+            )
+        return task
+
+    def list_tasks(
+        self, session: Session
+    ) -> tuple[list[Task], dict[int, tuple[int, int]]]:
+        """Return all tasks (TaskID order) and their {id: (total, ready)} counts."""
+        tasks = self.tasks.list_all(session)
+        counts = self.tasks.subtask_counts(session, [t.TaskID for t in tasks])
+        return tasks, counts
+
+    def get_task(
+        self, session: Session, task_id: int
+    ) -> tuple[Task, tuple[int, int]]:
+        """Return a task and its (total, ready) subtask counts.
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        task = self.tasks.get_with_relations(session, task_id)
+        if task is None:
+            raise NotFoundError(f"Task {task_id} not found")
+        return task, self.tasks.subtask_counts(session, [task_id])[task_id]
+
+    def update_task(
+        self,
+        session: Session,
+        task_id: int,
+        name: str | None,
+        description: str | None,
+        contact_id: int | None,
+        task_definition_id: int | None,
+        task_state: TaskState | None,
+        actor: ActingUser,
+    ) -> tuple[Task, tuple[int, int]]:
+        """Update a task's mutable fields (each optional).
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        task = self.tasks.get_by_id(session, task_id)
+        if task is None:
+            raise NotFoundError(f"Task {task_id} not found")
+
+        changes: dict[str, str] = {}
+        if name is not None:
+            changes["name"] = f"{task.TaskName} -> {name}"
+            task.TaskName = name
+        if description is not None:
+            changes["description"] = f"{task.Description} -> {description}"
+            task.Description = description
+        if contact_id is not None:
+            changes["contact_id"] = f"{task.ContactID} -> {contact_id}"
+            task.ContactID = contact_id
+        if task_definition_id is not None:
+            changes["task_definition_id"] = (
+                f"{task.TaskDefinitionID} -> {task_definition_id}"
+            )
+            task.TaskDefinitionID = task_definition_id
+        if task_state is not None:
+            changes["task_state"] = f"{task.TaskState} -> {task_state}"
+            task.TaskState = task_state
+
+        session.commit()
+        task = self.tasks.get_with_relations(session, task_id)
+        counts = self.tasks.subtask_counts(session, [task_id])[task_id]
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/task/{task_id}",
+                entity="Task",
+                entity_id=task_id,
+                changes=changes if changes else None,
+            )
+        return task, counts
+
+    def delete_task(
+        self, session: Session, task_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a task (its subtasks cascade at the DB level).
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        task = self.tasks.get_by_id(session, task_id)
+        if task is None:
+            raise NotFoundError(f"Task {task_id} not found")
+
+        deleted_data = {
+            "name": task.TaskName,
+            "description": task.Description,
+            "contact_id": task.ContactID,
+            "task_definition_id": task.TaskDefinitionID,
+            "creator_id": task.CreatorID,
+            "task_state": str(task.TaskState) if task.TaskState else None,
+        }
+        session.delete(task)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/task/{task_id}",
+                entity="Task",
+                entity_id=task_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+
+def get_task_service() -> TaskService:
+    """Default TaskService wiring for FastAPI ``Depends()``."""
+    return TaskService(
+        TaskRepository(), SubTaskRepository(), logger=get_db_logger()
+    )
+```
+
+Update `server/services/__init__.py` (add the import + `__all__` entry, keeping all existing exports):
+
+```python
+from .acting_user import ActingUser
+from .device_service import DeviceService
+from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
+from .feature_service import FeatureService
+from .form_schema_service import FormSchemaService
+from .patient_service import PatientService
+from .study_service import StudyService
+from .tag_service import TagService
+from .task_service import TaskService
+
+__all__ = [
+    "ServiceError",
+    "NotFoundError",
+    "BadRequestError",
+    "ConflictError",
+    "ActingUser",
+    "DeviceService",
+    "PatientService",
+    "FormSchemaService",
+    "StudyService",
+    "FeatureService",
+    "TagService",
+    "TaskService",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_task_service.py -v`
+Expected: PASS (11 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/task_service.py server/services/__init__.py server/tests/test_task_service.py
+git commit -m "feat(services): add TaskService with task CRUD and injected audit logging"
+```
+
+---
+
+## Task 4: TaskService — task-rooted subtask reads
+
+Adds the two read methods behind `GET /task/{id}/subtasks` (paginated, optional status filter, optional images, each row carrying its **absolute** index across the unfiltered ordered list) and `GET /task/{id}/subtask/{index}` (fetch by absolute index, optionally with the following subtask). These are task-rooted (they 404 via the task, or return an empty page) and belong in `TaskService`; the per-subtask-id CRUD is 3b's `SubTaskService`.
+
+> **Note — `with_images` is a passthrough at this layer.** Both methods forward `with_images` straight to `SubTaskRepository.list_for_task`; the Service adds no logic for it, and the DTO that actually differs by `with_images` is built in the route. So the tests below deliberately use `with_images=False` — the eager-load itself is covered once, at the repository level, by `test_list_for_task_with_images_loads_links` (Task 2). Per the lean-test-granularity convention, we do not add a Service test that only re-asserts a boolean passthrough.
+
+**Files:**
+- Modify: `server/services/task_service.py` (add two methods to `TaskService`)
+- Modify: `server/tests/test_task_service.py` (append tests)
+
+**Interfaces:**
+- Consumes: `SubTaskRepository.all_ids_for_task`, `.list_for_task`, `.count_for_task` (Task 2); `TaskRepository.get_by_id` (Task 1); `eyened_orm.SubTask`, `eyened_orm.task.SubTaskState`.
+- Produces (added to `TaskService`):
+  - `list_task_subtasks(session, task_id: int, *, with_images: bool, limit: int, page: int, status: SubTaskState | None) -> tuple[list[tuple[SubTask, int]], int]` — `[(subtask, absolute_index), ...]` for the requested page + total count (honoring `status`); 404 if the task is absent. `absolute_index` is the subtask's 0-based position within *all* the task's subtasks ordered by `SubTaskID` (computed **before** any status filter), matching today's handler.
+  - `get_task_subtask(session, task_id: int, subtask_index: int, *, with_images: bool, with_next: bool) -> tuple[SubTask, SubTask | None]` — the subtask at that absolute index and, if `with_next`, the one after it (`None` if there is none); 404 if no subtask sits at `subtask_index`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_task_service.py`:
+
+```python
+def _make_subtask(session, task_id: int, state: SubTaskState) -> SubTask:
+    st = SubTask(TaskID=task_id, TaskState=state)
+    session.add(st)
+    session.flush()
+    return st
+
+
+def test_list_task_subtasks_paginates_with_absolute_index(session):
+    """list_task_subtasks returns a page, each row tagged with its absolute index."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    made = [_make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(5)]
+    session.commit()
+
+    rows, count = _service().list_task_subtasks(
+        session, task.TaskID, with_images=False, limit=2, page=1, status=None
+    )
+
+    assert count == 5
+    assert [(st.SubTaskID, idx) for st, idx in rows] == [
+        (made[2].SubTaskID, 2),
+        (made[3].SubTaskID, 3),
+    ]
+
+
+def test_list_task_subtasks_filters_by_status_keeps_absolute_index(session):
+    """A status filter narrows rows/count but indices stay absolute (pre-filter)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)  # abs index 0
+    ready = _make_subtask(session, task.TaskID, SubTaskState.Ready)  # abs index 1
+    session.commit()
+
+    rows, count = _service().list_task_subtasks(
+        session, task.TaskID, with_images=False, limit=10, page=0,
+        status=SubTaskState.Ready,
+    )
+
+    assert count == 1
+    assert [(st.SubTaskID, idx) for st, idx in rows] == [(ready.SubTaskID, 1)]
+
+
+def test_list_task_subtasks_unknown_task_raises_not_found(session):
+    """Listing subtasks of a missing task is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().list_task_subtasks(
+            session, 999_999, with_images=False, limit=10, page=0, status=None
+        )
+
+
+def test_get_task_subtask_returns_by_index(session):
+    """get_task_subtask returns the subtask at the given absolute index."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    made = [_make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(3)]
+    session.commit()
+
+    main, nxt = _service().get_task_subtask(
+        session, task.TaskID, 1, with_images=False, with_next=False
+    )
+
+    assert main.SubTaskID == made[1].SubTaskID
+    assert nxt is None
+
+
+def test_get_task_subtask_with_next_returns_following(session):
+    """with_next also returns the subtask after the requested index."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    made = [_make_subtask(session, task.TaskID, SubTaskState.NotStarted) for _ in range(3)]
+    session.commit()
+
+    main, nxt = _service().get_task_subtask(
+        session, task.TaskID, 1, with_images=False, with_next=True
+    )
+
+    assert main.SubTaskID == made[1].SubTaskID
+    assert nxt is not None
+    assert nxt.SubTaskID == made[2].SubTaskID
+
+
+def test_get_task_subtask_out_of_range_raises_not_found(session):
+    """An index past the last subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    session.commit()
+
+    with pytest.raises(NotFoundError):
+        _service().get_task_subtask(
+            session, task.TaskID, 5, with_images=False, with_next=False
+        )
+```
+
+> **Note — imports:** `SubTask` and `SubTaskState` are already imported at the top of `test_task_service.py` (Task 3). The appended `_make_subtask` helper reuses them.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_task_service.py -v`
+Expected: FAIL — `AttributeError: 'TaskService' object has no attribute 'list_task_subtasks'`.
+
+- [ ] **Step 3: Add the two methods**
+
+Add these methods to the `TaskService` class in `server/services/task_service.py` (place them after `delete_task`, before the module-level `get_task_service`). Also add `SubTask` and `SubTaskState` to the `eyened_orm` / `eyened_orm.task` imports at the top of the file:
+
+```python
+# extend the existing imports at the top of task_service.py:
+from eyened_orm import SubTask, Task
+from eyened_orm.task import SubTaskState, TaskState
+```
+
+```python
+    def list_task_subtasks(
+        self,
+        session: Session,
+        task_id: int,
+        *,
+        with_images: bool,
+        limit: int,
+        page: int,
+        status: SubTaskState | None,
+    ) -> tuple[list[tuple[SubTask, int]], int]:
+        """Return one page of a task's subtasks, each with its absolute index.
+
+        ``absolute_index`` is the subtask's 0-based position within *all* the
+        task's subtasks ordered by SubTaskID (computed before the ``status``
+        filter). The returned count honors ``status``.
+
+        Raises:
+            NotFoundError: If the task does not exist.
+        """
+        if self.tasks.get_by_id(session, task_id) is None:
+            raise NotFoundError(f"Task {task_id} not found")
+
+        index_of = {
+            sid: i
+            for i, sid in enumerate(self.subtasks.all_ids_for_task(session, task_id))
+        }
+        rows = self.subtasks.list_for_task(
+            session,
+            task_id,
+            status=status,
+            limit=limit,
+            offset=limit * page,
+            with_images=with_images,
+        )
+        count = self.subtasks.count_for_task(session, task_id, status=status)
+        # Every returned row is one of the task's subtasks, so its id is always
+        # in index_of (rows are a subset of all_ids_for_task).
+        return [(st, index_of[st.SubTaskID]) for st in rows], count
+
+    def get_task_subtask(
+        self,
+        session: Session,
+        task_id: int,
+        subtask_index: int,
+        *,
+        with_images: bool,
+        with_next: bool,
+    ) -> tuple[SubTask, SubTask | None]:
+        """Return the subtask at ``subtask_index`` and, if asked, the next one.
+
+        Raises:
+            NotFoundError: If no subtask sits at ``subtask_index``.
+        """
+        rows = self.subtasks.list_for_task(
+            session,
+            task_id,
+            status=None,
+            limit=2 if with_next else 1,
+            offset=subtask_index,
+            with_images=with_images,
+        )
+        if not rows:
+            raise NotFoundError("SubTask not found")
+        nxt = rows[1] if (with_next and len(rows) > 1) else None
+        return rows[0], nxt
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_task_service.py -v`
+Expected: PASS (17 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/task_service.py server/tests/test_task_service.py
+git commit -m "feat(services): add task-rooted subtask reads to TaskService"
+```
+
+---
+
+## Task 5: Rewire `routes/task.py` to use TaskService
+
+Make every `task.py` handler thin: build an `ActingUser`, call the Service, convert the ORM result via `DTOConverter`, return. All inline `select(...)`/`db.get(...)`, `raise HTTPException(...)`, `db.commit()`/`db.refresh()`, `delete(...)`, `get_db_logger()` calls, and the `_task_query_options`/`_subtask_counts_by_task_id`/`bisect` helpers are removed — they now live in the Repository/Service.
+
+**Files:**
+- Modify: `server/routes/task.py` (full replacement)
+
+**Interfaces:**
+- Consumes: `TaskService` + `get_task_service` (Tasks 3–4); `ActingUser`; existing `DTOConverter.task_to_get`/`subtask_to_get`/`subtask_with_images_to_get`, the `dtos_tasks` DTOs, `get_db`, `get_current_user`, and `eyened_orm.SubTaskState` (the `subtask_status` query-param type).
+- Produces: unchanged HTTP contract — `POST /task` → `TaskGET`; `GET /task` → `list[TaskGET]`; `GET /task/{id}` → `TaskGET`; `PATCH /task/{id}` → `TaskGET`; `DELETE /task/{id}` → 204; `GET /task/{id}/subtasks` → `SubTasksWithImagesResponse | SubTasksResponse`; `GET /task/{id}/subtask/{index}` → `SubTaskWithImagesGET | SubTaskGET`. Same 404s (now via the central handler).
+
+> **Note — route-only test coverage (accepted gap):** `server/tests/` has no task route test today (only `test_routes_auth.py`), and this phase adds none — matching how 2a/2b/2c shipped. So the route-only logic left here (converter selection by `with_images`, response-envelope assembly, and applying the Service-returned `index` / `next_task` via `.copy(update=...)`) is exercised **only** by the optional manual smoke in Verification, not automatically. The risk is low because the index computation and all 404s now live in the Service and are unit-tested; the residual untested surface is the thin converter-choice + envelope wiring. If you want it covered, add a single FastAPI `TestClient` test with `app.dependency_overrides` for `get_db`/`get_current_user` — but that is new shared route-test infrastructure, so treat it as its own task rather than folding it in here.
+
+- [ ] **Step 1: Replace the module contents with thin Service-backed handlers**
+
+Replace the entire contents of `server/routes/task.py` with:
+
+```python
+from typing import List, Optional, Union
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from eyened_orm import SubTaskState
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_tasks import (
+    SubTaskGET,
+    SubTasksResponse,
+    SubTasksWithImagesResponse,
+    SubTaskWithImagesGET,
+    TaskGET,
+    TaskPATCH,
+    TaskPUT,
+)
+from ..services.acting_user import ActingUser
+from ..services.task_service import TaskService, get_task_service
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/task", response_model=TaskGET)
+async def create_task(
+    dto: TaskPUT,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Create a task owned by the current user."""
+    task = service.create_task(
+        db,
+        dto.name,
+        dto.description,
+        dto.contact_id,
+        dto.task_definition_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.task_to_get(task, num_tasks=0, num_tasks_ready=0)
+
+
+@router.get("/task", response_model=List[TaskGET])
+async def list_tasks(
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """List all tasks (no pagination)."""
+    tasks, counts = service.list_tasks(db)
+    return [
+        DTOConverter.task_to_get(
+            t,
+            num_tasks=counts[t.TaskID][0],
+            num_tasks_ready=counts[t.TaskID][1],
+        )
+        for t in tasks
+    ]
+
+
+@router.get("/task/{task_id}", response_model=TaskGET)
+async def get_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single task with its subtask counts."""
+    task, (num_tasks, num_tasks_ready) = service.get_task(db, task_id)
+    return DTOConverter.task_to_get(
+        task, num_tasks=num_tasks, num_tasks_ready=num_tasks_ready
+    )
+
+
+@router.patch("/task/{task_id}", response_model=TaskGET)
+async def patch_task(
+    task_id: int,
+    dto: TaskPATCH,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Update a task's name/description/contact/definition/state."""
+    task, (num_tasks, num_tasks_ready) = service.update_task(
+        db,
+        task_id,
+        dto.name,
+        dto.description,
+        dto.contact_id,
+        dto.task_definition_id,
+        dto.task_state,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.task_to_get(
+        task, num_tasks=num_tasks, num_tasks_ready=num_tasks_ready
+    )
+
+
+@router.delete("/task/{task_id}", status_code=204)
+async def delete_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Delete a task."""
+    service.delete_task(
+        db,
+        task_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.get(
+    "/task/{task_id}/subtasks",
+    response_model=Union[SubTasksWithImagesResponse, SubTasksResponse],
+)
+async def list_subtasks(
+    task_id: int,
+    with_images: bool = False,
+    limit: int = 200,
+    page: int = 0,
+    subtask_status: Optional[SubTaskState] = None,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """List subtasks of a task (pagination, optional images, optional status filter).
+
+    ``index`` is the 0-based position within all subtasks of the task ordered by
+    SubTaskID (computed before any subtask_status filtering).
+    """
+    rows_with_index, count = service.list_task_subtasks(
+        db,
+        task_id,
+        with_images=with_images,
+        limit=limit,
+        page=page,
+        status=subtask_status,
+    )
+    convert = (
+        DTOConverter.subtask_with_images_to_get
+        if with_images
+        else DTOConverter.subtask_to_get
+    )
+    subtasks = [
+        convert(st).copy(update={"index": index}) for st, index in rows_with_index
+    ]
+    return {"subtasks": subtasks, "limit": limit, "page": page, "count": count}
+
+
+@router.get(
+    "/task/{task_id}/subtask/{subtask_index}",
+    response_model=Union[SubTaskWithImagesGET, SubTaskGET],
+)
+async def get_subtask(
+    task_id: int,
+    subtask_index: int,
+    with_images: bool = False,
+    with_next: bool = False,
+    db: Session = Depends(get_db),
+    service: TaskService = Depends(get_task_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single subtask by index, optionally with images and the next subtask."""
+    main, nxt = service.get_task_subtask(
+        db,
+        task_id,
+        subtask_index,
+        with_images=with_images,
+        with_next=with_next,
+    )
+    convert = (
+        DTOConverter.subtask_with_images_to_get
+        if with_images
+        else DTOConverter.subtask_to_get
+    )
+    main_dto = convert(main).copy(update={"index": subtask_index})
+    if nxt is not None:
+        next_dto = convert(nxt).copy(update={"index": subtask_index + 1})
+        main_dto = main_dto.copy(update={"next_task": next_dto})
+    return main_dto
+```
+
+- [ ] **Step 2: Verify the router imports and exposes all seven routes**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "from server.routes import task; print(sorted((r.path, tuple(sorted(r.methods))) for r in task.router.routes))"`
+Expected: prints the routes — `/task` (GET, POST), `/task/{task_id}` (GET, PATCH, DELETE), `/task/{task_id}/subtasks` (GET), `/task/{task_id}/subtask/{subtask_index}` (GET) — with no traceback.
+
+- [ ] **Step 3: Confirm the app still boots**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "import server.main; print('ok')"`
+Expected: prints `ok` with no traceback.
+
+- [ ] **Step 4: Run the full test suite to confirm no regressions**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: all tests pass (prior 165 + Task 1–2 repository tests: 9 + Task 3–4 service tests: 17 = **191 passed**); no import/collection errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/routes/task.py
+git commit -m "refactor(routes): route task endpoints through TaskService"
+```
+
+---
+
+## Verification (end-to-end, on `feature/rbac-step1-service-layer`)
+
+1. **Full suite green:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q` — prior suite plus the new TaskRepository/SubTaskRepository/TaskService tests pass (191 passed).
+2. **All seven routes exposed:** the Task 5 Step 2 command prints GET/POST `/task`, GET/PATCH/DELETE `/task/{task_id}`, GET `/task/{task_id}/subtasks`, and GET `/task/{task_id}/subtask/{subtask_index}`.
+3. **App boots:** `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/python -c "import server.main; print('ok')"` → `ok`.
+4. **Manual smoke (optional, real dev DB + server):**
+   - `POST /api/task` with `{"name": "X", "task_definition_id": <valid>}` → 200 `TaskGET` with `task_state: "NotStarted"`, `num_tasks: 0`; `PATCH` its name/state → 200; `DELETE` it → 204.
+   - `GET`/`PATCH`/`DELETE` on `/api/task/999999` → HTTP 404 `{"detail": "Task 999999 not found"}` (proves the `NotFoundError` → central-handler path is live).
+   - For a task with subtasks: `GET /api/task/{id}/subtasks?limit=2&page=1` → each subtask's `index` is its absolute position; `?subtask_status=Ready` narrows the page but keeps absolute indices; `GET /api/task/{id}/subtask/0?with_next=true` → the first subtask plus `next_task`; an out-of-range index → 404 `{"detail": "SubTask not found"}`.
+5. **Branch isolation:** `git log development..HEAD` shows only the RBAC-step1 commits; `development` has not moved.
+
+## Out of scope / follow-up
+
+- **Phase 3b (`subtask.py`)** — next plan/PR on this branch, same pattern: introduces `SubTaskService` (+ `get_subtask` by id, `patch`/`delete`, `add_image`/`remove_image`) and extends `SubTaskRepository` with `get_by_id`, `get_with_images`, and the image-link methods (`resolve_image_instance_id`, `max_image_index`, `get_image_link`). Note `subtask.py` today wraps `add_subtask_image` in a `try/except → HTTPException(500)`; in 3b that becomes ordinary Service behavior (let the central handler map failures) — call it out in the 3b plan.
+- Phase 4 (`import_api`, `instances`, `form_annotations`, `segmentations`) — later plans/PRs on this branch.
+- Transaction-ownership review across all Services (spec "Follow-up work") once every phase has migrated.
+- RBAC enforcement itself is **Step 2** (`PermissionDeniedError` + per-method authz checks that read `ActingUser`).

--- a/docs/superpowers/plans/2026-07-10-form-annotations-phase4b.md
+++ b/docs/superpowers/plans/2026-07-10-form-annotations-phase4b.md
@@ -1,0 +1,1597 @@
+# form_annotations Repository/Service Migration (RBAC Step 1, Phase 4b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the `form_annotations.py` endpoints — the FormAnnotation CRUD (`POST/GET/GET{id}/PATCH{id}/DELETE{id}`), the raw-value read/write (`GET/PUT .../value`), and the three FormAnnotation-tag mutations (`POST/DELETE/PATCH .../tags`) — through a new `FormAnnotationService` backed by a new `FormAnnotationRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as every shipped slice (Device/Patient/FormSchema/Study/Feature/Tag/Task/SubTask/ImageInstance): thin route (parse → build `ActingUser` for mutations → Service → `DTOConverter` → return), a Service with constructor-injected Repositories that raises domain exceptions and owns the commit, and framework-agnostic Repositories that take a `Session`. This is the **second slice of the spec's Phase 4** (after `instances.py` / 4a); `segmentations.py` (4c) is the last, a separate plan. `FormAnnotationService` reuses the existing `ImageInstanceRepository` (for `image_id`→instance resolution) and `TagRepository` (for the tag guard), both from earlier phases.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model module — `form_annotation_repository.py`, `form_annotation_service.py`.
+- **Class names:** `FormAnnotationRepository` / `FormAnnotationService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repositories via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `import_api.py`, `Base`'s generic classmethods, or any pre-existing shipped slice (beyond the one additive `ImageInstanceRepository.get_by_public_id` method Task 1 appends).
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions reused from earlier phases
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session that is only *closed*, never committed, by its context manager. Every mutating Service method calls `session.commit()` itself — the Service is the transaction boundary. (The spec's deferred "transaction ownership" follow-up will revisit this layer-wide; do not change it here.)
+- **Audit logging is injected, not global-reached.** The Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the mutating method, guarded by `if self.logger is not None:`. The default factory wires the real logger via `get_db_logger()` (which returns `None` when DB logging is disabled); Service tests inject `None` or the small hand-rolled `FakeAuditLogger`.
+- **Acting user:** routes map their handler-layer `CurrentUser` onto the framework-agnostic `ActingUser(id, username)` value object (`server/services/acting_user.py`, already exists) before calling a mutating Service method.
+- **Lean test granularity:** thin `session.get(...)`/`.first()` wrappers get **no** dedicated Repository test — they are exercised through the Service tests. Every test carries a one-line docstring as its description.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`. The two commands that import `server.*` (app-boot / router-introspection checks) need dummy DB env vars, mirroring `server/tests/conftest.py`: prefix them with `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer` (all already exist):** `NotFoundError` and `BadRequestError` (400) in `server/services/exceptions.py`, registered in `server/main.py` — the single handler dispatches every `ServiceError` subclass by MRO, so **this phase needs no `main.py` change**. `ActingUser`; `TagRepository.get_by_id`; `ImageInstanceRepository` (Task 1 only *appends* a `get_by_public_id` method); the `session` fixture in `server/tests/conftest.py`; both `repositories/`/`services/` packages with their `__init__.py` re-exports. **`form_annotations.router` is already registered** in `server/main.py` (`app_api.include_router(form_annotations.router)`, line 36), so no registration change is needed.
+
+> **Existing facts confirmed for this plan** (verified against the route source and the ORM):
+> - `FormAnnotation` (`orm/eyened_orm/form_annotation.py:44`): `FormAnnotationID` (int PK); NOT-NULL FKs `FormSchemaID`, `PatientID`, `CreatorID`; nullable FKs `StudyID`, `ImageInstanceID`, `SubTaskID`, `FormAnnotationReferenceID`; `Laterality` (nullable enum); `FormData` (nullable JSON); **`Inactive` (bool, default False)** — delete is a soft-delete (`Inactive = True`). Relationships: `FormSchema`, `Patient`, `Study`, `ImageInstance`, `Creator`, `SubTask`, `FormAnnotationTagLinks` (`lazy="selectin"`).
+> - `FormAnnotationTagLink` (`orm/eyened_orm/tag.py:223`): **composite PK `(TagID, FormAnnotationID)`**; `CreatorID` (FK, NOT NULL); `Comment` (`String(256)`, nullable); `Tag`/`FormAnnotation` relationships, `Creator` (`lazy="selectin"`). So `session.get(FormAnnotationTagLink, {"TagID": ..., "FormAnnotationID": ...})` is the by-key lookup.
+> - `Tag` (`orm/eyened_orm/tag.py:47`): `TagID` PK; `TagName`, `TagType` (`SAEnum(TagType)`), **`TagDescription` (NOT NULL)**, `CreatorID` (NOT NULL). `TagType` members include `FormAnnotation`.
+> - A minimal `FormAnnotation` row FK-requires a `Project`→`Patient` chain, a `FormSchema` (`SchemaName` is `unique`), and a `Creator`. `Study`/`ImageInstance` are optional. The `_make_annotation` helper below builds exactly that minimal graph.
+> - `FormSchema(SchemaName=...)`, `Project(ProjectName=..., External=ExternalEnum.N)`, `Patient(PatientIdentifier=..., ProjectID=...)`, `Creator(CreatorName=..., IsHuman=True)` are the minimal constructors (mirrors the helpers in `test_image_instance_service.py` / `test_task_repository.py`).
+
+> **DTO facts confirmed:** `DTOConverter.form_annotation_to_get(annotation, with_tag_metadata=False)` and `DTOConverter.link_to_tag_metadata(link)` are the converters the route uses; both stay in the route. **The route calls `form_annotation_to_get(row)` with the default `with_tag_metadata=False` everywhere** — so `tags` is always `[]` in the response today; this plan preserves that call exactly. `FormAnnotationGET`/`FormAnnotationPUT`/`FormAnnotationPATCH`/`TagMeta`/`ObjectTagPOST`/`ObjectTagPATCH` DTOs are unchanged. `FormAnnotationPUT`/`FormAnnotationBase` fields are exactly: `form_schema_id, patient_id, study_id, image_id, laterality, sub_task_id, form_data, form_annotation_reference_id` — so `service.create(session, actor=..., **annotation.dict())` maps cleanly.
+
+> **Behavior-preserving decisions (call out in review):**
+> 1. **All inline `raise HTTPException(404/400)` move into the Service** as `NotFoundError` (404) / `BadRequestError` (400). Same wire status; the central handlers map them. The wrong-tag-type guard (`Tag.TagType != TagType.FormAnnotation`) becomes `BadRequestError`.
+> 2. **The legacy `image_id`→`ImageInstanceID` resolver keeps its exact behavior.** `_resolve_image_instance_id` (plain `PublicID` equality, no PK/digit fallback, 404 when absent) is reproduced as a new `ImageInstanceRepository.get_by_public_id` (returns `None`) + a private Service helper that raises `NotFoundError`. This is intentionally *not* the fallback-carrying `get_full_graph_by_public_id`/`get_with_storage_by_public_id` — those have a `session.get(int/raw id)` fallback the legacy resolver never had.
+> 3. **The PATCH `changes` audit dict keeps its pre-refactor formatting quirk verbatim** (pinned by a test, matching the 4a "pin the quirk" precedent). Today's route computes `changes = {k: f"{getattr(annotation, k, None)} -> {v}" for k, v in payload.items()}` where `k` is the **snake_case** DTO key, so `getattr(<ORM>, "form_schema_id", None)` is always `None` and every logged change reads `None -> <new>`. This is audit-log-only (not an API response), so this refactor preserves it exactly rather than silently changing observable behavior; a reviewer may file a separate fix.
+> 4. **`PUT .../value` uses `log_simple`** (one-line high-frequency log), not `log_update`; `GET .../value` returns raw `FormData` (not a DTO). Both preserved.
+> 5. **DTO conversion is unchanged** — the route keeps calling `form_annotation_to_get(row)` with `with_tag_metadata=False`, so the always-`[]` `tags` behavior is untouched. The list query's eager-load graph is moved verbatim into the Repository (behavior-preserving; harmless even though the default converter ignores it).
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: the existing suite passes (baseline after 4a landed: **227 passed**). If the number differs, that count is your real baseline — proceed as long as it is green. **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+## Task 1: FormAnnotationRepository + `ImageInstanceRepository.get_by_public_id`
+
+Create `FormAnnotationRepository` with the reads the `form_annotations.py` handlers perform inline today: the filtered active-list with its eager-load graph, the by-id read with tag links, a plain by-id `session.get`, and a composite-key tag-link lookup. Append one small `get_by_public_id` resolver to the existing `ImageInstanceRepository` (the faithful equivalent of the legacy `_resolve_image_instance_id`). Following precedent (lean granularity), the thin wrappers — `FormAnnotationRepository.get_by_id`, `.get_tag_link`, and `ImageInstanceRepository.get_by_public_id` — get **no** dedicated Repository test; they are exercised through the Task 2–4 Service tests. The two tests here cover the methods with real branching: the filtered/active list and the tag-link-loaded read. No method commits; the Service owns the transaction boundary.
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/form_annotation_repository.py`
+- Modify: `orm/eyened_orm/repositories/image_instance_repository.py` (append `get_by_public_id`)
+- Modify: `orm/eyened_orm/repositories/__init__.py` (re-export `FormAnnotationRepository`)
+- Test: `orm/eyened_orm/tests/test_form_annotation_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm` models `FormAnnotation`, `FormAnnotationTagLink`, `ImageInstance`, `ImageInstanceTagLink`, `Study`, `StudyTagLink`.
+- Produces (all take `session: Session` first):
+  - `FormAnnotationRepository.get_by_id(session, annotation_id: int) -> FormAnnotation | None` — thin `session.get`.
+  - `FormAnnotationRepository.get_with_tag_links(session, annotation_id: int) -> FormAnnotation | None` — by id with `FormAnnotationTagLinks`→`Tag`/`Creator` eager-loaded.
+  - `FormAnnotationRepository.list_active(session, *, patient_id: int | None = None, study_id: int | None = None, image_instance_id: int | None = None, form_schema_id: int | None = None, sub_task_id: int | None = None) -> list[FormAnnotation]` — `~Inactive`, filtered, with the list eager-load graph.
+  - `FormAnnotationRepository.get_tag_link(session, tag_id: int, annotation_id: int) -> FormAnnotationTagLink | None` — thin composite-key `session.get`.
+  - `ImageInstanceRepository.get_by_public_id(session, public_id: str) -> ImageInstance | None` — plain `PublicID` equality, no eager loads, no PK/digit fallback.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_form_annotation_repository.py`:
+
+```python
+from eyened_orm import Creator, FormAnnotation, FormSchema, Patient, Project
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.form_annotation_repository import (
+    FormAnnotationRepository,
+)
+
+
+def _make_annotation(
+    session,
+    key: str,
+    *,
+    inactive: bool = False,
+    study_id: int | None = None,
+    image_instance_id: int | None = None,
+) -> FormAnnotation:
+    """Build the minimal FK graph a FormAnnotation requires; return the row."""
+    project = Project(ProjectName=f"P-{key}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{key}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    schema = FormSchema(SchemaName=f"S-{key}")
+    session.add(schema)
+    session.flush()
+    creator = Creator(CreatorName=f"c-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    ann = FormAnnotation(
+        FormSchemaID=schema.FormSchemaID,
+        PatientID=patient.PatientID,
+        CreatorID=creator.CreatorID,
+        StudyID=study_id,
+        ImageInstanceID=image_instance_id,
+        Inactive=inactive,
+        FormData={"k": "v"},
+    )
+    session.add(ann)
+    session.flush()
+    return ann
+
+
+def test_list_active_excludes_inactive_and_filters_by_schema(session):
+    """list_active drops Inactive rows and applies the form_schema_id filter."""
+    keep = _make_annotation(session, "keep")
+    _make_annotation(session, "gone", inactive=True)
+    repo = FormAnnotationRepository()
+
+    rows = repo.list_active(session)
+    ids = {r.FormAnnotationID for r in rows}
+    assert keep.FormAnnotationID in ids
+    assert all(not r.Inactive for r in rows)
+
+    by_schema = repo.list_active(session, form_schema_id=keep.FormSchemaID)
+    assert [r.FormAnnotationID for r in by_schema] == [keep.FormAnnotationID]
+
+    assert repo.list_active(session, form_schema_id=999_999) == []
+
+
+def test_get_with_tag_links_found_and_missing(session):
+    """get_with_tag_links returns the row (tag links loaded) or None if absent."""
+    ann = _make_annotation(session, "one")
+    repo = FormAnnotationRepository()
+
+    got = repo.get_with_tag_links(session, ann.FormAnnotationID)
+    assert got is not None and got.FormAnnotationID == ann.FormAnnotationID
+    assert list(got.FormAnnotationTagLinks) == []  # eager-loaded, empty
+
+    assert repo.get_with_tag_links(session, 999_999) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_form_annotation_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.form_annotation_repository'`.
+
+- [ ] **Step 3: Write the repository and append the resolver**
+
+Create `orm/eyened_orm/repositories/form_annotation_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import (
+    FormAnnotation,
+    FormAnnotationTagLink,
+    ImageInstance,
+    ImageInstanceTagLink,
+    Study,
+    StudyTagLink,
+)
+
+
+class FormAnnotationRepository:
+    """Data access for FormAnnotation reads and its Tag links."""
+
+    def get_by_id(
+        self, session: Session, annotation_id: int
+    ) -> FormAnnotation | None:
+        """Return the annotation by id, or None if absent."""
+        return session.get(FormAnnotation, annotation_id)
+
+    def get_with_tag_links(
+        self, session: Session, annotation_id: int
+    ) -> FormAnnotation | None:
+        """Return the annotation by id with its tag links loaded, or None."""
+        return session.get(
+            FormAnnotation,
+            annotation_id,
+            options=(
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Tag),
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Creator),
+            ),
+        )
+
+    def list_active(
+        self,
+        session: Session,
+        *,
+        patient_id: int | None = None,
+        study_id: int | None = None,
+        image_instance_id: int | None = None,
+        form_schema_id: int | None = None,
+        sub_task_id: int | None = None,
+    ) -> list[FormAnnotation]:
+        """Return active (``~Inactive``) annotations matching the given filters.
+
+        Mirrors the eager-load graph the ``GET /form-annotations`` handler
+        built inline. ``image_instance_id`` is already resolved from a
+        PublicID by the Service; ``None`` filters are not applied.
+        """
+        query = (
+            select(FormAnnotation)
+            .filter(~FormAnnotation.Inactive)
+            .options(
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Tag),
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Creator),
+                selectinload(FormAnnotation.Study)
+                .selectinload(Study.StudyTagLinks)
+                .selectinload(StudyTagLink.Tag),
+                selectinload(FormAnnotation.Study)
+                .selectinload(Study.StudyTagLinks)
+                .selectinload(StudyTagLink.Creator),
+                selectinload(FormAnnotation.ImageInstance)
+                .selectinload(ImageInstance.ImageInstanceTagLinks)
+                .selectinload(ImageInstanceTagLink.Tag),
+                selectinload(FormAnnotation.ImageInstance)
+                .selectinload(ImageInstance.ImageInstanceTagLinks)
+                .selectinload(ImageInstanceTagLink.Creator),
+            )
+        )
+        if patient_id is not None:
+            query = query.filter(FormAnnotation.PatientID == patient_id)
+        if study_id is not None:
+            query = query.filter(FormAnnotation.StudyID == study_id)
+        if image_instance_id is not None:
+            query = query.filter(
+                FormAnnotation.ImageInstanceID == image_instance_id
+            )
+        if form_schema_id is not None:
+            query = query.filter(FormAnnotation.FormSchemaID == form_schema_id)
+        if sub_task_id is not None:
+            query = query.filter(FormAnnotation.SubTaskID == sub_task_id)
+        return list(session.scalars(query).all())
+
+    def get_tag_link(
+        self, session: Session, tag_id: int, annotation_id: int
+    ) -> FormAnnotationTagLink | None:
+        """Return the link for (tag_id, annotation_id), or None if absent."""
+        return session.get(
+            FormAnnotationTagLink,
+            {"TagID": tag_id, "FormAnnotationID": annotation_id},
+        )
+```
+
+Append `get_by_public_id` to the existing `ImageInstanceRepository` class in `orm/eyened_orm/repositories/image_instance_repository.py` (add it after the existing `get_tag_link` method; `select` is already imported at the top of that module):
+
+```python
+    def get_by_public_id(
+        self, session: Session, public_id: str
+    ) -> ImageInstance | None:
+        """Return the instance with this PublicID (no eager loads), or None.
+
+        Plain PublicID resolver used to map an external image id to its row —
+        the faithful equivalent of the legacy ``_resolve_image_instance_id``
+        helper (no PK/digit fallback, unlike ``get_full_graph_by_public_id``).
+        """
+        return session.scalars(
+            select(ImageInstance).where(ImageInstance.PublicID == public_id)
+        ).first()
+```
+
+Update `orm/eyened_orm/repositories/__init__.py` (add the import + `__all__` entry, keeping all existing exports):
+
+```python
+from .form_annotation_repository import FormAnnotationRepository
+```
+
+```python
+    "FormAnnotationRepository",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_form_annotation_repository.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/form_annotation_repository.py orm/eyened_orm/repositories/image_instance_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_form_annotation_repository.py
+git commit -m "feat(repositories): add FormAnnotationRepository and ImageInstance PublicID resolver"
+```
+
+---
+
+## Task 2: FormAnnotationService — reads (list, get, value)
+
+Create `FormAnnotationService` with the three read paths: the filtered list (resolving an optional `image_id` first), the by-id read with tag links, and the raw `FormData` read. Missing rows translate to `NotFoundError` (→404); an `image_id` filter that resolves to nothing also raises `NotFoundError`, matching today's `_resolve_image_instance_id` 404. The constructor takes all three Repositories (`FormAnnotationRepository`, `ImageInstanceRepository`, `TagRepository` — the last two are needed by Tasks 3–4) plus the injected logger; the default factory wires them and the real logger.
+
+**Files:**
+- Create: `server/services/form_annotation_service.py`
+- Modify: `server/services/__init__.py` (re-export `FormAnnotationService`)
+- Test: `server/tests/test_form_annotation_service.py`
+
+**Interfaces:**
+- Consumes: `FormAnnotationRepository` (Task 1); `ImageInstanceRepository.get_by_public_id`, `TagRepository` (existing); `NotFoundError` (existing); `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.FormAnnotation`.
+- Produces:
+  - `FormAnnotationService(repository, image_repository, tag_repository, logger=None)`
+  - `list_annotations(session, *, patient_id, study_id, image_id, form_schema_id, sub_task_id) -> list[FormAnnotation]` — resolves `image_id` (404 if given & unknown).
+  - `get_annotation(session, annotation_id: int) -> FormAnnotation` — 404 if absent.
+  - `get_value(session, annotation_id: int) -> Any` — returns `FormData`; 404 if absent.
+  - `get_form_annotation_service() -> FormAnnotationService` — default-wiring factory.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_form_annotation_service.py`:
+
+```python
+import pytest
+
+from eyened_orm import (
+    Creator,
+    DeviceInstance,
+    DeviceModel,
+    FormAnnotation,
+    FormSchema,
+    ImageInstance,
+    Patient,
+    Project,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.form_annotation_repository import (
+    FormAnnotationRepository,
+)
+from eyened_orm.repositories.image_instance_repository import (
+    ImageInstanceRepository,
+)
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.exceptions import NotFoundError
+from server.services.form_annotation_service import FormAnnotationService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+        self.simples: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+    def log_simple(self, **kwargs) -> None:
+        self.simples.append(kwargs)
+
+
+def _service(logger=None) -> FormAnnotationService:
+    return FormAnnotationService(
+        FormAnnotationRepository(),
+        ImageInstanceRepository(),
+        TagRepository(),
+        logger=logger,
+    )
+
+
+def _make_patient_and_schema(session, key: str) -> tuple[int, int]:
+    """Create a Project/Patient + FormSchema; return (patient_id, schema_id)."""
+    project = Project(ProjectName=f"P-{key}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{key}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    schema = FormSchema(SchemaName=f"S-{key}")
+    session.add(schema)
+    session.flush()
+    return patient.PatientID, schema.FormSchemaID
+
+
+def _make_annotation(session, key: str, *, inactive: bool = False) -> FormAnnotation:
+    """Create a minimal active/inactive FormAnnotation; return the row."""
+    patient_id, schema_id = _make_patient_and_schema(session, key)
+    creator = Creator(CreatorName=f"c-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    ann = FormAnnotation(
+        FormSchemaID=schema_id,
+        PatientID=patient_id,
+        CreatorID=creator.CreatorID,
+        Inactive=inactive,
+        FormData={"answer": 1},
+    )
+    session.add(ann)
+    session.flush()
+    return ann
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal graph an ImageInstance FK-requires; return its id."""
+    project = Project(ProjectName=f"IP-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"IID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID)
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{public_id}",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_list_annotations_excludes_inactive(session):
+    """list_annotations returns only active rows (no image_id filter)."""
+    keep = _make_annotation(session, "keep")
+    _make_annotation(session, "gone", inactive=True)
+    session.commit()
+
+    rows = _service().list_annotations(
+        session,
+        patient_id=None,
+        study_id=None,
+        image_id=None,
+        form_schema_id=None,
+        sub_task_id=None,
+    )
+
+    ids = {r.FormAnnotationID for r in rows}
+    assert keep.FormAnnotationID in ids
+    assert all(not r.Inactive for r in rows)
+
+
+def test_list_annotations_unknown_image_id_raises_not_found(session):
+    """An image_id filter that resolves to nothing raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().list_annotations(
+            session,
+            patient_id=None,
+            study_id=None,
+            image_id="no-such-image",
+            form_schema_id=None,
+            sub_task_id=None,
+        )
+
+
+def test_get_annotation_unknown_raises_not_found(session):
+    """Getting a missing annotation is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_annotation(session, 999_999)
+
+
+def test_get_value_returns_form_data(session):
+    """get_value returns the annotation's FormData payload."""
+    ann = _make_annotation(session, "val")
+    session.commit()
+
+    assert _service().get_value(session, ann.FormAnnotationID) == {"answer": 1}
+
+
+def test_get_value_unknown_raises_not_found(session):
+    """get_value on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_value(session, 999_999)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_annotation_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.form_annotation_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/form_annotation_service.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import FormAnnotation
+from eyened_orm.repositories.form_annotation_repository import (
+    FormAnnotationRepository,
+)
+from eyened_orm.repositories.image_instance_repository import (
+    ImageInstanceRepository,
+)
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .exceptions import NotFoundError
+
+
+class FormAnnotationService:
+    """Business logic for FormAnnotation CRUD, values, and Tag links."""
+
+    def __init__(
+        self,
+        repository: FormAnnotationRepository,
+        image_repository: ImageInstanceRepository,
+        tag_repository: TagRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.images = image_repository
+        self.tags = tag_repository
+        self.logger = logger
+
+    def _resolve_image_instance_id(
+        self, session: Session, image_id: str | None
+    ) -> int | None:
+        """Map a PublicID to its ImageInstanceID (None passes through).
+
+        Raises:
+            NotFoundError: If a non-None image_id resolves to no instance.
+        """
+        if image_id is None:
+            return None
+        instance = self.images.get_by_public_id(session, image_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+        return instance.ImageInstanceID
+
+    def list_annotations(
+        self,
+        session: Session,
+        *,
+        patient_id: int | None,
+        study_id: int | None,
+        image_id: str | None,
+        form_schema_id: int | None,
+        sub_task_id: int | None,
+    ) -> list[FormAnnotation]:
+        """List active annotations matching the filters (resolving image_id).
+
+        Raises:
+            NotFoundError: If image_id is given but resolves to no instance.
+        """
+        image_instance_id = self._resolve_image_instance_id(session, image_id)
+        return self.repository.list_active(
+            session,
+            patient_id=patient_id,
+            study_id=study_id,
+            image_instance_id=image_instance_id,
+            form_schema_id=form_schema_id,
+            sub_task_id=sub_task_id,
+        )
+
+    def get_annotation(
+        self, session: Session, annotation_id: int
+    ) -> FormAnnotation:
+        """Return an annotation by id (with tag links loaded).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        item = self.repository.get_with_tag_links(session, annotation_id)
+        if item is None:
+            raise NotFoundError("FormAnnotation not found")
+        return item
+
+    def get_value(self, session: Session, annotation_id: int) -> Any:
+        """Return an annotation's raw FormData payload.
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        item = self.repository.get_by_id(session, annotation_id)
+        if item is None:
+            raise NotFoundError("FormAnnotation not found")
+        return item.FormData
+
+
+def get_form_annotation_service() -> FormAnnotationService:
+    """Default FormAnnotationService wiring for FastAPI ``Depends()``."""
+    return FormAnnotationService(
+        FormAnnotationRepository(),
+        ImageInstanceRepository(),
+        TagRepository(),
+        logger=get_db_logger(),
+    )
+```
+
+Update `server/services/__init__.py` (add the import + `__all__` entry, keeping all existing exports):
+
+```python
+from .form_annotation_service import FormAnnotationService
+```
+
+```python
+    "FormAnnotationService",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_annotation_service.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/form_annotation_service.py server/services/__init__.py server/tests/test_form_annotation_service.py
+git commit -m "feat(services): add FormAnnotationService reads (list, get, value)"
+```
+
+---
+
+## Task 3: FormAnnotationService — CRUD mutations (create, update, soft-delete, set-value)
+
+Add the four non-tag mutations. **create** resolves `image_id` (404 if unknown), inserts, commits, refreshes, and logs an insert; returns the new annotation. **update** loads the row (404), applies only the provided fields (`image_id` re-resolves; the field set mirrors the route's `exclude_unset` dict), commits, refreshes, and logs an update whose `changes` dict preserves the pre-refactor `None -> <new>` formatting quirk (decision #3). **soft_delete** loads the row (404), sets `Inactive = True`, commits, and logs a delete with the saved `deleted_data`. **set_value** loads the row (404), overwrites `FormData`, commits, and logs via `log_simple`.
+
+**Files:**
+- Modify: `server/services/form_annotation_service.py` (add four methods + `_FIELD_MAP`)
+- Modify: `server/tests/test_form_annotation_service.py` (append CRUD tests + `_actor` helper)
+
+**Interfaces:**
+- Consumes: `FormAnnotationRepository.get_by_id` (Task 1); `ActingUser` (existing); `eyened_orm.FormAnnotation`.
+- Produces (added to `FormAnnotationService`):
+  - `create(session, *, form_schema_id, patient_id, study_id, image_id, laterality, sub_task_id, form_data, form_annotation_reference_id, actor: ActingUser) -> FormAnnotation` — 404 if `image_id` unknown.
+  - `update(session, annotation_id: int, updates: dict[str, Any], actor: ActingUser) -> FormAnnotation` — 404 if annotation/`image_id` unknown; partial by `updates` keys.
+  - `soft_delete(session, annotation_id: int, actor: ActingUser) -> None` — 404 if absent; sets `Inactive`.
+  - `set_value(session, annotation_id: int, form_data: Any, actor: ActingUser) -> None` — 404 if absent.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_form_annotation_service.py` (add `from server.services.acting_user import ActingUser` to the top-of-file imports alongside the existing imports):
+
+```python
+def _actor(session, key: str = "actor") -> ActingUser:
+    creator = Creator(CreatorName=f"u-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def test_create_resolves_image_and_logs_insert(session):
+    """create resolves image_id, persists the row, and logs one insert."""
+    actor = _actor(session)
+    patient_id, schema_id = _make_patient_and_schema(session, "c1")
+    image_id = _make_image(session, "img-1")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    ann = _service(logger).create(
+        session,
+        form_schema_id=schema_id,
+        patient_id=patient_id,
+        study_id=None,
+        image_id="img-1",
+        laterality=None,
+        sub_task_id=None,
+        form_data={"a": 1},
+        form_annotation_reference_id=None,
+        actor=actor,
+    )
+
+    assert ann.FormAnnotationID is not None
+    assert ann.ImageInstanceID == image_id
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "FormAnnotation"
+
+
+def test_create_unknown_image_raises_not_found(session):
+    """create with an unresolvable image_id raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    patient_id, schema_id = _make_patient_and_schema(session, "c2")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().create(
+            session,
+            form_schema_id=schema_id,
+            patient_id=patient_id,
+            study_id=None,
+            image_id="no-image",
+            laterality=None,
+            sub_task_id=None,
+            form_data=None,
+            form_annotation_reference_id=None,
+            actor=actor,
+        )
+
+
+def test_update_applies_field_and_pins_changes_quirk(session):
+    """update sets a provided field; the audit changes dict reads 'None -> ...'."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "u1")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    updated = _service(logger).update(
+        session, ann.FormAnnotationID, {"form_data": {"b": 2}}, actor
+    )
+
+    assert updated.FormData == {"b": 2}
+    # Decision #3: pre-refactor quirk — snake_case getattr always yields None.
+    assert logger.updates[0]["changes"]["form_data"].startswith("None -> ")
+
+
+def test_update_unknown_raises_not_found(session):
+    """update on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().update(session, 999_999, {"form_data": {}}, _actor(session))
+
+
+def test_soft_delete_sets_inactive(session):
+    """soft_delete flags the row Inactive and logs one delete."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "d1")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).soft_delete(session, ann.FormAnnotationID, actor)
+
+    assert ann.Inactive is True
+    assert len(logger.deletes) == 1
+
+
+def test_soft_delete_unknown_raises_not_found(session):
+    """soft_delete on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().soft_delete(session, 999_999, _actor(session))
+
+
+def test_set_value_overwrites_form_data_and_logs_simple(session):
+    """set_value overwrites FormData and emits one log_simple record."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "v1")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).set_value(session, ann.FormAnnotationID, {"new": 9}, actor)
+
+    assert ann.FormData == {"new": 9}
+    assert len(logger.simples) == 1
+
+
+def test_set_value_unknown_raises_not_found(session):
+    """set_value on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().set_value(session, 999_999, {}, _actor(session))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_annotation_service.py -v`
+Expected: FAIL — `AttributeError: 'FormAnnotationService' object has no attribute 'create'`.
+
+- [ ] **Step 3: Add the four methods**
+
+Add a module-level `_FIELD_MAP` (below the imports, above the class) mapping the DTO snake_case update keys to ORM attributes, and add the four methods to `FormAnnotationService` (after `get_value`, before the module-level factory). Also extend the top-of-file import line to include `ActingUser`:
+
+```python
+# add to the existing "from .exceptions import NotFoundError" area:
+from .acting_user import ActingUser
+```
+
+```python
+# module-level, below imports and above the class:
+_FIELD_MAP = {
+    "form_schema_id": "FormSchemaID",
+    "patient_id": "PatientID",
+    "study_id": "StudyID",
+    "laterality": "Laterality",
+    "sub_task_id": "SubTaskID",
+    "form_data": "FormData",
+    "form_annotation_reference_id": "FormAnnotationReferenceID",
+}
+```
+
+```python
+    def create(
+        self,
+        session: Session,
+        *,
+        form_schema_id: int,
+        patient_id: int,
+        study_id: int | None,
+        image_id: str | None,
+        laterality: Any,
+        sub_task_id: int | None,
+        form_data: Any,
+        form_annotation_reference_id: int | None,
+        actor: ActingUser,
+    ) -> FormAnnotation:
+        """Create a FormAnnotation owned by the acting user.
+
+        Raises:
+            NotFoundError: If image_id is given but resolves to no instance.
+        """
+        image_instance_id = self._resolve_image_instance_id(session, image_id)
+        annotation = FormAnnotation(
+            FormSchemaID=form_schema_id,
+            PatientID=patient_id,
+            StudyID=study_id,
+            ImageInstanceID=image_instance_id,
+            Laterality=laterality,
+            CreatorID=actor.id,
+            SubTaskID=sub_task_id,
+            FormData=form_data,
+            FormAnnotationReferenceID=form_annotation_reference_id,
+        )
+        session.add(annotation)
+        session.commit()
+        session.refresh(annotation)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/form-annotations",
+                entity="FormAnnotation",
+                entity_id=annotation.FormAnnotationID,
+                fields={
+                    "form_schema_id": annotation.FormSchemaID,
+                    "patient_id": annotation.PatientID,
+                    "study_id": annotation.StudyID,
+                    "image_instance_id": annotation.ImageInstanceID,
+                    "sub_task_id": annotation.SubTaskID,
+                },
+            )
+        return annotation
+
+    def update(
+        self,
+        session: Session,
+        annotation_id: int,
+        updates: dict[str, Any],
+        actor: ActingUser,
+    ) -> FormAnnotation:
+        """Apply the provided (snake_case-keyed) fields to an annotation.
+
+        ``updates`` carries only the fields the client set (the route's
+        ``exclude_unset`` dict); ``image_id`` is re-resolved to an
+        ImageInstanceID.
+
+        Raises:
+            NotFoundError: If the annotation, or a given image_id, is unknown.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        if "image_id" in updates:
+            annotation.ImageInstanceID = self._resolve_image_instance_id(
+                session, updates["image_id"]
+            )
+        for key, attr in _FIELD_MAP.items():
+            if key in updates:
+                setattr(annotation, attr, updates[key])
+
+        session.commit()
+        session.refresh(annotation)
+        if self.logger is not None:
+            # Decision #3: preserve the pre-refactor audit formatting quirk —
+            # snake_case getattr on the ORM object always yields None, so every
+            # logged change reads "None -> <new>". Behavior-preserving on
+            # purpose; not an API response. A reviewer may fix separately.
+            changes = {
+                key: f"{getattr(annotation, key, None)} -> {value}"
+                for key, value in updates.items()
+            }
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/form-annotations/{annotation_id}",
+                entity="FormAnnotation",
+                entity_id=annotation_id,
+                changes=changes if changes else None,
+            )
+        return annotation
+
+    def soft_delete(
+        self, session: Session, annotation_id: int, actor: ActingUser
+    ) -> None:
+        """Soft-delete an annotation (sets Inactive; row is kept).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        deleted_data = {
+            "form_schema_id": annotation.FormSchemaID,
+            "patient_id": annotation.PatientID,
+            "study_id": annotation.StudyID,
+            "image_instance_id": annotation.ImageInstanceID,
+            "sub_task_id": annotation.SubTaskID,
+            "laterality": annotation.Laterality,
+            "creator_id": annotation.CreatorID,
+        }
+        annotation.Inactive = True
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/form-annotations/{annotation_id}",
+                entity="FormAnnotation",
+                entity_id=annotation_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+    def set_value(
+        self,
+        session: Session,
+        annotation_id: int,
+        form_data: Any,
+        actor: ActingUser,
+    ) -> None:
+        """Overwrite an annotation's FormData payload (high-frequency op).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        annotation.FormData = form_data
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_simple(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PUT /api/form-annotations/{annotation_id}/value",
+                operation="UPDATE",
+                entity="FormAnnotation",
+                entity_id=annotation_id,
+            )
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_annotation_service.py -v`
+Expected: PASS (13 passed — the 5 from Task 2 plus these 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/form_annotation_service.py server/tests/test_form_annotation_service.py
+git commit -m "feat(services): add FormAnnotationService CRUD and value mutations"
+```
+
+---
+
+## Task 4: FormAnnotationService — tag add/patch/remove
+
+Add the three tag mutations, preserving today's lookup order and failure paths: **tag** resolves the annotation (404), the tag (404), checks the tag type is `FormAnnotation` (400 → `BadRequestError`), then creates the link (or updates its comment when re-tagged with a comment). **patch_tag** resolves annotation (404), tag (404), type (400), then the link (404), and overwrites the comment if provided. **untag** resolves the annotation (404) then deletes the link if present (idempotent — no error when absent). `tag`/`patch_tag` return the `FormAnnotationTagLink` with `.Tag` set (to avoid a lazy-load at DTO time); `untag` returns `None`.
+
+**Files:**
+- Modify: `server/services/form_annotation_service.py` (add three methods)
+- Modify: `server/tests/test_form_annotation_service.py` (append tag tests + a `_make_tag` helper)
+
+**Interfaces:**
+- Consumes: `FormAnnotationRepository.get_by_id`, `.get_tag_link` (Task 1); `TagRepository.get_by_id` (existing); `ActingUser`, `BadRequestError` (existing); `eyened_orm.FormAnnotationTagLink`; `eyened_orm.tag.TagType`.
+- Produces (added to `FormAnnotationService`):
+  - `tag(session, annotation_id: int, tag_id: int, comment: str | None, actor: ActingUser) -> FormAnnotationTagLink` — create-or-update-comment; 404 annotation/tag, 400 wrong type.
+  - `patch_tag(session, annotation_id: int, tag_id: int, comment: str | None, actor: ActingUser) -> FormAnnotationTagLink` — 404 annotation/tag/link, 400 wrong type.
+  - `untag(session, annotation_id: int, tag_id: int, actor: ActingUser) -> None` — 404 annotation; idempotent delete.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_form_annotation_service.py` (add `from eyened_orm import Tag` — extend the existing `eyened_orm` import block — and `from eyened_orm.tag import TagType`, `from server.services.exceptions import BadRequestError` at the top of the file):
+
+```python
+def _make_tag(session, creator_id: int, tag_type: TagType = TagType.FormAnnotation) -> Tag:
+    tag = Tag(
+        TagName=f"t-{tag_type.name}-{creator_id}",
+        TagDescription="d",
+        TagType=tag_type,
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_tag_creates_link_and_logs(session):
+    """tag links a FormAnnotation tag, returns the link, and logs one insert."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    link = _service(logger).tag(
+        session, ann.FormAnnotationID, tag.TagID, "hi", actor
+    )
+
+    assert link.TagID == tag.TagID
+    assert link.Comment == "hi"
+    assert link.Tag.TagID == tag.TagID
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "FormAnnotationTagLink"
+
+
+def test_tag_unknown_annotation_raises_not_found(session):
+    """tag on a missing annotation is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag(session, 999_999, tag.TagID, None, actor)
+
+
+def test_tag_unknown_tag_raises_not_found(session):
+    """tag with an unknown tag id is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t2")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag(session, ann.FormAnnotationID, 999_999, None, actor)
+
+
+def test_tag_wrong_type_raises_bad_request(session):
+    """tag with a non-FormAnnotation tag raises BadRequestError (-> 400)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t3")
+    tag = _make_tag(session, actor.id, tag_type=TagType.ImageInstance)
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().tag(session, ann.FormAnnotationID, tag.TagID, None, actor)
+
+
+def test_tag_existing_updates_comment(session):
+    """A second tag with a comment updates the existing link, not duplicates."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t4")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+
+    service.tag(session, ann.FormAnnotationID, tag.TagID, "first", actor)
+    link = service.tag(session, ann.FormAnnotationID, tag.TagID, "second", actor)
+
+    assert link.Comment == "second"
+
+
+def test_patch_tag_updates_comment(session):
+    """patch_tag overwrites the comment on an existing link."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t5")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag(session, ann.FormAnnotationID, tag.TagID, "old", actor)
+
+    link = service.patch_tag(session, ann.FormAnnotationID, tag.TagID, "new", actor)
+
+    assert link.Comment == "new"
+
+
+def test_patch_tag_unknown_link_raises_not_found(session):
+    """patch_tag with no existing link raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t6")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().patch_tag(session, ann.FormAnnotationID, tag.TagID, "x", actor)
+
+
+def test_untag_removes_link(session):
+    """untag deletes the link for that (annotation, tag)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t7")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag(session, ann.FormAnnotationID, tag.TagID, None, actor)
+
+    service.untag(session, ann.FormAnnotationID, tag.TagID, actor)
+
+    assert (
+        FormAnnotationRepository().get_tag_link(
+            session, tag.TagID, ann.FormAnnotationID
+        )
+        is None
+    )
+
+
+def test_untag_absent_link_is_idempotent(session):
+    """untag with no link present is a no-op (no error)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t8")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    # Does not raise even though no link exists.
+    _service().untag(session, ann.FormAnnotationID, tag.TagID, actor)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_annotation_service.py -v`
+Expected: FAIL — `AttributeError: 'FormAnnotationService' object has no attribute 'tag'`.
+
+- [ ] **Step 3: Add the three methods**
+
+Extend the service module imports (add `FormAnnotationTagLink` to the `eyened_orm` import, add `TagType` and `BadRequestError`), then add the methods to `FormAnnotationService` (after `set_value`, before the module-level factory):
+
+```python
+# extend the existing eyened_orm import:
+from eyened_orm import FormAnnotation, FormAnnotationTagLink
+from eyened_orm.tag import TagType
+```
+
+```python
+# extend the exceptions import:
+from .exceptions import BadRequestError, NotFoundError
+```
+
+```python
+    def tag(
+        self,
+        session: Session,
+        annotation_id: int,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> FormAnnotationTagLink:
+        """Attach a Tag to an annotation (idempotent; updates comment if re-tagged).
+
+        Raises:
+            NotFoundError: If the annotation or the tag does not exist.
+            BadRequestError: If the tag is not a FormAnnotation-type tag.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.FormAnnotation:
+            raise BadRequestError("Tag type must be FormAnnotation")
+
+        link = self.repository.get_tag_link(session, tag.TagID, annotation_id)
+        if link is None:
+            link = FormAnnotationTagLink(
+                TagID=tag.TagID,
+                FormAnnotationID=annotation_id,
+                CreatorID=actor.id,
+                Comment=comment,
+            )
+            session.add(link)
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/form-annotations/{annotation_id}/tags",
+                    entity="FormAnnotationTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "form_annotation_id": annotation_id,
+                        "comment": comment,
+                    },
+                )
+        elif comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/form-annotations/{annotation_id}/tags",
+                    entity="FormAnnotationTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "form_annotation_id": annotation_id,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag  # avoid a Tag lazy-load at DTO time
+        return link
+
+    def patch_tag(
+        self,
+        session: Session,
+        annotation_id: int,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> FormAnnotationTagLink:
+        """Update the comment on an existing annotation tag link.
+
+        Raises:
+            NotFoundError: If the annotation, tag, or link does not exist.
+            BadRequestError: If the tag is not a FormAnnotation-type tag.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.FormAnnotation:
+            raise BadRequestError("Tag type must be FormAnnotation")
+
+        link = self.repository.get_tag_link(session, tag_id, annotation_id)
+        if link is None:
+            raise NotFoundError("Link not found")
+
+        if comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=(
+                        f"PATCH /api/form-annotations/{annotation_id}"
+                        f"/tags/{tag_id}"
+                    ),
+                    entity="FormAnnotationTagLink",
+                    fields={
+                        "tag_id": tag_id,
+                        "form_annotation_id": annotation_id,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag
+        return link
+
+    def untag(
+        self, session: Session, annotation_id: int, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Remove a Tag from an annotation (idempotent; no error if not linked).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        link = self.repository.get_tag_link(session, tag_id, annotation_id)
+        if link is not None:
+            deleted_data = {
+                "tag_id": tag_id,
+                "form_annotation_id": annotation_id,
+                "comment": link.Comment,
+                "creator_id": link.CreatorID,
+            }
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=(
+                        f"DELETE /api/form-annotations/{annotation_id}"
+                        f"/tags/{tag_id}"
+                    ),
+                    entity="FormAnnotationTagLink",
+                    fields={"tag_id": tag_id, "form_annotation_id": annotation_id},
+                    deleted_data=deleted_data,
+                )
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_form_annotation_service.py -v`
+Expected: PASS (22 passed — the 13 from Tasks 2–3 plus these 9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/form_annotation_service.py server/tests/test_form_annotation_service.py
+git commit -m "feat(services): add FormAnnotationService tag add/patch/remove"
+```
+
+---
+
+## Task 5: Route `form_annotations.py` through `FormAnnotationService`
+
+Rewrite every DB-touching handler to be thin: parse → build `ActingUser` (mutations only) → call `FormAnnotationService` → `DTOConverter` → return. No handler contains inline queries, the `_resolve_image_instance_id` helper, `raise HTTPException` for not-found/wrong-type, `session.commit`, or direct `get_db_logger()` calls anymore — those move into the Service; the central `NotFoundError`/`BadRequestError` handlers (already registered) map the 404s/400s. DTO conversion stays at the boundary and keeps its exact `form_annotation_to_get(row)` call (default `with_tag_metadata=False`). Verified by the full suite still passing and an app-boot smoke check — matching how the earlier route slices were verified (no route-level test files exist for these slices).
+
+**Files:**
+- Modify: `server/routes/form_annotations.py` (rewrite the whole module)
+
+**Interfaces:**
+- Consumes: `FormAnnotationService`, `get_form_annotation_service` (Tasks 2–4); `ActingUser` (existing); `DTOConverter` (existing).
+- Produces: no new symbols — this is the HTTP boundary.
+
+- [ ] **Step 1: Rewrite the route module**
+
+Replace the entire contents of `server/routes/form_annotations.py` with:
+
+```python
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_aux import ObjectTagPATCH, ObjectTagPOST, TagMeta
+from ..dtos.dtos_main import (
+    FormAnnotationGET,
+    FormAnnotationPATCH,
+    FormAnnotationPUT,
+)
+from ..services.acting_user import ActingUser
+from ..services.form_annotation_service import (
+    FormAnnotationService,
+    get_form_annotation_service,
+)
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/form-annotations", response_model=FormAnnotationGET)
+async def create_form_annotation(
+    annotation: FormAnnotationPUT,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Create a form annotation."""
+    item = service.create(
+        db,
+        actor=ActingUser(id=current_user.id, username=current_user.username),
+        **annotation.dict(),
+    )
+    return DTOConverter.form_annotation_to_get(item)
+
+
+@router.get("/form-annotations", response_model=List[FormAnnotationGET])
+async def get_form_annotations(
+    patient_id: Optional[int] = None,
+    study_id: Optional[int] = None,
+    image_id: Optional[str] = None,
+    form_schema_id: Optional[int] = None,
+    sub_task_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """List active form annotations, optionally filtered."""
+    rows = service.list_annotations(
+        db,
+        patient_id=patient_id,
+        study_id=study_id,
+        image_id=image_id,
+        form_schema_id=form_schema_id,
+        sub_task_id=sub_task_id,
+    )
+    return [DTOConverter.form_annotation_to_get(row) for row in rows]
+
+
+@router.get("/form-annotations/{annotation_id}", response_model=FormAnnotationGET)
+async def get_form_annotation(
+    annotation_id: int,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single form annotation by id."""
+    item = service.get_annotation(db, annotation_id)
+    return DTOConverter.form_annotation_to_get(item)
+
+
+@router.patch("/form-annotations/{annotation_id}", response_model=FormAnnotationGET)
+async def update_form_annotation(
+    annotation_id: int,
+    annotation: FormAnnotationPATCH,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Partially update a form annotation."""
+    item = service.update(
+        db,
+        annotation_id,
+        annotation.dict(exclude_unset=True),
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.form_annotation_to_get(item)
+
+
+@router.delete("/form-annotations/{annotation_id}", status_code=204)
+async def delete_form_annotation(
+    annotation_id: int,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Soft-delete a form annotation."""
+    service.soft_delete(
+        db,
+        annotation_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.get("/form-annotations/{form_annotation_id}/value")
+async def get_form_annotation_value(
+    form_annotation_id: int,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a form annotation's raw FormData payload."""
+    return service.get_value(db, form_annotation_id)
+
+
+@router.put("/form-annotations/{form_annotation_id}/value", status_code=204)
+async def update_form_annotation_value(
+    form_annotation_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Overwrite a form annotation's FormData payload."""
+    form_data = await request.json()
+    service.set_value(
+        db,
+        form_annotation_id,
+        form_data,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.post("/form-annotations/{annotation_id}/tags", response_model=TagMeta)
+async def tag_form_annotation(
+    annotation_id: int,
+    body: ObjectTagPOST,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
+    """Attach a Tag to a FormAnnotation by tag ID (idempotent)."""
+    link = service.tag(
+        db,
+        annotation_id,
+        body.tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.link_to_tag_metadata(link)
+
+
+@router.delete("/form-annotations/{annotation_id}/tags/{tag_id}", status_code=204)
+async def untag_form_annotation(
+    annotation_id: int,
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Remove a Tag from a FormAnnotation (idempotent)."""
+    service.untag(
+        db,
+        annotation_id,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.patch(
+    "/form-annotations/{annotation_id}/tags/{tag_id}", response_model=TagMeta
+)
+async def patch_form_annotation_tag(
+    annotation_id: int,
+    tag_id: int,
+    body: ObjectTagPATCH,
+    db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
+    """Update comment on an existing FormAnnotation tag link."""
+    link = service.patch_tag(
+        db,
+        annotation_id,
+        tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.link_to_tag_metadata(link)
+```
+
+- [ ] **Step 2: App-boot smoke check (imports + routes register)**
+
+> **Note:** the routers are mounted as a sub-app (`server/main.py` does `app.mount("/api", app_api)`), so the route paths live on **`app_api.routes`** and carry **no** `/api` prefix. Introspect `app_api`, not `app`.
+
+Run:
+
+```bash
+EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password \
+  dev/.venv/bin/python -c "
+from server.main import app_api
+paths = {r.path for r in app_api.routes}
+for p in [
+    '/form-annotations',
+    '/form-annotations/{annotation_id}',
+    '/form-annotations/{form_annotation_id}/value',
+    '/form-annotations/{annotation_id}/tags',
+    '/form-annotations/{annotation_id}/tags/{tag_id}',
+]:
+    assert p in paths, (p, sorted(x for x in paths if 'form-annotation' in x))
+print('form-annotation routes OK')
+"
+```
+
+Expected: prints `form-annotation routes OK` (the app imports cleanly and every route is registered on the mounted `/api` sub-app).
+
+- [ ] **Step 3: Run the full suite to confirm no regression**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: PASS — **251 passed** (227 baseline + 2 repository tests from Task 1 + 22 service tests from Tasks 2–4), no failures. (If your Task 0 baseline differed, the total is that baseline + 24.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/form_annotations.py
+git commit -m "refactor(routes): route form-annotation endpoints through FormAnnotationService"
+```
+
+---
+
+## Phase 4b done — second slice of spec Phase 4
+
+After Task 5, `form_annotations.py` no longer queries the ORM directly: it parses, calls `FormAnnotationService`, and converts DTOs. Do **not** merge `feature/rbac-step1-service-layer` to `development`; the last slice is spec **Phase 4c** (`segmentations.py`), a separate plan — it can reuse the `ImageInstanceRepository` resolvers and the `TagRepository` guard established here.
+
+Update the `rbac-step1-migration-state` memory: form_annotations (4b) done; Phase 4c (`segmentations.py`) is the only remaining slice; test count **251**.
+```

--- a/docs/superpowers/plans/2026-07-10-instances-phase4a.md
+++ b/docs/superpowers/plans/2026-07-10-instances-phase4a.md
@@ -1,0 +1,1238 @@
+# instances Repository/Service Migration (RBAC Step 1, Phase 4a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the `instances.py` endpoints — the two `ImageInstance` graph reads (`GET /instances/{id}`, `GET /images/{public_id}`), the storage-redirect reads (`GET /images/{id}/data`, `/thumbnail`), and the three instance-tag mutations (`POST/PATCH/DELETE /instances/{id}/tags[/{tag_id}]`) — through a new `ImageInstanceService` backed by a new `ImageInstanceRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as the shipped Device/Patient/FormSchema/Study/Feature/Tag/Task/SubTask slices — thin route (parse → build `ActingUser` → Service → `DTOConverter` → return), a Service with constructor-injected Repositories that raises domain exceptions and owns the commit, and a framework-agnostic Repository that takes a `Session`. This is the **first slice of the spec's Phase 4** (the largest, most complex phase); `form_annotations.py` (4b) and `segmentations.py` (4c) follow as their own plans. `ImageInstanceRepository` created here (with `PublicID`→instance resolution) is reused by 4b/4c.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model module — `image_instance_repository.py`, `image_instance_service.py`.
+- **Class names:** `ImageInstanceRepository` / `ImageInstanceService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repositories via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `import_api.py`, `Base`'s generic classmethods, or any pre-existing shipped slice.
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions reused from earlier phases
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session that is only *closed*, never committed, by its context manager. Every mutating Service method calls `session.commit()` itself — the Service is the transaction boundary. (The spec's deferred "transaction ownership" follow-up will revisit this layer-wide; do not change it here.)
+- **Audit logging is injected, not global-reached.** The Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the mutating method, guarded by `if self.logger is not None:`. The default factory wires the real logger via `get_db_logger()` (which returns `None` when DB logging is disabled); Service tests inject `None` or a small hand-rolled fake.
+- **Acting user:** routes map their handler-layer `CurrentUser` onto the framework-agnostic `ActingUser(id, username)` value object (`server/services/acting_user.py`, already exists) before calling a mutating Service method.
+- **Lean test granularity:** thin `session.get(...)` wrappers get **no** dedicated Repository test — they are exercised through the Service tests. Every test carries a one-line docstring as its description.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`. The two commands that import `server.*` (app-boot / router-introspection checks) need dummy DB env vars, mirroring `server/tests/conftest.py`: prefix them with `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer`:** `NotFoundError` **and `BadRequestError`** (400) already exist in `server/services/exceptions.py`, registered in `server/main.py` via `register_exception_handlers` — the single handler dispatches every `ServiceError` subclass by MRO, so **this phase needs no `main.py` change**. `ActingUser`, `TagRepository` (`get_by_id`), the `session` fixture in `server/tests/conftest.py`, and both `repositories/`/`services/` packages with their `__init__.py` re-exports all already exist. **`instances.router` is already registered** in `server/main.py` (`app_api.include_router(instances.router)`), so no registration change is needed.
+
+> **Existing facts confirmed for this plan** (verified against the route source and the ORM):
+> - `ImageInstance` (`orm/eyened_orm/image_instance.py:187`): `ImageInstanceID` (int PK); `PublicID` (`str`, the external id the API resolves, `_name_column`); relationships `Series`→`Study`→`Patient`→`Project`, `DeviceInstance`→`DeviceModel`, `Scan` (nullable), `ImageStorages`→`StorageBackend`, `ImageInstanceTagLinks`, `Segmentations`, `FormAnnotations`, `ModelSegmentations`.
+> - `ImageInstanceTagLink` (`orm/eyened_orm/tag.py:135`): **composite PK `(TagID, ImageInstanceID)`**, both FKs `ondelete="CASCADE"`; `CreatorID` (FK, NOT NULL); `Comment` (`String(256)`, nullable); `Tag`/`ImageInstance` relationships, `Creator` (`lazy="selectin"`). So `session.get(ImageInstanceTagLink, {"TagID": ..., "ImageInstanceID": ...})` is the by-key lookup.
+> - `Tag` (`orm/eyened_orm/tag.py:46`): `TagID` (PK); `TagName`, `TagType` (`SAEnum(TagType)`), **`TagDescription` (NOT NULL)**, `CreatorID` (NOT NULL). `TagType` members include `ImageInstance`, `Segmentation`, `FormAnnotation`.
+> - A real `ImageInstance` row FK-requires a `Series`→`Study`→`Patient`→`Project` chain **and** a `DeviceInstance`→`DeviceModel`. The `_make_image` helper below builds exactly that minimal graph (mirrors the one added to `test_task_repository.py` in phase 3).
+
+> **DTO facts confirmed:** `DTOConverter.image_instance_to_get(item, with_tag_metadata=, with_segmentations=, with_form_annotations=, with_model_segmentations=)` and `DTOConverter.link_to_tag_metadata(link)` are the two converters the route uses; both stay in the route. `ImageGET`/`TagMeta`/`ObjectTagPOST`/`ObjectTagPATCH` DTOs are unchanged.
+
+> **Behavior-preserving decisions (call out in review):**
+> 1. **The wrong-tag-type check (`Tag.TagType != TagType.ImageInstance`) becomes a `BadRequestError` (400)** in the Service instead of an inline `HTTPException(400)`. Same wire status (400); the central handler maps it.
+> 2. **The legacy `PublicID` resolvers keep their exact fallback behavior.** `_get_image_instance_by_public_id` (storage-loaded, try `PublicID` then fall back to `session.get(ImageInstance, public_id)` on `NoResultFound`) and the `GET /images/{id}` reader (try `PublicID`, else `session.get(ImageInstance, int(image_id))` when `image_id.isdigit()`) are moved verbatim into `ImageInstanceRepository` methods that return `None` (never raise); the Service raises `NotFoundError`. The stray `print(...)` warning in the old fallback is dropped (logging noise, not behavior).
+> 3. **Storage-ref resolution and the `X-Accel-Redirect` response building stay in the route.** The Service only resolves the `ImageInstance` (raising `NotFoundError` if absent) for the `/data` and `/thumbnail` endpoints; `resolve_image_data_ref` / `resolve_thumbnail_ref` (framework-agnostic `eyened_orm` helpers) and the `index < 0` (400) / `ValueError` (422) request-shaped validation remain at the HTTP boundary, as they are not model-CRUD.
+> 4. **The two pure-redirect endpoints** (`GET /instances/images/{dataset_identifier:path}`, `GET /instances/thumbnails/{thumbnail_identifier:path}`) touch no DB and are left **exactly as-is** — no Service involvement.
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: the existing suite passes (baseline: **211 passed**). **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+## Task 1: ImageInstanceRepository — graph reads, PublicID resolution, tag-link lookup
+
+Create `ImageInstanceRepository` with the reads the `instances.py` handlers perform inline today: the conditional eager-load graph (shared by the by-id and by-PublicID readers), the storage-loaded PublicID resolver used by the data/thumbnail/tag handlers, and a composite-key tag-link lookup. Following precedent (lean test granularity), the two thin `session.get(...)`-shaped methods get no dedicated Repository test: `get_tag_link` is exercised through the Task 3 Service tests, and `get_full_graph_by_id` (a plain `session.get` + shared options builder) through the Task 2 Service tests. The two tests here cover the methods with real branching — the PublicID/digit fallback (with every eager-load branch on) and the storage-resolver fallback. No method commits; the Service owns the transaction boundary.
+
+**Files:**
+- Create: `orm/eyened_orm/repositories/image_instance_repository.py`
+- Modify: `orm/eyened_orm/repositories/__init__.py` (re-export `ImageInstanceRepository`)
+- Test: `orm/eyened_orm/tests/test_image_instance_repository.py`
+
+**Interfaces:**
+- Consumes: `eyened_orm` models `ImageInstance`, `ImageInstanceTagLink`, `ImageStorage`, `Series`, `Study`, `Patient`, `DeviceInstance`, `Segmentation`, `ModelSegmentation`, `FormAnnotation`; `eyened_orm.tag.SegmentationTagLink`, `FormAnnotationTagLink`.
+- Produces (all take `session: Session` first):
+  - `get_full_graph_by_id(session, instance_id: int, *, with_segmentations: bool, with_form_annotations: bool, with_model_segmentations: bool) -> ImageInstance | None`
+  - `get_full_graph_by_public_id(session, image_id: str, *, with_segmentations: bool, with_form_annotations: bool, with_model_segmentations: bool) -> ImageInstance | None` — try `PublicID`, else `session.get(int(image_id))` when `image_id.isdigit()`.
+  - `get_with_storage_by_public_id(session, public_id: str) -> ImageInstance | None` — storage-loaded, with the legacy `session.get(public_id)` fallback.
+  - `get_tag_link(session, tag_id: int, image_instance_id: int) -> ImageInstanceTagLink | None` — thin composite-key `session.get`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `orm/eyened_orm/tests/test_image_instance_repository.py`:
+
+```python
+import datetime
+
+from eyened_orm import (
+    DeviceInstance,
+    DeviceModel,
+    ImageInstance,
+    Patient,
+    Project,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal Series/Device graph an ImageInstance FK-requires.
+
+    Returns the new ImageInstanceID.
+    """
+    project = Project(ProjectName=f"P-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{public_id}",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_get_full_graph_by_public_id_resolves_graph_and_digit_fallback(session):
+    """Resolve by PublicID (all eager-load branches on), else by numeric PK string."""
+    image_id = _make_image(session, "pub-str")
+    _make_image(session, "9999")  # a PublicID that is itself a digit string
+    repo = ImageInstanceRepository()
+    # all flags True so the conditional selectinload branches are exercised
+    kw = dict(
+        with_segmentations=True,
+        with_form_annotations=True,
+        with_model_segmentations=True,
+    )
+
+    by_public = repo.get_full_graph_by_public_id(session, "pub-str", **kw)
+    assert by_public is not None and by_public.ImageInstanceID == image_id
+    assert by_public.Series.Study.Patient.Project is not None  # base graph loaded
+
+    # A numeric string that is not a PublicID falls back to session.get(int)
+    by_pk = repo.get_full_graph_by_public_id(session, str(image_id), **kw)
+    assert by_pk is not None and by_pk.ImageInstanceID == image_id
+
+    assert repo.get_full_graph_by_public_id(session, "no-such-id", **kw) is None
+
+
+def test_get_with_storage_by_public_id_found_and_missing(session):
+    """get_with_storage_by_public_id resolves by PublicID, or None if absent."""
+    image_id = _make_image(session, "pub-store")
+    repo = ImageInstanceRepository()
+
+    item = repo.get_with_storage_by_public_id(session, "pub-store")
+    assert item is not None and item.ImageInstanceID == image_id
+
+    assert repo.get_with_storage_by_public_id(session, "missing") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_image_instance_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'eyened_orm.repositories.image_instance_repository'`.
+
+- [ ] **Step 3: Write the repository**
+
+Create `orm/eyened_orm/repositories/image_instance_repository.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import (
+    DeviceInstance,
+    FormAnnotation,
+    ImageInstance,
+    ImageInstanceTagLink,
+    ImageStorage,
+    ModelSegmentation,
+    Patient,
+    Segmentation,
+    Series,
+    Study,
+)
+from eyened_orm.tag import FormAnnotationTagLink, SegmentationTagLink
+
+_STORAGE_LOADER = selectinload(ImageInstance.ImageStorages).selectinload(
+    ImageStorage.StorageBackend
+)
+
+
+def _full_graph_options(
+    with_segmentations: bool,
+    with_form_annotations: bool,
+    with_model_segmentations: bool,
+) -> list:
+    """Build the conditional selectinload chain the two GET readers share."""
+    opts = [
+        selectinload(ImageInstance.Series)
+        .selectinload(Series.Study)
+        .selectinload(Study.Patient)
+        .selectinload(Patient.Project),
+        selectinload(ImageInstance.DeviceInstance).selectinload(
+            DeviceInstance.DeviceModel
+        ),
+        selectinload(ImageInstance.Scan),
+        _STORAGE_LOADER,
+        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
+            ImageInstanceTagLink.Tag
+        ),
+        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
+            ImageInstanceTagLink.Creator
+        ),
+    ]
+    if with_segmentations:
+        opts += [
+            selectinload(ImageInstance.Segmentations).selectinload(
+                Segmentation.Feature
+            ),
+            selectinload(ImageInstance.Segmentations).selectinload(
+                Segmentation.Creator
+            ),
+            selectinload(ImageInstance.Segmentations)
+            .selectinload(Segmentation.SegmentationTagLinks)
+            .selectinload(SegmentationTagLink.Tag),
+            selectinload(ImageInstance.Segmentations)
+            .selectinload(Segmentation.SegmentationTagLinks)
+            .selectinload(SegmentationTagLink.Creator),
+        ]
+    if with_form_annotations:
+        opts += [
+            selectinload(ImageInstance.FormAnnotations)
+            .selectinload(FormAnnotation.FormAnnotationTagLinks)
+            .selectinload(FormAnnotationTagLink.Tag),
+            selectinload(ImageInstance.FormAnnotations)
+            .selectinload(FormAnnotation.FormAnnotationTagLinks)
+            .selectinload(FormAnnotationTagLink.Creator),
+        ]
+    if with_model_segmentations:
+        opts += [
+            selectinload(ImageInstance.ModelSegmentations).selectinload(
+                ModelSegmentation.Model
+            ),
+        ]
+    return opts
+
+
+class ImageInstanceRepository:
+    """Data access for ImageInstance reads and its Tag links."""
+
+    def get_full_graph_by_id(
+        self,
+        session: Session,
+        instance_id: int,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance | None:
+        """Return the instance by int id with the conditional graph, or None."""
+        opts = _full_graph_options(
+            with_segmentations, with_form_annotations, with_model_segmentations
+        )
+        return session.get(ImageInstance, instance_id, options=tuple(opts))
+
+    def get_full_graph_by_public_id(
+        self,
+        session: Session,
+        image_id: str,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance | None:
+        """Return the instance by PublicID (numeric-PK fallback), or None."""
+        opts = _full_graph_options(
+            with_segmentations, with_form_annotations, with_model_segmentations
+        )
+        item = (
+            session.scalars(
+                select(ImageInstance)
+                .options(*opts)
+                .where(ImageInstance.PublicID == image_id)
+            )
+            .first()
+        )
+        if item is None and image_id.isdigit():
+            item = session.get(ImageInstance, int(image_id), options=tuple(opts))
+        return item
+
+    def get_with_storage_by_public_id(
+        self, session: Session, public_id: str
+    ) -> ImageInstance | None:
+        """Return the instance by PublicID with storage loaded (PK fallback), or None.
+
+        Mirrors the legacy ``_get_image_instance_by_public_id`` resolver: try the
+        PublicID; on no match fall back to ``session.get`` with the raw id.
+        """
+        try:
+            return session.scalars(
+                select(ImageInstance)
+                .options(_STORAGE_LOADER)
+                .where(ImageInstance.PublicID == public_id)
+            ).one()
+        except NoResultFound:
+            return session.get(ImageInstance, public_id)
+
+    def get_tag_link(
+        self, session: Session, tag_id: int, image_instance_id: int
+    ) -> ImageInstanceTagLink | None:
+        """Return the link for (tag_id, image_instance_id), or None if absent."""
+        return session.get(
+            ImageInstanceTagLink,
+            {"TagID": tag_id, "ImageInstanceID": image_instance_id},
+        )
+```
+
+Update `orm/eyened_orm/repositories/__init__.py` (add the import + `__all__` entry, keeping all existing exports):
+
+```python
+from .image_instance_repository import ImageInstanceRepository
+```
+
+```python
+    "ImageInstanceRepository",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_image_instance_repository.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/image_instance_repository.py orm/eyened_orm/repositories/__init__.py orm/eyened_orm/tests/test_image_instance_repository.py
+git commit -m "feat(repositories): add ImageInstanceRepository reads and tag-link lookup"
+```
+
+---
+
+## Task 2: ImageInstanceService — instance reads
+
+Create `ImageInstanceService` with the three read paths the handlers use: by-id graph read, by-PublicID graph read, and storage-resolution for the data/thumbnail endpoints. The only failure path is a missing instance (`NotFoundError` → 404). The constructor takes `ImageInstanceRepository` **and** `TagRepository` (the tag mutations in Task 3 need it); the default factory wires both plus the real logger.
+
+**Files:**
+- Create: `server/services/image_instance_service.py`
+- Modify: `server/services/__init__.py` (re-export `ImageInstanceService`)
+- Test: `server/tests/test_image_instance_service.py`
+
+**Interfaces:**
+- Consumes: `ImageInstanceRepository` (Task 1); `TagRepository` (existing); `NotFoundError`, `BadRequestError` (existing); `ActingUser` (existing); `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.ImageInstance`.
+- Produces:
+  - `ImageInstanceService(repository: ImageInstanceRepository, tag_repository: TagRepository, logger: DatabaseModificationLogger | None = None)`
+  - `get_instance(session, instance_id: int, *, with_segmentations: bool, with_form_annotations: bool, with_model_segmentations: bool) -> ImageInstance` — 404 if absent.
+  - `get_by_public_id(session, image_id: str, *, with_segmentations: bool, with_form_annotations: bool, with_model_segmentations: bool) -> ImageInstance` — 404 if absent.
+  - `get_for_storage(session, public_id: str) -> ImageInstance` — storage-loaded resolver for the data/thumbnail endpoints; 404 if absent.
+  - `get_image_instance_service() -> ImageInstanceService` — default-wiring factory.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_image_instance_service.py`:
+
+```python
+import datetime
+
+import pytest
+
+from eyened_orm import (
+    DeviceInstance,
+    DeviceModel,
+    ImageInstance,
+    Patient,
+    Project,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.exceptions import NotFoundError
+from server.services.image_instance_service import ImageInstanceService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal graph an ImageInstance FK-requires; return its id."""
+    project = Project(ProjectName=f"P-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{public_id}",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def _service(logger=None) -> ImageInstanceService:
+    return ImageInstanceService(
+        ImageInstanceRepository(), TagRepository(), logger=logger
+    )
+
+
+_READ_KW = dict(
+    with_segmentations=False,
+    with_form_annotations=False,
+    with_model_segmentations=False,
+)
+
+
+def test_get_instance_returns_it(session):
+    """get_instance returns the instance at the given id."""
+    image_id = _make_image(session, "pub-1")
+    session.commit()
+
+    got = _service().get_instance(session, image_id, **_READ_KW)
+
+    assert got.ImageInstanceID == image_id
+
+
+def test_get_instance_unknown_raises_not_found(session):
+    """Getting a missing instance is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_instance(session, 999_999, **_READ_KW)
+
+
+def test_get_by_public_id_unknown_raises_not_found(session):
+    """Resolving a missing PublicID is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_by_public_id(session, "nope", **_READ_KW)
+
+
+def test_get_for_storage_unknown_raises_not_found(session):
+    """get_for_storage on a missing PublicID raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_for_storage(session, "missing")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_image_instance_service.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.services.image_instance_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `server/services/image_instance_service.py`:
+
+```python
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import ImageInstance
+from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .exceptions import NotFoundError
+
+
+class ImageInstanceService:
+    """Business logic for ImageInstance reads and its Tag links."""
+
+    def __init__(
+        self,
+        repository: ImageInstanceRepository,
+        tag_repository: TagRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.tags = tag_repository
+        self.logger = logger
+
+    def get_instance(
+        self,
+        session: Session,
+        instance_id: int,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance:
+        """Return an instance by int id, with the requested eager-load graph.
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        item = self.repository.get_full_graph_by_id(
+            session,
+            instance_id,
+            with_segmentations=with_segmentations,
+            with_form_annotations=with_form_annotations,
+            with_model_segmentations=with_model_segmentations,
+        )
+        if item is None:
+            raise NotFoundError("ImageInstance not found")
+        return item
+
+    def get_by_public_id(
+        self,
+        session: Session,
+        image_id: str,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance:
+        """Return an instance by PublicID, with the requested eager-load graph.
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        item = self.repository.get_full_graph_by_public_id(
+            session,
+            image_id,
+            with_segmentations=with_segmentations,
+            with_form_annotations=with_form_annotations,
+            with_model_segmentations=with_model_segmentations,
+        )
+        if item is None:
+            raise NotFoundError("ImageInstance not found")
+        return item
+
+    def get_for_storage(self, session: Session, public_id: str) -> ImageInstance:
+        """Return the storage-loaded instance for a data/thumbnail request.
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        item = self.repository.get_with_storage_by_public_id(session, public_id)
+        if item is None:
+            raise NotFoundError("ImageInstance not found")
+        return item
+
+
+def get_image_instance_service() -> ImageInstanceService:
+    """Default ImageInstanceService wiring for FastAPI ``Depends()``."""
+    return ImageInstanceService(
+        ImageInstanceRepository(), TagRepository(), logger=get_db_logger()
+    )
+```
+
+Update `server/services/__init__.py` (add the import + `__all__` entry, keeping all existing exports):
+
+```python
+from .image_instance_service import ImageInstanceService
+```
+
+```python
+    "ImageInstanceService",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_image_instance_service.py -v`
+Expected: PASS (4 passed). (`get_instance` carries the base-graph happy path; the `get_by_public_id`/`get_for_storage` happy paths are already covered by the Task 1 repository tests, so only their `NotFoundError` translation is asserted here.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/image_instance_service.py server/services/__init__.py server/tests/test_image_instance_service.py
+git commit -m "feat(services): add ImageInstanceService instance reads"
+```
+
+---
+
+## Task 3: ImageInstanceService — instance tag add/patch/remove
+
+Add the three instance-tag mutations. Each preserves today's lookup order and failure paths: **tag_instance** resolves the instance (404), the tag (404), checks the tag type (400 → `BadRequestError`), then creates the link (or updates its comment if it already exists); **patch_instance_tag** resolves instance (404), tag (404), type (400), then the link (404), and updates the comment if provided; **untag_instance** resolves the instance (404) then deletes the link if present (idempotent — no error when the link is absent). Each returns the `ImageInstanceTagLink` (with `.Tag` set to avoid a lazy-load) for the route to convert, except `untag_instance` which returns `None`.
+
+**Files:**
+- Modify: `server/services/image_instance_service.py` (add three methods)
+- Modify: `server/tests/test_image_instance_service.py` (append tag tests + a `_make_tag` helper)
+
+**Interfaces:**
+- Consumes: `ImageInstanceRepository.get_with_storage_by_public_id`, `.get_tag_link` (Task 1); `TagRepository.get_by_id` (existing); `ActingUser`, `BadRequestError` (existing); `eyened_orm.ImageInstanceTagLink`; `eyened_orm.tag.TagType`.
+- Produces (added to `ImageInstanceService`):
+  - `tag_instance(session, public_id: str, tag_id: int, comment: str | None, actor: ActingUser) -> ImageInstanceTagLink` — create-or-update-comment; 404 instance/tag, 400 wrong type.
+  - `patch_instance_tag(session, public_id: str, tag_id: int, comment: str | None, actor: ActingUser) -> ImageInstanceTagLink` — 404 instance/tag/link, 400 wrong type.
+  - `untag_instance(session, public_id: str, tag_id: int, actor: ActingUser) -> None` — 404 instance; idempotent delete.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_image_instance_service.py` (add the imports `ActingUser`, `BadRequestError`, `Creator`, `Tag`, `TagType` at the top of the file alongside the existing imports):
+
+```python
+# add to the existing imports at the top of the file:
+from eyened_orm import Creator, Tag
+from eyened_orm.tag import TagType
+from server.services.acting_user import ActingUser
+from server.services.exceptions import BadRequestError
+```
+
+```python
+def _actor(session) -> ActingUser:
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _make_tag(session, creator_id: int, tag_type: TagType = TagType.ImageInstance) -> Tag:
+    tag = Tag(
+        TagName=f"t-{tag_type.name}",
+        TagDescription="d",
+        TagType=tag_type,
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_tag_instance_creates_link(session):
+    """tag_instance links a tag to an instance and returns the link."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    link = _service().tag_instance(session, "pub-1", tag.TagID, "hi", actor)
+
+    assert link.TagID == tag.TagID
+    assert link.Comment == "hi"
+    assert link.Tag.TagID == tag.TagID
+
+
+def test_tag_instance_unknown_instance_raises_not_found(session):
+    """tag_instance on a missing instance is translated to NotFoundError."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag_instance(session, "nope", tag.TagID, None, actor)
+
+
+def test_tag_instance_unknown_tag_raises_not_found(session):
+    """tag_instance with an unknown tag id is translated to NotFoundError."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag_instance(session, "pub-1", 999_999, None, actor)
+
+
+def test_tag_instance_wrong_tag_type_raises_bad_request(session):
+    """tag_instance with a non-ImageInstance tag raises BadRequestError (-> 400)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id, tag_type=TagType.Segmentation)
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().tag_instance(session, "pub-1", tag.TagID, None, actor)
+
+
+def test_tag_instance_existing_updates_comment(session):
+    """A second tag_instance with a comment updates the existing link, not duplicates."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+
+    service.tag_instance(session, "pub-1", tag.TagID, "first", actor)
+    link = service.tag_instance(session, "pub-1", tag.TagID, "second", actor)
+
+    assert link.Comment == "second"
+
+
+def test_tag_instance_logs_insert(session):
+    """tag_instance emits one insert audit record for ImageInstanceTagLink."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).tag_instance(session, "pub-1", tag.TagID, None, actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "ImageInstanceTagLink"
+
+
+def test_patch_instance_tag_updates_comment(session):
+    """patch_instance_tag overwrites the comment on an existing link."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag_instance(session, "pub-1", tag.TagID, "old", actor)
+
+    link = service.patch_instance_tag(session, "pub-1", tag.TagID, "new", actor)
+
+    assert link.Comment == "new"
+
+
+def test_patch_instance_tag_unknown_link_raises_not_found(session):
+    """patch_instance_tag with no existing link raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().patch_instance_tag(session, "pub-1", tag.TagID, "x", actor)
+
+
+def test_untag_instance_removes_link(session):
+    """untag_instance deletes the link for that (instance, tag)."""
+    actor = _actor(session)
+    image_id = _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag_instance(session, "pub-1", tag.TagID, None, actor)
+
+    service.untag_instance(session, "pub-1", tag.TagID, actor)
+
+    assert ImageInstanceRepository().get_tag_link(session, tag.TagID, image_id) is None
+
+
+def test_untag_instance_absent_link_is_idempotent(session):
+    """untag_instance with no link present is a no-op (no error)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    # Does not raise even though no link exists.
+    _service().untag_instance(session, "pub-1", tag.TagID, actor)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_image_instance_service.py -v`
+Expected: FAIL — `AttributeError: 'ImageInstanceService' object has no attribute 'tag_instance'`.
+
+- [ ] **Step 3: Add the three methods**
+
+Add `ImageInstanceTagLink` and `TagType` to the top-of-file imports and `ActingUser`/`BadRequestError` to the service module, then add the methods to `ImageInstanceService` (after `get_for_storage`, before the module-level factory):
+
+```python
+# extend the top-of-file imports:
+from eyened_orm import ImageInstance, ImageInstanceTagLink
+from eyened_orm.tag import TagType
+```
+
+```python
+# add to the existing "from .exceptions import ..." line and add ActingUser:
+from .acting_user import ActingUser
+from .exceptions import BadRequestError, NotFoundError
+```
+
+```python
+    def tag_instance(
+        self,
+        session: Session,
+        public_id: str,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> ImageInstanceTagLink:
+        """Attach a Tag to an instance (idempotent; updates comment if re-tagged).
+
+        Raises:
+            NotFoundError: If the instance or the tag does not exist.
+            BadRequestError: If the tag is not an ImageInstance-type tag.
+        """
+        instance = self.repository.get_with_storage_by_public_id(session, public_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.ImageInstance:
+            raise BadRequestError("Tag type must be ImageInstance")
+
+        link = self.repository.get_tag_link(
+            session, tag.TagID, instance.ImageInstanceID
+        )
+        if link is None:
+            link = ImageInstanceTagLink(
+                TagID=tag.TagID,
+                ImageInstanceID=instance.ImageInstanceID,
+                CreatorID=actor.id,
+                Comment=comment,
+            )
+            session.add(link)
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/instances/{public_id}/tags",
+                    entity="ImageInstanceTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "image_instance_id": instance.ImageInstanceID,
+                        "comment": comment,
+                    },
+                )
+        elif comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/instances/{public_id}/tags",
+                    entity="ImageInstanceTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "image_instance_id": public_id,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag  # avoid a Tag lazy-load at DTO time
+        return link
+
+    def patch_instance_tag(
+        self,
+        session: Session,
+        public_id: str,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> ImageInstanceTagLink:
+        """Update the comment on an existing instance tag link.
+
+        Raises:
+            NotFoundError: If the instance, tag, or link does not exist.
+            BadRequestError: If the tag is not an ImageInstance-type tag.
+        """
+        instance = self.repository.get_with_storage_by_public_id(session, public_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.ImageInstance:
+            raise BadRequestError("Tag type must be ImageInstance")
+
+        link = self.repository.get_tag_link(
+            session, tag_id, instance.ImageInstanceID
+        )
+        if link is None:
+            raise NotFoundError("Link not found")
+
+        if comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"PATCH /api/instances/{public_id}/tags/{tag_id}",
+                    entity="ImageInstanceTagLink",
+                    fields={
+                        "tag_id": tag_id,
+                        "image_instance_id": instance.ImageInstanceID,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag
+        return link
+
+    def untag_instance(
+        self, session: Session, public_id: str, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Remove a Tag from an instance (idempotent; no error if not linked).
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        instance = self.repository.get_with_storage_by_public_id(session, public_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+
+        link = self.repository.get_tag_link(
+            session, tag_id, instance.ImageInstanceID
+        )
+        if link is not None:
+            deleted_data = {
+                "tag_id": tag_id,
+                "image_instance_id": instance.ImageInstanceID,
+                "comment": link.Comment,
+                "creator_id": link.CreatorID,
+            }
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"DELETE /api/instances/{public_id}/tags/{tag_id}",
+                    entity="ImageInstanceTagLink",
+                    fields={"tag_id": tag_id, "image_instance_id": public_id},
+                    deleted_data=deleted_data,
+                )
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_image_instance_service.py -v`
+Expected: PASS (14 passed — the 4 from Task 2 plus these 10).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/image_instance_service.py server/tests/test_image_instance_service.py
+git commit -m "feat(services): add ImageInstanceService instance tag add/patch/remove"
+```
+
+---
+
+## Task 4: Route `instances.py` through `ImageInstanceService`
+
+Rewrite the DB-touching `instances.py` handlers to be thin: parse → build `ActingUser` (mutations only) → call `ImageInstanceService` → `DTOConverter` → return. The two pure-redirect endpoints (`/instances/images/{...}`, `/instances/thumbnails/{...}`) are untouched. No handler contains inline queries, `raise HTTPException` for not-found/wrong-type, `session.commit`, or direct `get_db_logger()` calls anymore — those move into the Service; the central `NotFoundError`/`BadRequestError` handlers (already registered) map the 404s/400s. Storage-ref resolution and redirect building stay in the `/data` and `/thumbnail` handlers (request/response shaping, not model-CRUD). Verified by the full suite still passing and an app-boot smoke check — matching how the earlier route slices were verified (no route-level test files exist for these slices).
+
+**Files:**
+- Modify: `server/routes/instances.py` (rewrite the DB-touching handlers)
+
+**Interfaces:**
+- Consumes: `ImageInstanceService`, `get_image_instance_service` (Task 2/3); `ActingUser` (existing); `DTOConverter` (existing); `resolve_image_data_ref`, `resolve_thumbnail_ref` (existing `eyened_orm.storage_access`).
+- Produces: no new symbols — this is the HTTP boundary.
+
+- [ ] **Step 1: Rewrite the route module**
+
+Replace the entire contents of `server/routes/instances.py` with:
+
+```python
+from typing import Optional
+
+from eyened_orm.storage_access import resolve_image_data_ref, resolve_thumbnail_ref
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_instances import ImageGET
+from ..dtos.dtos_aux import ObjectTagPOST, ObjectTagPATCH, TagMeta
+from ..services.acting_user import ActingUser
+from ..services.image_instance_service import (
+    ImageInstanceService,
+    get_image_instance_service,
+)
+from .auth import CurrentUser, get_current_user, is_authenticated
+
+router = APIRouter()
+
+
+@router.get("/instances/{instance_id}", response_model=ImageGET)
+async def get_instance(
+    instance_id: int,
+    with_segmentations: bool = False,
+    with_form_annotations: bool = False,
+    with_model_segmentations: bool = False,
+    with_tag_metadata: bool = False,
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single image instance by id, with optional related graphs."""
+    item = service.get_instance(
+        db,
+        instance_id,
+        with_segmentations=with_segmentations,
+        with_form_annotations=with_form_annotations,
+        with_model_segmentations=with_model_segmentations,
+    )
+    return DTOConverter.image_instance_to_get(
+        item,
+        with_tag_metadata=with_tag_metadata,
+        with_segmentations=with_segmentations,
+        with_form_annotations=with_form_annotations,
+        with_model_segmentations=with_model_segmentations,
+    )
+
+
+@router.get("/images/{image_id}", response_model=ImageGET)
+async def get_public_image(
+    image_id: str,
+    with_segmentations: bool = False,
+    with_form_annotations: bool = False,
+    with_model_segmentations: bool = False,
+    with_tag_metadata: bool = False,
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single image instance by PublicID, with optional related graphs."""
+    item = service.get_by_public_id(
+        db,
+        image_id,
+        with_segmentations=with_segmentations,
+        with_form_annotations=with_form_annotations,
+        with_model_segmentations=with_model_segmentations,
+    )
+    return DTOConverter.image_instance_to_get(
+        item,
+        with_tag_metadata=with_tag_metadata,
+        with_segmentations=with_segmentations,
+        with_form_annotations=with_form_annotations,
+        with_model_segmentations=with_model_segmentations,
+    )
+
+
+def build_storage_redirect_response(path: str) -> Response:
+    response = Response()
+    response.headers["X-Accel-Redirect"] = path
+    return response
+
+
+@router.get("/images/{image_id}/data")
+async def get_public_image_data(
+    image_id: str,
+    index: Optional[int] = None,
+    meta: bool = False,
+    _: bool = Depends(is_authenticated),
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+):
+    """Redirect to the stored image data for an instance (by PublicID)."""
+    item = service.get_for_storage(db, image_id)
+    if index is not None and index < 0:
+        raise HTTPException(400, "index must be >= 0")
+    try:
+        ref = resolve_image_data_ref(item, index=index, meta=meta)
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from e
+    return build_storage_redirect_response(ref.nginx_path)
+
+
+@router.get("/images/{image_id}/thumbnail")
+async def get_public_image_thumbnail(
+    image_id: str,
+    size: int = 144,
+    _: bool = Depends(is_authenticated),
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+):
+    """Redirect to the stored thumbnail for an instance (by PublicID)."""
+    item = service.get_for_storage(db, image_id)
+    try:
+        ref = resolve_thumbnail_ref(item, size=size)
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from e
+    return build_storage_redirect_response(ref.nginx_path)
+
+
+@router.get("/instances/images/{dataset_identifier:path}")
+async def get_file(
+    dataset_identifier: str,
+    _: bool = Depends(is_authenticated),
+):
+    # Set X-Accel-Redirect header to tell NGINX to serve the file
+    response = Response()
+    response.headers["X-Accel-Redirect"] = "/files/" + dataset_identifier
+    return response
+
+
+@router.get("/instances/thumbnails/{thumbnail_identifier:path}")
+async def get_thumb(
+    thumbnail_identifier: str,
+    _: bool = Depends(is_authenticated),
+):
+    response = Response()
+    response.headers["X-Accel-Redirect"] = "/thumbnails/" + thumbnail_identifier
+    return response
+
+
+@router.post("/instances/{instance_id}/tags", response_model=TagMeta)
+async def tag_instance(
+    instance_id: str,
+    body: ObjectTagPOST,
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
+    """Attach a Tag to an ImageInstance by tag ID (idempotent)."""
+    link = service.tag_instance(
+        db,
+        instance_id,
+        body.tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.link_to_tag_metadata(link)
+
+
+@router.patch("/instances/{instance_id}/tags/{tag_id}", response_model=TagMeta)
+async def patch_instance_tag(
+    instance_id: str,
+    tag_id: int,
+    body: ObjectTagPATCH,
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
+    """Update comment on an existing ImageInstance tag link."""
+    link = service.patch_instance_tag(
+        db,
+        instance_id,
+        tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.link_to_tag_metadata(link)
+
+
+@router.delete("/instances/{instance_id}/tags/{tag_id}", status_code=204)
+async def untag_instance(
+    instance_id: str,
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Remove a Tag from an ImageInstance (idempotent)."""
+    service.untag_instance(
+        db,
+        instance_id,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+```
+
+- [ ] **Step 2: App-boot smoke check (imports + routes register)**
+
+Run:
+
+> **Note:** the routers are mounted as a sub-app (`server/main.py:109` does `app.mount("/api", app_api)`), so the route paths live on **`app_api.routes`** and carry **no** `/api` prefix. Introspect `app_api`, not `app`.
+
+```bash
+EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password \
+  dev/.venv/bin/python -c "
+from server.main import app_api
+paths = {r.path for r in app_api.routes}
+for p in [
+    '/instances/{instance_id}',
+    '/images/{image_id}',
+    '/images/{image_id}/data',
+    '/images/{image_id}/thumbnail',
+    '/instances/{instance_id}/tags',
+    '/instances/{instance_id}/tags/{tag_id}',
+    '/instances/images/{dataset_identifier:path}',
+    '/instances/thumbnails/{thumbnail_identifier:path}',
+]:
+    assert p in paths, (p, sorted(x for x in paths if 'instance' in x or 'image' in x))
+print('instance routes OK')
+"
+```
+
+Expected: prints `instance routes OK` (the app imports cleanly and every route is registered on the mounted `/api` sub-app).
+
+- [ ] **Step 3: Run the full suite to confirm no regression**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: PASS — **227 passed** (211 baseline + 2 repository tests from Task 1 + 14 service tests from Tasks 2–3), no failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/instances.py
+git commit -m "refactor(routes): route instance endpoints through ImageInstanceService"
+```
+
+---
+
+## Phase 4a done — first slice of spec Phase 4
+
+After Task 4, `instances.py` no longer queries the ORM directly: it parses, calls `ImageInstanceService`, and converts DTOs (the two pure-redirect endpoints stay as-is). Do **not** merge `feature/rbac-step1-service-layer` to `development`; the next slices are spec **Phase 4b** (`form_annotations.py`) and **4c** (`segmentations.py`), each a separate plan — both can reuse the `ImageInstanceRepository` PublicID resolvers added here.
+
+Update the `rbac-step1-migration-state` memory: instances (4a) done; Phase 4b/4c next; test count **227**.
+```

--- a/docs/superpowers/plans/2026-07-10-subtask-phase3b.md
+++ b/docs/superpowers/plans/2026-07-10-subtask-phase3b.md
@@ -1,0 +1,1001 @@
+# subtask Repository/Service Migration (RBAC Step 1, Phase 3b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the `subtask.py` endpoints — by-id subtask read/update/delete (`GET/PATCH/DELETE /subtasks/{id}`) plus the image-link mutations (`POST /subtasks/{id}/images`, `DELETE /subtasks/{id}/images/{instance_id}`) — through a new `SubTaskService` backed by the existing `SubTaskRepository`, committing directly onto the current `feature/rbac-step1-service-layer` branch (never touching `development`).
+
+**Architecture:** Same layering as the reviewed Device/Patient/FormSchema/Study/Feature/Tag/Task slices — thin route (parse → Service → `DTOConverter` → return), a Service with a constructor-injected Repository that raises domain exceptions and owns the commit, and a framework-agnostic Repository that takes a `Session`. This phase completes the spec's "Phase 3" (Phase 3a shipped `task.py` + `TaskService` + the task-rooted subtask reads; **3b, this plan**, ships `subtask.py` + `SubTaskService`, the per-subtask-id CRUD and image-link mutations under `/subtasks/...`). It **extends the existing `SubTaskRepository`** (added in 3a to `task_repository.py`) with by-id and image-link data-access methods, and **adds `SubTaskService` to the existing `task_service.py`** alongside `TaskService` (per the spec's directory table: `task_service.py` holds `TaskService`, `SubTaskService`).
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.0 (ORM `eyened_orm`), pytest with the in-memory SQLite `session` fixture.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-07-03-repository-service-layer-design.md`. Every task implicitly includes these:
+
+- **Filenames:** snake_case, one file per model module — `task_repository.py`, `task_service.py`. Per the spec's directory table, `task_repository.py` holds `TaskRepository`, `SubTaskRepository`; `task_service.py` holds `TaskService`, `SubTaskService`. (`TaskDefinitionRepository`/`SubTaskImageLinkRepository` are **not** created: YAGNI — no endpoint does that CRUD, and image-instance resolution / link lookups are reads that belong on `SubTaskRepository` since they exist only to serve subtask image linking.)
+- **Class names:** `SubTaskRepository` / `SubTaskService`.
+- **Repositories** live in `orm/eyened_orm/repositories/`, take a `Session` as a method argument (never own/create sessions), have no FastAPI imports, and return `None`/empty on "not found" — never raise HTTP-shaped errors.
+- **Services** live in `server/services/`, receive their Repositories via constructor injection, and raise the domain exceptions in `server/services/exceptions.py` — **never** raise `HTTPException` directly.
+- **DTO conversion stays at the route boundary** (via `DTOConverter`), never inside a Service.
+- **Package `__init__.py` files re-export** their public classes (with `__all__`), keeping all existing exports.
+- **No mocking library.** DB-backed tests use the real in-memory SQLite `session` fixture (already exposed to `server/tests/` by the foundation's `server/tests/conftest.py`). Any non-DB fake is a small hand-rolled object.
+- **Do not touch:** CLI/worker code, `search.py`, `auth.py`, `Base`'s generic classmethods, the pre-existing Device/Patient/FormSchema/Study/Feature/Tag slices, or `TaskService`/`task.py` (that was 3a — `SubTaskService` is additive to the same module).
+- **Repository tests** → `orm/eyened_orm/tests/`; **Service tests** → `server/tests/`.
+
+### Conventions reused from the `task` (3a) phase
+
+- **Commit ownership:** `get_db` (`server/db.py`) yields a session that is only *closed*, never committed, by its context manager. Every mutating Service method calls `session.commit()` itself — the Service is the transaction boundary. (The spec's deferred "transaction ownership" follow-up will revisit this layer-wide; do not change it here.)
+- **Audit logging is injected, not global-reached.** The Service takes `logger: DatabaseModificationLogger | None = None` via its constructor and calls it inside the mutating method. `get_subtask_service()` wires the real logger via `get_db_logger()`; Service tests inject `None` or a small hand-rolled fake. Every logging call stays guarded by `if self.logger is not None:` (matching today's `if logger:` guard, since `get_db_logger()` returns `None` when DB logging is disabled).
+- **Acting user:** routes map their handler-layer `CurrentUser` onto the framework-agnostic `ActingUser(id, username)` value object (`server/services/acting_user.py`, already exists) before calling a Service.
+- **Lean test granularity:** thin `session.get(...)` wrappers (`SubTaskRepository.get_by_id`, `get_image_link`) get **no** dedicated Repository test — they are exercised through the Service tests. Every test carries a one-line docstring as its description.
+
+> **Interpreter note:** no `python`/`pytest` on `PATH`; the venv is at `dev/.venv`. Every command uses `dev/.venv/bin/python` / `dev/.venv/bin/pytest`. The two commands that import `server.*` (app-boot / router-introspection checks) need dummy DB env vars, mirroring `server/tests/conftest.py`: prefix them with `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password`.
+
+> **Reused from earlier work on `feature/rbac-step1-service-layer`:** `NotFoundError` and the central handler (`server/services/exceptions.py`, registered in `server/main.py` via `register_exception_handlers` — the handler dispatches every `ServiceError` subclass by MRO, so this phase needs **no** `main.py` change); the `session` fixture already imported in `server/tests/conftest.py`; the `ActingUser` value object; both `repositories/` and `services/` packages with their `__init__.py` re-exports; the `SubTaskRepository` class and its module-level `_SUBTASK_IMAGE_LOADER` eager-load chain (both in `orm/eyened_orm/repositories/task_repository.py`, added in 3a). **`subtask.router` is already registered** in `server/main.py` (`app_api.include_router(subtask.router)`), so no registration change is needed either. This phase introduces **no new exception type**: every `subtask.py` failure path today is a 404 (`GET`/`PATCH`/`DELETE` on a missing subtask; add-image on a missing subtask or missing `ImageInstance`; remove-image on a missing `ImageInstance` or missing link), all served by the existing `NotFoundError`.
+
+> **Existing ORM facts confirmed for this plan** (verified against `orm/eyened_orm/task.py` and the in-memory SQLite test DB, `PRAGMA foreign_keys=ON`):
+> - `SubTask` (`orm/eyened_orm/task.py:173`): `SubTaskID` (PK); `TaskID` (NOT NULL FK → `Task.TaskID`, `ondelete="CASCADE"`); `CreatorID` (nullable FK); `Comments` (`Text`, nullable); `TaskState` (`Mapped["SubTaskState"]`, **column default `SubTaskState.NotStarted`**). `SubTaskImageLinks` relationship (`passive_deletes=True`, `order_by="SubTaskImageLink.ImageIndex"`). `SubTaskState` members: `NotStarted`, `Busy`, `Ready`.
+> - `SubTaskImageLink` (`orm/eyened_orm/task.py:142`): **composite PK `(SubTaskID, ImageInstanceID)`**, both FKs `ondelete="CASCADE"`; `ImageIndex` (`int`, NOT NULL); `UniqueConstraint(SubTaskID, ImageIndex)`. So `session.get(SubTaskImageLink, {"SubTaskID": ..., "ImageInstanceID": ...})` is the by-key lookup, and `session.delete(link)` removes one link. A minimal link row inserts fine given a real `SubTask` + `ImageInstance`.
+> - `ImageInstance` has `PublicID` (the external string id the route resolves) and `ImageInstanceID` (int PK). A real `ImageInstance` row FK-requires a `Series`→`Study`→`Patient`→`Project` chain **and** a `DeviceInstance`→`DeviceModel`; the existing `_make_image` helper in `orm/eyened_orm/tests/test_task_repository.py` (added in 3a) builds exactly that minimal graph and returns the new `ImageInstanceID`.
+> - The 3a `_SUBTASK_IMAGE_LOADER` chain (`selectinload(SubTask.SubTaskImageLinks).selectinload(SubTaskImageLink.ImageInstance).selectinload(ImageInstance.ImageStorages).selectinload(ImageStorage.StorageBackend)`) is already defined at module level in `task_repository.py` and is reused for by-id image loading here.
+
+> **DTO facts confirmed:** `DTOConverter.subtask_to_get(subtask)` (`dto_converter.py:655`) and `DTOConverter.subtask_with_images_to_get(subtask)` (`dto_converter.py:666`) build `SubTaskGET`/`SubTaskWithImagesGET` (`server/dtos/dtos_tasks.py`). All DTO calls stay in the route. `SubTaskPATCH` and `AddImageRequest` are request bodies defined **inline in `subtask.py`** (they move with the rewritten route).
+
+> **Behavior-preserving decisions (call out in review):**
+> 1. **`SubTaskPATCH.task_state` is retyped from `Optional[str]` to `Optional[SubTaskState]`**, mirroring how 3a typed `TaskPATCH.task_state` as the enum. Accepted values are unchanged (the enum member names); the only difference is that an invalid value now 422s at the schema boundary instead of reaching the DB. The Service therefore takes `task_state: SubTaskState | None` and assigns the enum directly.
+> 2. **The old `add_subtask_image` broad `try/except Exception → rollback → HTTP 500 "Error adding image link"` is dropped.** On the happy path (a not-yet-linked image) the `max(ImageIndex)+1` write cannot collide with `UniqueConstraint(SubTaskID, ImageIndex)`, so the add + commit succeeds without a guard. The one failing input is re-linking the **same** image to the **same** subtask: `SubTaskImageLink` has a composite PK `(SubTaskID, ImageInstanceID)` (`orm/eyened_orm/task.py:156-162`), so that commit raises `IntegrityError`. This is **behavior-preserving at the wire level** — the old route caught it and returned HTTP 500 (`"Error adding image link"`); the new code lets it propagate to FastAPI's default 500. Same status (500), only a generic body instead of the specific message; `get_session()` closes/rolls back the poisoned transaction in its `finally` and each request gets a fresh session, so there is no DB corruption. (Correction from the original draft, which wrongly claimed the same image could be linked twice: the composite PK forbids that.) A cleaner `IntegrityError → ConflictError` (409) contract is deliberately left to the spec's deferred transaction-ownership follow-up, not added per-method here.
+
+---
+
+## Task 0 (git): Confirm the working branch and a green baseline
+
+Not a code task. All new work stays on `feature/rbac-step1-service-layer`; `development` is never touched.
+
+- [ ] **Step 1: Confirm the working branch**
+
+```bash
+git branch --show-current   # expect: feature/rbac-step1-service-layer
+```
+
+- [ ] **Step 2: Confirm the pre-existing suite is green before adding anything**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: the existing suite (foundation + Device/Patient/FormSchema/Study/Feature/Tag/Task slices) collects and passes (baseline: **191 passed**). **If anything is already red, stop and surface it — do not build on a red baseline.**
+
+---
+
+## Task 1: SubTaskRepository — by-id + image-link data access
+
+Extend the existing `SubTaskRepository` (in `task_repository.py`) with the reads/lookups the `subtask.py` handlers perform inline today: a by-id fetch, a by-id image-eager-loaded fetch (shared by `GET ?with_images` and the post-mutation refetch), `PublicID`→`ImageInstanceID` resolution, the next `ImageIndex` for a subtask, and a link-by-key lookup. `get_by_id` and `get_image_link` are thin `session.get(...)` wrappers (existence lookups for patch/delete/add/remove), so — following the `devices`/`feature`/`tag`/`task` precedent — they get no dedicated Repository test (they are exercised through the Task 2/3 Service tests). No method commits; the Service owns the transaction boundary.
+
+**Files:**
+- Modify: `orm/eyened_orm/repositories/task_repository.py` (add 5 methods to `SubTaskRepository`)
+- Modify: `orm/eyened_orm/tests/test_task_repository.py` (append `SubTaskRepository` image/lookup tests)
+
+**Interfaces:**
+- Consumes: `eyened_orm.SubTask`, `eyened_orm.SubTaskImageLink`, `eyened_orm.ImageInstance` (all already imported at the top of `task_repository.py`).
+- Produces (added to `SubTaskRepository`, all take `session: Session` first):
+  - `get_by_id(session, subtask_id: int) -> SubTask | None` — thin `session.get`.
+  - `get_with_images(session, subtask_id: int) -> SubTask | None` — the subtask with the `_SUBTASK_IMAGE_LOADER` chain applied, or `None`.
+  - `resolve_image_instance_id(session, public_id: str) -> int | None` — the `ImageInstanceID` for that `PublicID`, or `None`.
+  - `next_image_index(session, subtask_id: int) -> int` — `max(ImageIndex)+1` over the subtask's links, or `0` if it has none.
+  - `get_image_link(session, subtask_id: int, image_instance_id: int) -> SubTaskImageLink | None` — thin composite-key `session.get`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `orm/eyened_orm/tests/test_task_repository.py` (the helpers `_creator`, `_task_def`, `_make_task`, `_make_subtask`, `_make_image` and the `SubTaskRepository` import already exist at the top of the file from 3a):
+
+```python
+def test_get_with_images_loads_link_chain(session):
+    """get_with_images returns the subtask with its image links eager-loaded."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    st = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    image_id = _make_image(session, "pub-1")
+    from eyened_orm import SubTaskImageLink
+
+    session.add(
+        SubTaskImageLink(SubTaskID=st.SubTaskID, ImageInstanceID=image_id, ImageIndex=0)
+    )
+    session.flush()
+
+    loaded = SubTaskRepository().get_with_images(session, st.SubTaskID)
+
+    assert loaded is not None
+    assert [link.ImageInstance.PublicID for link in loaded.SubTaskImageLinks] == ["pub-1"]
+
+
+def test_resolve_image_instance_id_found_and_missing(session):
+    """resolve_image_instance_id maps a PublicID to its int id, or None if absent."""
+    image_id = _make_image(session, "pub-42")
+    repo = SubTaskRepository()
+
+    assert repo.resolve_image_instance_id(session, "pub-42") == image_id
+    assert repo.resolve_image_instance_id(session, "nope") is None
+
+
+def test_next_image_index_starts_at_zero_then_increments(session):
+    """next_image_index is 0 for a subtask with no links, else max(ImageIndex)+1."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    st = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    image_id = _make_image(session, "pub-1")
+    repo = SubTaskRepository()
+
+    assert repo.next_image_index(session, st.SubTaskID) == 0
+
+    from eyened_orm import SubTaskImageLink
+
+    session.add(
+        SubTaskImageLink(SubTaskID=st.SubTaskID, ImageInstanceID=image_id, ImageIndex=3)
+    )
+    session.flush()
+
+    assert repo.next_image_index(session, st.SubTaskID) == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_task_repository.py -v`
+Expected: FAIL — `AttributeError: 'SubTaskRepository' object has no attribute 'get_with_images'`.
+
+- [ ] **Step 3: Add the methods**
+
+Add these five methods to the `SubTaskRepository` class in `orm/eyened_orm/repositories/task_repository.py` (append after the existing `list_for_task` method). `SubTask`, `SubTaskImageLink`, `ImageInstance`, `func`, `select`, and `_SUBTASK_IMAGE_LOADER` are all already in scope in this module:
+
+```python
+    def get_by_id(self, session: Session, subtask_id: int) -> SubTask | None:
+        """Return the subtask with the given id, or None if absent."""
+        return session.get(SubTask, subtask_id)
+
+    def get_with_images(self, session: Session, subtask_id: int) -> SubTask | None:
+        """Return the subtask with its image links eager-loaded, or None."""
+        return (
+            session.execute(
+                select(SubTask)
+                .options(_SUBTASK_IMAGE_LOADER)
+                .where(SubTask.SubTaskID == subtask_id)
+            )
+            .scalars()
+            .first()
+        )
+
+    def resolve_image_instance_id(
+        self, session: Session, public_id: str
+    ) -> int | None:
+        """Return the ImageInstanceID for a PublicID, or None if no image matches."""
+        return session.scalar(
+            select(ImageInstance.ImageInstanceID).where(
+                ImageInstance.PublicID == public_id
+            )
+        )
+
+    def next_image_index(self, session: Session, subtask_id: int) -> int:
+        """Return the next ImageIndex for the subtask (max+1, or 0 if it has none)."""
+        current_max = session.scalar(
+            select(func.max(SubTaskImageLink.ImageIndex)).where(
+                SubTaskImageLink.SubTaskID == subtask_id
+            )
+        )
+        return 0 if current_max is None else current_max + 1
+
+    def get_image_link(
+        self, session: Session, subtask_id: int, image_instance_id: int
+    ) -> SubTaskImageLink | None:
+        """Return the link for (subtask_id, image_instance_id), or None if absent."""
+        return session.get(
+            SubTaskImageLink,
+            {"SubTaskID": subtask_id, "ImageInstanceID": image_instance_id},
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest orm/eyened_orm/tests/test_task_repository.py -v`
+Expected: PASS (12 passed — the 9 from 3a plus these 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orm/eyened_orm/repositories/task_repository.py orm/eyened_orm/tests/test_task_repository.py
+git commit -m "feat(repositories): add SubTaskRepository by-id and image-link reads"
+```
+
+---
+
+## Task 2: SubTaskService — by-id read/update/delete
+
+Holds the per-subtask business rules the `subtask.py` handlers encode today (read one subtask ± images; update `Comments`/`TaskState`; delete), owns the commit, and emits audit logging via an injected logger. The only failure path is a missing subtask (`NotFoundError` → 404). Lives in `task_service.py` alongside `TaskService`. The constructor takes just the `SubTaskRepository`; the default factory wires it plus the real logger.
+
+**Files:**
+- Modify: `server/services/task_service.py` (add `SubTaskService` + `get_subtask_service`)
+- Modify: `server/services/__init__.py` (re-export `SubTaskService`)
+- Test: `server/tests/test_subtask_service.py`
+
+**Interfaces:**
+- Consumes: `SubTaskRepository` (existing, extended in Task 1); `NotFoundError` (existing); `ActingUser` (existing); `DatabaseModificationLogger`/`get_db_logger` (`server/utils/db_logging.py`); `eyened_orm.SubTask`, `eyened_orm.task.SubTaskState`.
+- Produces:
+  - `SubTaskService(subtask_repository: SubTaskRepository, logger: DatabaseModificationLogger | None = None)`.
+  - `get_subtask(session, subtask_id: int, *, with_images: bool) -> SubTask` — the subtask (image-loaded iff `with_images`); 404 if absent.
+  - `update_subtask(session, subtask_id: int, comments: str | None, task_state: SubTaskState | None, actor: ActingUser) -> SubTask` — each field optional; 404 if absent.
+  - `delete_subtask(session, subtask_id: int, actor: ActingUser) -> None` — 404 if absent.
+  - `get_subtask_service() -> SubTaskService` — default-wiring factory (`SubTaskRepository()` + `get_db_logger()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_subtask_service.py`:
+
+```python
+import pytest
+
+from eyened_orm import Creator, SubTask, Task, TaskDefinition
+from eyened_orm.task import SubTaskState, TaskState
+from eyened_orm.repositories.task_repository import SubTaskRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import NotFoundError
+from server.services.task_service import SubTaskService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _actor(session) -> ActingUser:
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _task_def(session, name: str = "td") -> TaskDefinition:
+    td = TaskDefinition(TaskDefinitionName=name)
+    session.add(td)
+    session.flush()
+    return td
+
+
+def _make_task(session, td_id: int, creator_id: int, name: str = "T") -> Task:
+    task = Task(
+        TaskName=name,
+        TaskDefinitionID=td_id,
+        CreatorID=creator_id,
+        TaskState=TaskState.NotStarted,
+    )
+    session.add(task)
+    session.flush()
+    return task
+
+
+def _make_subtask(session, task_id: int, state: SubTaskState = SubTaskState.NotStarted) -> SubTask:
+    st = SubTask(TaskID=task_id, TaskState=state, Comments="orig")
+    session.add(st)
+    session.flush()
+    return st
+
+
+def _service(logger=None) -> SubTaskService:
+    return SubTaskService(SubTaskRepository(), logger=logger)
+
+
+def test_get_subtask_returns_it(session):
+    """get_subtask returns the subtask at the given id."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+
+    got = _service().get_subtask(session, st.SubTaskID, with_images=False)
+
+    assert got.SubTaskID == st.SubTaskID
+
+
+def test_get_subtask_unknown_raises_not_found(session):
+    """Getting a missing subtask is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_subtask(session, 999_999, with_images=False)
+
+
+def test_update_subtask_changes_fields(session):
+    """update_subtask overwrites the provided comments and task_state."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+
+    updated = _service().update_subtask(
+        session, st.SubTaskID, "newcomment", SubTaskState.Ready, actor
+    )
+
+    assert updated.Comments == "newcomment"
+    assert updated.TaskState == SubTaskState.Ready
+
+
+def test_update_subtask_unknown_raises_not_found(session):
+    """Updating a missing subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().update_subtask(session, 999_999, "x", None, actor)
+
+
+def test_update_subtask_logs_update(session):
+    """update_subtask emits one update audit record for the SubTask entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).update_subtask(session, st.SubTaskID, "c", None, actor)
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "SubTask"
+
+
+def test_delete_subtask_removes_it(session):
+    """delete_subtask removes the subtask row."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+
+    _service().delete_subtask(session, st.SubTaskID, actor)
+
+    assert SubTaskRepository().get_by_id(session, st.SubTaskID) is None
+
+
+def test_delete_subtask_unknown_raises_not_found(session):
+    """Deleting a missing subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().delete_subtask(session, 999_999, actor)
+
+
+def test_delete_subtask_logs_delete(session):
+    """delete_subtask emits one delete audit record for the SubTask entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_subtask(session, st.SubTaskID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "SubTask"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_subtask_service.py -v`
+Expected: FAIL — `ImportError: cannot import name 'SubTaskService' from 'server.services.task_service'`.
+
+- [ ] **Step 3: Write the service**
+
+Add `SubTaskService` and `get_subtask_service` to `server/services/task_service.py`. Insert the `SubTaskService` class after the `TaskService` class and before the module-level `get_task_service` function; add `get_subtask_service` at the end of the module. (`SubTask`, `SubTaskState`, `SubTaskRepository`, `Session`, `ActingUser`, `NotFoundError`, `DatabaseModificationLogger`, `get_db_logger` are all already imported at the top of the file from 3a.)
+
+```python
+class SubTaskService:
+    """Business logic for individual subtasks and their image links."""
+
+    def __init__(
+        self,
+        subtask_repository: SubTaskRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.subtasks = subtask_repository
+        self.logger = logger
+
+    def get_subtask(
+        self, session: Session, subtask_id: int, *, with_images: bool
+    ) -> SubTask:
+        """Return a subtask, image-loaded iff ``with_images``.
+
+        Raises:
+            NotFoundError: If the subtask does not exist.
+        """
+        subtask = (
+            self.subtasks.get_with_images(session, subtask_id)
+            if with_images
+            else self.subtasks.get_by_id(session, subtask_id)
+        )
+        if subtask is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+        return subtask
+
+    def update_subtask(
+        self,
+        session: Session,
+        subtask_id: int,
+        comments: str | None,
+        task_state: SubTaskState | None,
+        actor: ActingUser,
+    ) -> SubTask:
+        """Update a subtask's comments/state (each optional).
+
+        Raises:
+            NotFoundError: If the subtask does not exist.
+        """
+        subtask = self.subtasks.get_by_id(session, subtask_id)
+        if subtask is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+
+        changes: dict[str, str] = {}
+        if comments is not None:
+            changes["comments"] = f"{subtask.Comments} -> {comments}"
+            subtask.Comments = comments
+        if task_state is not None:
+            changes["task_state"] = f"{subtask.TaskState} -> {task_state}"
+            subtask.TaskState = task_state
+
+        session.commit()
+        session.refresh(subtask)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/subtasks/{subtask_id}",
+                entity="SubTask",
+                entity_id=subtask_id,
+                changes=changes if changes else None,
+            )
+        return subtask
+
+    def delete_subtask(
+        self, session: Session, subtask_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a subtask (its image links cascade at the DB level).
+
+        Raises:
+            NotFoundError: If the subtask does not exist.
+        """
+        subtask = self.subtasks.get_by_id(session, subtask_id)
+        if subtask is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+
+        deleted_data = {
+            "task_id": subtask.TaskID,
+            "comments": subtask.Comments,
+            "task_state": str(subtask.TaskState) if subtask.TaskState else None,
+            "creator_id": subtask.CreatorID,
+        }
+        session.delete(subtask)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/subtasks/{subtask_id}",
+                entity="SubTask",
+                entity_id=subtask_id,
+                deleted_data=deleted_data,
+            )
+        return None
+```
+
+Add at the very end of the module (after `get_task_service`):
+
+```python
+def get_subtask_service() -> SubTaskService:
+    """Default SubTaskService wiring for FastAPI ``Depends()``."""
+    return SubTaskService(SubTaskRepository(), logger=get_db_logger())
+```
+
+Update `server/services/__init__.py` (add the import + `__all__` entry, keeping all existing exports):
+
+```python
+from .task_service import SubTaskService, TaskService
+```
+
+```python
+    "TaskService",
+    "SubTaskService",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_subtask_service.py -v`
+Expected: PASS (8 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/task_service.py server/services/__init__.py server/tests/test_subtask_service.py
+git commit -m "feat(services): add SubTaskService with subtask CRUD and injected audit logging"
+```
+
+---
+
+## Task 3: SubTaskService — image link add/remove
+
+Adds the two image-link mutations behind `POST /subtasks/{id}/images` (append a link at the next `ImageIndex`) and `DELETE /subtasks/{id}/images/{instance_id}` (remove a link by its image's `PublicID`). Both preserve today's lookup order and failure paths: add checks the subtask first (404) then resolves the image (404); remove resolves the image first (404) then the link (404). Both return the subtask re-fetched with its images so the route can serialize the updated set. See the "Behavior-preserving decisions" note in the header about dropping the old broad `except → 500`.
+
+**Files:**
+- Modify: `server/services/task_service.py` (add two methods to `SubTaskService`)
+- Modify: `server/tests/test_subtask_service.py` (append tests + image-graph helper)
+
+**Interfaces:**
+- Consumes: `SubTaskRepository.get_by_id`, `.resolve_image_instance_id`, `.next_image_index`, `.get_image_link`, `.get_with_images` (Task 1); `eyened_orm.SubTaskImageLink`.
+- Produces (added to `SubTaskService`):
+  - `add_image(session, subtask_id: int, image_public_id: str, actor: ActingUser) -> SubTask` — appends a link at the next `ImageIndex`, returns the image-loaded subtask; 404 if the subtask or the image is absent.
+  - `remove_image(session, subtask_id: int, image_public_id: str, actor: ActingUser) -> SubTask` — removes the link for that image, returns the image-loaded subtask; 404 if the image or the link is absent.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_subtask_service.py`:
+
+```python
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal Series/Device graph an ImageInstance FK-requires.
+
+    Returns the new ImageInstanceID (mirrors the helper in test_task_repository.py).
+    """
+    import datetime
+
+    from eyened_orm import (
+        DeviceInstance,
+        DeviceModel,
+        ImageInstance,
+        Patient,
+        Project,
+        Series,
+        Study,
+    )
+    from eyened_orm.project import ExternalEnum
+
+    project = Project(ProjectName="P", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier="ID1", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier="ds",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_add_image_appends_link_at_next_index(session):
+    """add_image links the image to the subtask at the next ImageIndex."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+
+    updated = _service().add_image(session, st.SubTaskID, "pub-1", actor)
+
+    assert [link.ImageInstance.PublicID for link in updated.SubTaskImageLinks] == ["pub-1"]
+    assert [link.ImageIndex for link in updated.SubTaskImageLinks] == [0]
+
+
+def test_add_image_second_image_gets_next_index(session):
+    """A second add_image lands at ImageIndex 1, keeping insertion order."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    _make_image(session, "pub-2")
+    session.commit()
+    service = _service()
+
+    service.add_image(session, st.SubTaskID, "pub-1", actor)
+    updated = service.add_image(session, st.SubTaskID, "pub-2", actor)
+
+    assert [link.ImageIndex for link in updated.SubTaskImageLinks] == [0, 1]
+
+
+def test_add_image_unknown_subtask_raises_not_found(session):
+    """add_image on a missing subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().add_image(session, 999_999, "pub-1", actor)
+
+
+def test_add_image_unknown_image_raises_not_found(session):
+    """add_image with an unknown PublicID is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().add_image(session, st.SubTaskID, "nope", actor)
+
+
+def test_add_image_logs_insert(session):
+    """add_image emits one insert audit record for the SubTaskImageLink entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).add_image(session, st.SubTaskID, "pub-1", actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "SubTaskImageLink"
+
+
+def test_remove_image_deletes_the_link(session):
+    """remove_image deletes the link for that image, leaving the subtask empty."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+    service = _service()
+    service.add_image(session, st.SubTaskID, "pub-1", actor)
+
+    updated = service.remove_image(session, st.SubTaskID, "pub-1", actor)
+
+    assert updated.SubTaskImageLinks == []
+
+
+def test_remove_image_unknown_image_raises_not_found(session):
+    """remove_image with an unknown PublicID is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().remove_image(session, st.SubTaskID, "nope", actor)
+
+
+def test_remove_image_unlinked_image_raises_not_found(session):
+    """remove_image for an image not linked to the subtask raises NotFoundError."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")  # exists, but never linked
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().remove_image(session, st.SubTaskID, "pub-1", actor)
+
+
+def test_remove_image_logs_delete(session):
+    """remove_image emits one delete audit record for the SubTaskImageLink entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+    service = _service()
+    service.add_image(session, st.SubTaskID, "pub-1", actor)
+    logger = FakeAuditLogger()
+    SubTaskService(SubTaskRepository(), logger=logger).remove_image(
+        session, st.SubTaskID, "pub-1", actor
+    )
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "SubTaskImageLink"
+```
+
+> **Note — imports:** `SubTaskImageLink` is only needed inside the Service (Task 3 body), not the test. The test builds links via `add_image`, so no extra test import beyond `_make_image`'s local imports is required.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dev/.venv/bin/pytest server/tests/test_subtask_service.py -v`
+Expected: FAIL — `AttributeError: 'SubTaskService' object has no attribute 'add_image'`.
+
+- [ ] **Step 3: Add the two methods**
+
+Add these methods to the `SubTaskService` class in `server/services/task_service.py` (after `delete_subtask`, before the module-level factories). Add `SubTaskImageLink` to the top-of-file `eyened_orm` import (currently `from eyened_orm import SubTask, Task`):
+
+```python
+# extend the existing top-of-file import:
+from eyened_orm import SubTask, SubTaskImageLink, Task
+```
+
+```python
+    def add_image(
+        self,
+        session: Session,
+        subtask_id: int,
+        image_public_id: str,
+        actor: ActingUser,
+    ) -> SubTask:
+        """Link an image (by PublicID) to a subtask at the next ImageIndex.
+
+        Raises:
+            NotFoundError: If the subtask or the image does not exist.
+        """
+        if self.subtasks.get_by_id(session, subtask_id) is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+        image_instance_id = self.subtasks.resolve_image_instance_id(
+            session, image_public_id
+        )
+        if image_instance_id is None:
+            raise NotFoundError("ImageInstance not found")
+
+        link = SubTaskImageLink(
+            SubTaskID=subtask_id,
+            ImageInstanceID=image_instance_id,
+            ImageIndex=self.subtasks.next_image_index(session, subtask_id),
+        )
+        session.add(link)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"POST /api/subtasks/{subtask_id}/images",
+                entity="SubTaskImageLink",
+                fields={
+                    "subtask_id": subtask_id,
+                    "image_instance_id": image_instance_id,
+                },
+            )
+        return self.subtasks.get_with_images(session, subtask_id)
+
+    def remove_image(
+        self,
+        session: Session,
+        subtask_id: int,
+        image_public_id: str,
+        actor: ActingUser,
+    ) -> SubTask:
+        """Unlink an image (by PublicID) from a subtask.
+
+        Raises:
+            NotFoundError: If the image or the (subtask, image) link is absent.
+        """
+        image_instance_id = self.subtasks.resolve_image_instance_id(
+            session, image_public_id
+        )
+        if image_instance_id is None:
+            raise NotFoundError("ImageInstance not found")
+        link = self.subtasks.get_image_link(session, subtask_id, image_instance_id)
+        if link is None:
+            raise NotFoundError("Link not found")
+
+        session.delete(link)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=(
+                    f"DELETE /api/subtasks/{subtask_id}/images/{image_public_id}"
+                ),
+                entity="SubTaskImageLink",
+                deleted_data={
+                    "subtask_id": subtask_id,
+                    "image_instance_id": image_instance_id,
+                },
+            )
+        return self.subtasks.get_with_images(session, subtask_id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dev/.venv/bin/pytest server/tests/test_subtask_service.py -v`
+Expected: PASS (17 passed — the 8 from Task 2 plus these 9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/task_service.py server/tests/test_subtask_service.py
+git commit -m "feat(services): add SubTaskService image-link add/remove"
+```
+
+---
+
+## Task 4: Route `subtask.py` through `SubTaskService`
+
+Rewrite the five `subtask.py` handlers to be thin: parse → build `ActingUser` → call `SubTaskService` → `DTOConverter` → return. No handler contains inline queries, `raise HTTPException`, `session.commit`, or direct `get_db_logger()` calls anymore — those move into the Service; the central `NotFoundError` handler (already registered) maps the 404s. The `SubTaskPATCH` and `AddImageRequest` request bodies stay defined inline in `subtask.py`; `SubTaskPATCH.task_state` is retyped to the `SubTaskState` enum (see header decision #1). Verified by the full suite still passing and an app-boot smoke check — matching how 3a's `task.py` refactor was verified (no route-level test files exist for these slices).
+
+**Files:**
+- Modify: `server/routes/subtask.py` (full rewrite of the 5 handlers + inline DTOs)
+
+**Interfaces:**
+- Consumes: `SubTaskService`, `get_subtask_service` (Task 2/3); `ActingUser` (existing); `DTOConverter` (existing); `eyened_orm.task.SubTaskState`.
+- Produces: no new symbols other Python imports — this is the HTTP boundary.
+
+- [ ] **Step 1: Rewrite the route module**
+
+Replace the entire contents of `server/routes/subtask.py` with:
+
+```python
+from typing import Optional, Union
+
+from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from eyened_orm.task import SubTaskState
+
+from ..db import get_db
+from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_tasks import SubTaskGET, SubTaskWithImagesGET
+from ..services.acting_user import ActingUser
+from ..services.task_service import SubTaskService, get_subtask_service
+from .auth import CurrentUser, get_current_user
+
+router = APIRouter()
+
+
+class SubTaskPATCH(BaseModel):
+    comments: Optional[str] = None
+    task_state: Optional[SubTaskState] = None
+
+
+class AddImageRequest(BaseModel):
+    instance_id: str
+
+
+@router.get(
+    "/subtasks/{subtaskid}", response_model=Union[SubTaskWithImagesGET, SubTaskGET]
+)
+async def get_subtask(
+    subtaskid: int,
+    with_images: bool = False,
+    db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Get a single subtask, optionally with its images."""
+    st = service.get_subtask(db, subtaskid, with_images=with_images)
+    if with_images:
+        return DTOConverter.subtask_with_images_to_get(st)
+    return DTOConverter.subtask_to_get(st)
+
+
+@router.patch("/subtasks/{subtaskid}", response_model=SubTaskGET)
+async def patch_subtask(
+    subtaskid: int,
+    dto: SubTaskPATCH,
+    db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Update a subtask's comments and/or state."""
+    st = service.update_subtask(
+        db,
+        subtaskid,
+        dto.comments,
+        dto.task_state,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.subtask_to_get(st)
+
+
+@router.delete("/subtasks/{subtaskid}", status_code=204)
+async def delete_subtask(
+    subtaskid: int,
+    db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Delete a subtask."""
+    service.delete_subtask(
+        db,
+        subtaskid,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return Response(status_code=204)
+
+
+@router.post("/subtasks/{subtaskid}/images", response_model=SubTaskWithImagesGET)
+async def add_subtask_image(
+    subtaskid: int,
+    body: AddImageRequest,
+    db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Link an image to a subtask at the next available index."""
+    st = service.add_image(
+        db,
+        subtaskid,
+        body.instance_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.subtask_with_images_to_get(st)
+
+
+@router.delete(
+    "/subtasks/{subtaskid}/images/{instance_id}", response_model=SubTaskWithImagesGET
+)
+async def remove_subtask_image(
+    subtaskid: int,
+    instance_id: str,
+    db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Unlink an image from a subtask."""
+    st = service.remove_image(
+        db,
+        subtaskid,
+        instance_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.subtask_with_images_to_get(st)
+```
+
+- [ ] **Step 2: App-boot smoke check (imports + routes register)**
+
+Run:
+
+```bash
+EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password \
+  dev/.venv/bin/python -c "
+from server.main import app
+paths = {r.path for r in app.routes}
+assert '/api/subtasks/{subtaskid}' in paths, sorted(p for p in paths if 'subtask' in p)
+assert '/api/subtasks/{subtaskid}/images' in paths
+assert '/api/subtasks/{subtaskid}/images/{instance_id}' in paths
+print('subtask routes OK')
+"
+```
+
+Expected: prints `subtask routes OK` (the app imports cleanly and every rewritten subtask route is registered under the `/api` prefix).
+
+- [ ] **Step 3: Run the full suite to confirm no regression**
+
+Run: `EYENED_DATABASE_USER=test_user EYENED_DATABASE_PASSWORD=test_password dev/.venv/bin/pytest -q`
+Expected: PASS — **211 passed** (191 baseline + 3 repository tests from Task 1 + 17 service tests from Tasks 2–3), no failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/routes/subtask.py
+git commit -m "refactor(routes): route subtask endpoints through SubTaskService"
+```
+
+---
+
+## Phase 3b done — completes spec Phase 3
+
+After Task 4, `subtask.py` no longer queries the ORM directly: it parses, calls `SubTaskService`, and converts DTOs. Together with 3a (`task.py`/`TaskService`), this finishes the spec's **Phase 3**. Do **not** merge `feature/rbac-step1-service-layer` to `development`; the next slice is spec **Phase 4** (`import_api.py`, `instances.py`, `form_annotations.py`, `segmentations.py`), a separate plan.
+
+Update the `rbac-step1-migration-state` memory: subtask (3b) done; Phase 3 complete; Phase 4 next; test count **211**.

--- a/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
+++ b/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
@@ -335,6 +335,21 @@ ownership review above. Listed earliest phase first.
   RQ-worker path; and the server path (this port) and the client path
   (`DataAccessAdapter`) are two seams to the same store — unifying them so the
   fix lives once is the real long-term win.
+- **400-vs-404 precedence flip on simultaneous errors (thin-route consequence).**
+  The migration moved the entity-existence check into the Service (→404) while
+  the HTTP-level checks stay in the thin route (content-type → 400 on
+  `PUT .../data`; non-3D upload → 400 on `POST /segmentations`), so the route's
+  400 now fires before the Service's 404 — the reverse of the pre-refactor
+  route, which resolved the entity (404) before the content-type/parse check
+  (400). Observable ONLY when both conditions coincide: e.g.
+  `PUT /segmentations/{unknown_id}/data` with a wrong `Content-Type` now returns
+  400 (was 404), and `POST /segmentations` with an unknown `image_id` AND a
+  non-3D array now returns 400 (was 404). Every single-error case is unchanged
+  (unknown id with a valid request still 404; valid id with a bad request still
+  400). Affects `create_segmentation`, `update_segmentation_data`,
+  `update_model_segmentation_data`. Preserving exact precedence would require
+  reintroducing a DB existence check into the thin route (undoing the layering),
+  so it is recorded here rather than fixed; revisit if strict precedence matters.
 - `POST /segmentations/{id}/tags` ignores the client-supplied `ObjectTagPOST.comment`
   (no `Comment` persisted), unlike the instance/form-annotation taggers which do
   store it. Preserved verbatim from the pre-refactor handler; revisit for

--- a/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
+++ b/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
@@ -369,3 +369,32 @@ ownership review above. Listed earliest phase first.
 - `ModelSegmentation` write happy-path and repository `get_by_id` positive path are
   unit-tested only via the 404 branches (a `SegmentationModel` test factory does
   not exist yet); add once one does, alongside the Phase 2b positive-count test.
+
+**Phase 4c code-quality cleanup — actionable follow-up tasks** (non-blocking Minors
+surfaced by the per-task reviews; verbatim-from-plan cosmetics + small coverage
+gaps. None block a feature-branch merge; sweep together with the cross-phase
+transaction-ownership / audit-logging cleanup above):
+- [ ] `orm/eyened_orm/repositories/segmentation_repository.py` — drop or expand the
+  vague `ModelSegmentationRepository` docstring aside "(data endpoints only)";
+  state what it returns instead.
+- [ ] `server/tests/test_segmentation_service.py` — delete the unused
+  `_image_public_id` helper (defined, never called).
+- [ ] `server/tests/test_segmentation_service.py` — hoist the mid-file imports
+  (`from eyened_orm.segmentation import DataRepresentation, Datatype`;
+  `from eyened_orm import Tag`; `from eyened_orm.tag import TagType`) into the
+  top-of-file import block (E402 / isort ordering).
+- [ ] `server/tests/test_segmentation_service.py` — add an `untag`-on-unknown-
+  segmentation test (the `NotFoundError`/404 path, currently untested).
+- [ ] `server/tests/test_segmentation_service.py` — `test_tag_creates_link` asserts
+  `link.Tag.TagID`, which passes even under a lazy-load and so does not actually
+  pin the `link.Tag = tag` no-lazy-load intent; if that intent is worth pinning,
+  assert it without triggering a load (e.g. check `'Tag' in link.__dict__`).
+- [ ] `server/routes/segmentations.py` — restore the rationale comment lost from
+  `create_segmentation` (why the endpoint accepts multipart form-data with an
+  optional array upload — an omitted array yields an empty zeros volume so the
+  segmentation's metadata and data stay consistent) as a sentence in
+  `SegmentationService.create`'s docstring.
+- [ ] Spec co-location: itemize the `ModelSegmentationService.write_data`
+  "no audit logging" asymmetry in this block (it is currently only in the plan's
+  endpoint→service map). Behavior is correctly preserved — this is only a
+  documentation-completeness task.

--- a/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
+++ b/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
@@ -213,3 +213,144 @@ model(s), switch the corresponding route module to use them, ship.
   the caller commits once), so rollback-on-error and audit-inside-the-
   transaction come for free. Check for double-commit before changing
   (`grep -rn "\.commit()" server/services server/routes server/db.py`).
+
+### Deferred review findings (running list from the phased migration)
+
+Minor findings surfaced by the per-phase code reviews that were consciously
+deferred rather than fixed in-phase — none are correctness bugs. Appended per
+phase so they can be swept up together; several belong to the transaction-
+ownership review above. Listed earliest phase first.
+
+**Cross-phase (recur across every slice):**
+- Promote the per-handler `ActingUser(id=current_user.id, username=current_user.username)`
+  construction (built in the mutating handlers of every route slice) into a
+  single `get_acting_user` FastAPI dependency. First noted in Phase 2a; recurs
+  through 4b.
+- No route-level HTTP `TestClient` tests exist for any migrated slice — wiring
+  is verified statically and via Service unit tests. Add a thin route-level
+  smoke layer asserting the 404 body, the structured 409 bodies (feature delete
+  guards), and 422 on a bad enum (`task`/`subtask` `task_state`).
+- `routes/task.py` (and any slice reusing it) calls pydantic-v1
+  `.copy(update=...)`; sweep to the v2 API to silence deprecation warnings —
+  pre-existing, not introduced by the migration.
+- Audit change-strings that now stringify enums on both sides (e.g.
+  `"SubTaskState.NotStarted -> SubTaskState.Ready"` vs. the old
+  `"... -> Ready"`) — cosmetic; use `.value` if a stable audit text is wanted.
+  Same class as the Phase 4b decision-#3 item; fold into the audit cleanup.
+
+**Phase 2a (`studies`):**
+- Extract a shared `_require_study_and_study_tag(...)` validation helper once a
+  3rd copy of the study/tag existence + type-check block appears (Rule of Three:
+  2 copies today).
+- Add a direct `StudyRepository.get_by_id`/`get_tag` repository test (currently
+  covered only transitively via the Service tests) — low priority.
+- No test for the existing-link + `comment=None` no-op branch; `patch_study_tag`
+  has no dedicated unknown-study/tag 404 test (its paths are identical to
+  `tag_study`'s, which are tested).
+
+**Phase 2b (`features`):**
+- `FeatureRepository.count_segmentations` / `segmentation_counts` positive
+  (non-zero) path is tested nowhere against real `Segmentation` rows — only the
+  empty branch and a fake-injected blocking-delete guard. Add a positive-path
+  count test once a `Segmentation` test factory exists (needs the
+  `ImageInstance → Series + Creator` + enum-FK graph). Regression risk only if
+  these two queries are later refactored.
+- Add a one-line comment documenting `_SegBlockingRepo`'s guard-order dependency
+  (test helper).
+- `dto_converter.py` (out of this project's scope, flagged in passing): a
+  `ChildLinks` `getattr` fallback is structurally dead (the attribute never
+  existed) — delete it and its misleading comment; `feature_to_get` double-sorts
+  `FeatureAssociations` (CPU-only, cached collection).
+
+**Phase 2c (`tag`):**
+- Add an unstar-on-unknown-tag test (behaviorally identical to the existing
+  no-op test; left out per lean-test-granularity).
+
+**Phase 3a (`task`):**
+- `TaskRepository.subtask_counts(session, [])` == `{}` empty-input case (part of
+  the Interfaces contract) is untested — a one-line assert closes it.
+- `count_for_task`'s zero-row/zero-match case is asserted only by reading the
+  code (0-not-`None`), not by a test.
+- Ordering tests for `list_all` (`order_by(Task.TaskID)`) and `all_ids_for_task`
+  (`order_by(SubTaskID)`) pass trivially — SQLite insertion order coincides with
+  id order, so they don't independently prove the `ORDER BY`. Strengthen with
+  out-of-order inserts.
+- `delete_task`'s deleted-data snapshot has a dead `else None` branch
+  (`str(TaskState) if TaskState else None`; the enum is always truthy) —
+  cosmetic cleanup.
+- `create_task` audit fields omit `task_state`/`creator_id` (plan-mandated) —
+  revisit only if a richer insert-audit is wanted; loses no real info today
+  (`creator_id == actor.id` is logged as `user_id`; `task_state` is
+  deterministically `NotStarted`).
+- Perf (forward note only): `list_task_subtasks` issues 4 sequential queries and
+  `all_ids_for_task` scans the full unfiltered set per page — brief-mandated;
+  revisit if per-task subtask counts grow large.
+
+**Phase 3b (`subtask`):**
+- Re-linking the same image to the same subtask hits `SubTaskImageLink`'s
+  composite PK → `IntegrityError` → HTTP 500 (behavior-preserving vs. the old
+  route's caught 500). A proper 409 contract is deferred to the
+  transaction-ownership review above.
+- `add_image` / `remove_image` are annotated `-> SubTask` but can return
+  `SubTask | None` (runtime-safe via pre-checks/FK; a mypy/pyright nit).
+- `update_subtask`'s `session.refresh` is redundant under
+  `expire_on_commit=True`; dropping it unifies the 3 mutators.
+
+**Phase 4a (`instances`):**
+- `ImageInstanceService.tag`/`patch`/`untag` inline the instance-resolve +
+  None-check that duplicates `get_for_storage` — left self-contained
+  deliberately (same duplication class as the Phase 4b `tag`/`patch_tag` guard
+  block).
+
+**Phase 4b (`form_annotations`):**
+- `FormAnnotationService.update` reproduces a pre-refactor audit-log quirk
+  verbatim: its `changes` dict does `getattr(annotation, <snake_case_key>, None)`
+  on a PascalCase ORM object, so every logged change reads `None -> <new>`
+  (audit-log-only, not an API response; now unpinned by any test). Correct
+  source would be `_FIELD_MAP[key]` (and handling `image_id`). Fold into the
+  transaction-ownership / audit-logging review above.
+- `FormAnnotationService.tag` and `.patch_tag` duplicate an identical ~8-line
+  annotation + tag + wrong-type guard block; extract a private
+  `_load_annotation_and_typed_tag(...)` helper (Rule-of-Three: 2 copies today).
+- `server/services/__init__.py` `__all__` reordered `FeatureService` while
+  adding the new export (inert; drop to keep the diff minimal).
+- Redundant explicit `return None` in `soft_delete` / `set_value` / `untag`
+  (the methods are `-> None`).
+- `get_annotation`'s happy path (returns the row with tag links loaded) has no
+  direct Service-level test — only its 404 path; add a 2-line "returns the row"
+  test when Phase 4c next touches this file. (The repo-level `get_with_tag_links`
+  found/empty case IS tested.)
+- Pre-existing `ImageInstance.DatasetIdentifier is deprecated` DeprecationWarning
+  surfaces via the `_make_image` test helper (suite-wide, ~159 at baseline; not
+  introduced by this phase).
+
+**Phase 4c (`segmentations`):**
+- **Zarr concurrency (follow-up, not a migration bug).** The known concurrent
+  read/write failures are unchanged by this phase. The new `SegmentationDataStore`
+  port is the intended seam for the fix — e.g. a `LockingSegmentationDataStore`
+  decorator, or a backend with real concurrent-write support — swapped in
+  `get_segmentation_data_store()` with no Service/route/test edits. Note two
+  limits: `get_zarr_storage_manager()`/`get_data_access_adapter()` are
+  process-global `@lru_cache` singletons, so an in-process lock won't cover the
+  RQ-worker path; and the server path (this port) and the client path
+  (`DataAccessAdapter`) are two seams to the same store — unifying them so the
+  fix lives once is the real long-term win.
+- `POST /segmentations/{id}/tags` ignores the client-supplied `ObjectTagPOST.comment`
+  (no `Comment` persisted), unlike the instance/form-annotation taggers which do
+  store it. Preserved verbatim from the pre-refactor handler; revisit for
+  consistency (would change the `TagMeta.comment` in the response, hence deferred).
+- `SegmentationService.patch` reproduces the pre-refactor audit double-apply
+  quirk: `reference_segmentation_id`/`feature_id` are assigned before the
+  change-string is built, so they log `<new> -> <new>` while `threshold` logs the
+  correct `<old> -> <new>`. Audit-log-only; fold into the audit-logging cleanup.
+- `PUT /segmentations/{id}/data` and `PUT /model-segmentations/{id}/data` return
+  the raw ORM row (no `response_model`); fragile but behavior-preserving.
+- `GET /segmentations/{id}` eager-loads tag links (`get_with_tag_links`) that the
+  DTO then discards (`segmentation_to_get` called without `with_tag_metadata`).
+  Faithful to the extracted query; drop the eager-load or pass the flag once the
+  intended behavior is confirmed.
+- Zarr binary I/O runs inside `async def` handlers (blocking-in-async); pre-existing,
+  out of scope for a behavior-preserving migration.
+- `ModelSegmentation` write happy-path and repository `get_by_id` positive path are
+  unit-tested only via the 404 branches (a `SegmentationModel` test factory does
+  not exist yet); add once one does, alongside the Phase 2b positive-count test.

--- a/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
+++ b/docs/superpowers/specs/2026-07-03-repository-service-layer-design.md
@@ -35,8 +35,10 @@ itself into this change.
 - Migrating CLI/worker code (`orm/eyened_orm/commands/`) to use the new
   Repositories. Explicitly desired for the future, but out of scope here.
 - Converting `search.py` (1257 lines, a large cross-cutting/ad hoc query
-  surface) or `auth.py` (831 lines, token/session logic, not model-CRUD
-  shaped) to this pattern.
+  surface), `auth.py` (831 lines, token/session logic, not model-CRUD
+  shaped), or `import_api.py` (341 lines, import-pipeline and RQ job
+  orchestration built on the `eyened_orm.importer` subsystem, not
+  model-CRUD shaped) to this pattern.
 - Deprecating or removing `Base`'s existing generic query classmethods
   (`where`, `by_columns`, `get_or_create`, `by_name`, `select`) — they stay
   as-is and may still be used, including internally by new Repositories.
@@ -147,8 +149,8 @@ model(s), switch the corresponding route module to use them, ship.
 | 1 | `form_schema.py` (25 lines), `patients.py` (34 lines) | Still small; `patients.py` is RBAC-relevant (Step 2), an early real-world validation of the pattern on a meaningful model |
 | 2 | `studies.py`, `feature.py`, `tag.py` | Medium-sized, self-contained |
 | 3 | `subtask.py`, `task.py` | RBAC-relevant (Step 2); larger, touch `Task`, `SubTask`, `TaskDefinition` |
-| 4 | `import_api.py`, `instances.py`, `form_annotations.py`, `segmentations.py` | RBAC-relevant (Step 2: `FormAnnotation`, `Segmentation`); largest, most complex query logic to extract |
-| Out of scope | `search.py`, `auth.py` | See Non-goals |
+| 4 | `instances.py`, `form_annotations.py`, `segmentations.py` | RBAC-relevant (Step 2: `FormAnnotation`, `Segmentation`); largest, most complex query logic to extract |
+| Out of scope | `search.py`, `auth.py`, `import_api.py` | See Non-goals |
 
 ## Error Handling
 
@@ -197,3 +199,17 @@ model(s), switch the corresponding route module to use them, ship.
   enforcement via Service-layer authz checks) — separate brainstorm.
 - Migrate CLI/worker code in `orm/eyened_orm/commands/` to use Repositories.
 - Decide whether/how to convert `search.py` and `auth.py`.
+- **Transaction ownership — revisit across all Services once the layer
+  refactoring is done.** The mutating Services carried over today's
+  route behavior of calling `session.commit()` (and `session.refresh()`)
+  directly inside each method. This couples the Service to the transaction
+  lifecycle, has no explicit rollback on error, and runs audit logging
+  *after* commit (so a logging failure can't undo a persisted write). It
+  matches the pre-refactor behavior, so it is not a regression, but the
+  boundary should be decided deliberately for the layer as a whole rather
+  than per-method. Once all phases have migrated, review every Service and
+  pick one consistent model — e.g. move the commit boundary into the
+  `get_db` dependency / a unit-of-work context manager (Services `flush`,
+  the caller commits once), so rollback-on-error and audit-inside-the-
+  transaction come for free. Check for double-commit before changing
+  (`grep -rn "\.commit()" server/services server/routes server/db.py`).

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -4,6 +4,10 @@ from .form_annotation_repository import FormAnnotationRepository
 from .form_schema_repository import FormSchemaRepository
 from .image_instance_repository import ImageInstanceRepository
 from .patient_repository import PatientRepository
+from .segmentation_repository import (
+    ModelSegmentationRepository,
+    SegmentationRepository,
+)
 from .study_repository import StudyRepository
 from .tag_repository import TagRepository
 from .task_repository import SubTaskRepository, TaskRepository
@@ -19,4 +23,6 @@ __all__ = [
     "TagRepository",
     "TaskRepository",
     "SubTaskRepository",
+    "SegmentationRepository",
+    "ModelSegmentationRepository",
 ]

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -1,6 +1,7 @@
 from .device_repository import DeviceRepository
 from .feature_repository import FeatureRepository
 from .form_schema_repository import FormSchemaRepository
+from .image_instance_repository import ImageInstanceRepository
 from .patient_repository import PatientRepository
 from .study_repository import StudyRepository
 from .tag_repository import TagRepository
@@ -12,6 +13,7 @@ __all__ = [
     "FormSchemaRepository",
     "StudyRepository",
     "FeatureRepository",
+    "ImageInstanceRepository",
     "TagRepository",
     "TaskRepository",
     "SubTaskRepository",

--- a/orm/eyened_orm/repositories/__init__.py
+++ b/orm/eyened_orm/repositories/__init__.py
@@ -1,5 +1,6 @@
 from .device_repository import DeviceRepository
 from .feature_repository import FeatureRepository
+from .form_annotation_repository import FormAnnotationRepository
 from .form_schema_repository import FormSchemaRepository
 from .image_instance_repository import ImageInstanceRepository
 from .patient_repository import PatientRepository
@@ -10,6 +11,7 @@ from .task_repository import SubTaskRepository, TaskRepository
 __all__ = [
     "DeviceRepository",
     "PatientRepository",
+    "FormAnnotationRepository",
     "FormSchemaRepository",
     "StudyRepository",
     "FeatureRepository",

--- a/orm/eyened_orm/repositories/form_annotation_repository.py
+++ b/orm/eyened_orm/repositories/form_annotation_repository.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import (
+    FormAnnotation,
+    FormAnnotationTagLink,
+    ImageInstance,
+    ImageInstanceTagLink,
+    Study,
+    StudyTagLink,
+)
+
+
+class FormAnnotationRepository:
+    """Data access for FormAnnotation reads and its Tag links."""
+
+    def get_by_id(
+        self, session: Session, annotation_id: int
+    ) -> FormAnnotation | None:
+        """Return the annotation by id, or None if absent."""
+        return session.get(FormAnnotation, annotation_id)
+
+    def get_with_tag_links(
+        self, session: Session, annotation_id: int
+    ) -> FormAnnotation | None:
+        """Return the annotation by id with its tag links loaded, or None."""
+        return session.get(
+            FormAnnotation,
+            annotation_id,
+            options=(
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Tag),
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Creator),
+            ),
+        )
+
+    def list_active(
+        self,
+        session: Session,
+        *,
+        patient_id: int | None = None,
+        study_id: int | None = None,
+        image_instance_id: int | None = None,
+        form_schema_id: int | None = None,
+        sub_task_id: int | None = None,
+    ) -> list[FormAnnotation]:
+        """Return active (``~Inactive``) annotations matching the given filters.
+
+        Mirrors the eager-load graph the ``GET /form-annotations`` handler
+        built inline. ``image_instance_id`` is already resolved from a
+        PublicID by the Service; ``None`` filters are not applied.
+        """
+        query = (
+            select(FormAnnotation)
+            .filter(~FormAnnotation.Inactive)
+            .options(
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Tag),
+                selectinload(
+                    FormAnnotation.FormAnnotationTagLinks
+                ).selectinload(FormAnnotationTagLink.Creator),
+                selectinload(FormAnnotation.Study)
+                .selectinload(Study.StudyTagLinks)
+                .selectinload(StudyTagLink.Tag),
+                selectinload(FormAnnotation.Study)
+                .selectinload(Study.StudyTagLinks)
+                .selectinload(StudyTagLink.Creator),
+                selectinload(FormAnnotation.ImageInstance)
+                .selectinload(ImageInstance.ImageInstanceTagLinks)
+                .selectinload(ImageInstanceTagLink.Tag),
+                selectinload(FormAnnotation.ImageInstance)
+                .selectinload(ImageInstance.ImageInstanceTagLinks)
+                .selectinload(ImageInstanceTagLink.Creator),
+            )
+        )
+        if patient_id is not None:
+            query = query.filter(FormAnnotation.PatientID == patient_id)
+        if study_id is not None:
+            query = query.filter(FormAnnotation.StudyID == study_id)
+        if image_instance_id is not None:
+            query = query.filter(
+                FormAnnotation.ImageInstanceID == image_instance_id
+            )
+        if form_schema_id is not None:
+            query = query.filter(FormAnnotation.FormSchemaID == form_schema_id)
+        if sub_task_id is not None:
+            query = query.filter(FormAnnotation.SubTaskID == sub_task_id)
+        return list(session.scalars(query).all())
+
+    def get_tag_link(
+        self, session: Session, tag_id: int, annotation_id: int
+    ) -> FormAnnotationTagLink | None:
+        """Return the link for (tag_id, annotation_id), or None if absent."""
+        return session.get(
+            FormAnnotationTagLink,
+            {"TagID": tag_id, "FormAnnotationID": annotation_id},
+        )

--- a/orm/eyened_orm/repositories/image_instance_repository.py
+++ b/orm/eyened_orm/repositories/image_instance_repository.py
@@ -147,3 +147,16 @@ class ImageInstanceRepository:
             ImageInstanceTagLink,
             {"TagID": tag_id, "ImageInstanceID": image_instance_id},
         )
+
+    def get_by_public_id(
+        self, session: Session, public_id: str
+    ) -> ImageInstance | None:
+        """Return the instance with this PublicID (no eager loads), or None.
+
+        Plain PublicID resolver used to map an external image id to its row —
+        the faithful equivalent of the legacy ``_resolve_image_instance_id``
+        helper (no PK/digit fallback, unlike ``get_full_graph_by_public_id``).
+        """
+        return session.scalars(
+            select(ImageInstance).where(ImageInstance.PublicID == public_id)
+        ).first()

--- a/orm/eyened_orm/repositories/image_instance_repository.py
+++ b/orm/eyened_orm/repositories/image_instance_repository.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import (
+    DeviceInstance,
+    FormAnnotation,
+    ImageInstance,
+    ImageInstanceTagLink,
+    ImageStorage,
+    ModelSegmentation,
+    Patient,
+    Segmentation,
+    Series,
+    Study,
+)
+from eyened_orm.tag import FormAnnotationTagLink, SegmentationTagLink
+
+_STORAGE_LOADER = selectinload(ImageInstance.ImageStorages).selectinload(
+    ImageStorage.StorageBackend
+)
+
+
+def _full_graph_options(
+    with_segmentations: bool,
+    with_form_annotations: bool,
+    with_model_segmentations: bool,
+) -> list:
+    """Build the conditional selectinload chain the two GET readers share."""
+    opts = [
+        selectinload(ImageInstance.Series)
+        .selectinload(Series.Study)
+        .selectinload(Study.Patient)
+        .selectinload(Patient.Project),
+        selectinload(ImageInstance.DeviceInstance).selectinload(
+            DeviceInstance.DeviceModel
+        ),
+        selectinload(ImageInstance.Scan),
+        _STORAGE_LOADER,
+        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
+            ImageInstanceTagLink.Tag
+        ),
+        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
+            ImageInstanceTagLink.Creator
+        ),
+    ]
+    if with_segmentations:
+        opts += [
+            selectinload(ImageInstance.Segmentations).selectinload(
+                Segmentation.Feature
+            ),
+            selectinload(ImageInstance.Segmentations).selectinload(
+                Segmentation.Creator
+            ),
+            selectinload(ImageInstance.Segmentations)
+            .selectinload(Segmentation.SegmentationTagLinks)
+            .selectinload(SegmentationTagLink.Tag),
+            selectinload(ImageInstance.Segmentations)
+            .selectinload(Segmentation.SegmentationTagLinks)
+            .selectinload(SegmentationTagLink.Creator),
+        ]
+    if with_form_annotations:
+        opts += [
+            selectinload(ImageInstance.FormAnnotations)
+            .selectinload(FormAnnotation.FormAnnotationTagLinks)
+            .selectinload(FormAnnotationTagLink.Tag),
+            selectinload(ImageInstance.FormAnnotations)
+            .selectinload(FormAnnotation.FormAnnotationTagLinks)
+            .selectinload(FormAnnotationTagLink.Creator),
+        ]
+    if with_model_segmentations:
+        opts += [
+            selectinload(ImageInstance.ModelSegmentations).selectinload(
+                ModelSegmentation.Model
+            ),
+        ]
+    return opts
+
+
+class ImageInstanceRepository:
+    """Data access for ImageInstance reads and its Tag links."""
+
+    def get_full_graph_by_id(
+        self,
+        session: Session,
+        instance_id: int,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance | None:
+        """Return the instance by int id with the conditional graph, or None."""
+        opts = _full_graph_options(
+            with_segmentations, with_form_annotations, with_model_segmentations
+        )
+        return session.get(ImageInstance, instance_id, options=tuple(opts))
+
+    def get_full_graph_by_public_id(
+        self,
+        session: Session,
+        image_id: str,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance | None:
+        """Return the instance by PublicID (numeric-PK fallback), or None."""
+        opts = _full_graph_options(
+            with_segmentations, with_form_annotations, with_model_segmentations
+        )
+        item = (
+            session.scalars(
+                select(ImageInstance)
+                .options(*opts)
+                .where(ImageInstance.PublicID == image_id)
+            )
+            .first()
+        )
+        if item is None and image_id.isdigit():
+            item = session.get(ImageInstance, int(image_id), options=tuple(opts))
+        return item
+
+    def get_with_storage_by_public_id(
+        self, session: Session, public_id: str
+    ) -> ImageInstance | None:
+        """Return the instance by PublicID with storage loaded (PK fallback), or None.
+
+        Mirrors the legacy ``_get_image_instance_by_public_id`` resolver: try the
+        PublicID; on no match fall back to ``session.get`` with the raw id.
+        """
+        try:
+            return session.scalars(
+                select(ImageInstance)
+                .options(_STORAGE_LOADER)
+                .where(ImageInstance.PublicID == public_id)
+            ).one()
+        except NoResultFound:
+            return session.get(ImageInstance, public_id)
+
+    def get_tag_link(
+        self, session: Session, tag_id: int, image_instance_id: int
+    ) -> ImageInstanceTagLink | None:
+        """Return the link for (tag_id, image_instance_id), or None if absent."""
+        return session.get(
+            ImageInstanceTagLink,
+            {"TagID": tag_id, "ImageInstanceID": image_instance_id},
+        )

--- a/orm/eyened_orm/repositories/segmentation_repository.py
+++ b/orm/eyened_orm/repositories/segmentation_repository.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session, selectinload
+
+from eyened_orm import ModelSegmentation, Segmentation
+from eyened_orm.tag import SegmentationTagLink
+
+
+class SegmentationRepository:
+    """Data access for Segmentation reads and its Tag links."""
+
+    def get_by_id(
+        self, session: Session, segmentation_id: int
+    ) -> Segmentation | None:
+        """Return the segmentation by id, or None if absent."""
+        return session.get(Segmentation, segmentation_id)
+
+    def get_with_tag_links(
+        self, session: Session, segmentation_id: int
+    ) -> Segmentation | None:
+        """Return the segmentation with its tag links loaded, or None.
+
+        Mirrors the eager-load graph the ``GET /segmentations/{id}`` handler
+        built inline.
+        """
+        return session.get(
+            Segmentation,
+            segmentation_id,
+            options=(
+                selectinload(Segmentation.SegmentationTagLinks).selectinload(
+                    SegmentationTagLink.Tag
+                ),
+                selectinload(Segmentation.SegmentationTagLinks).selectinload(
+                    SegmentationTagLink.Creator
+                ),
+            ),
+        )
+
+    def get_tag_link(
+        self, session: Session, tag_id: int, segmentation_id: int
+    ) -> SegmentationTagLink | None:
+        """Return the link for (tag_id, segmentation_id), or None if absent."""
+        return session.get(
+            SegmentationTagLink,
+            {"TagID": tag_id, "SegmentationID": segmentation_id},
+        )
+
+
+class ModelSegmentationRepository:
+    """Data access for ModelSegmentation reads (data endpoints only)."""
+
+    def get_by_id(
+        self, session: Session, model_segmentation_id: int
+    ) -> ModelSegmentation | None:
+        """Return the model segmentation by id, or None if absent."""
+        return session.get(ModelSegmentation, model_segmentation_id)

--- a/orm/eyened_orm/repositories/task_repository.py
+++ b/orm/eyened_orm/repositories/task_repository.py
@@ -133,3 +133,47 @@ class SubTaskRepository:
         return list(
             session.execute(stmt.limit(limit).offset(offset)).scalars().all()
         )
+
+    def get_by_id(self, session: Session, subtask_id: int) -> SubTask | None:
+        """Return the subtask with the given id, or None if absent."""
+        return session.get(SubTask, subtask_id)
+
+    def get_with_images(self, session: Session, subtask_id: int) -> SubTask | None:
+        """Return the subtask with its image links eager-loaded, or None."""
+        return (
+            session.execute(
+                select(SubTask)
+                .options(_SUBTASK_IMAGE_LOADER)
+                .where(SubTask.SubTaskID == subtask_id)
+            )
+            .scalars()
+            .first()
+        )
+
+    def resolve_image_instance_id(
+        self, session: Session, public_id: str
+    ) -> int | None:
+        """Return the ImageInstanceID for a PublicID, or None if no image matches."""
+        return session.scalar(
+            select(ImageInstance.ImageInstanceID).where(
+                ImageInstance.PublicID == public_id
+            )
+        )
+
+    def next_image_index(self, session: Session, subtask_id: int) -> int:
+        """Return the next ImageIndex for the subtask (max+1, or 0 if it has none)."""
+        current_max = session.scalar(
+            select(func.max(SubTaskImageLink.ImageIndex)).where(
+                SubTaskImageLink.SubTaskID == subtask_id
+            )
+        )
+        return 0 if current_max is None else current_max + 1
+
+    def get_image_link(
+        self, session: Session, subtask_id: int, image_instance_id: int
+    ) -> SubTaskImageLink | None:
+        """Return the link for (subtask_id, image_instance_id), or None if absent."""
+        return session.get(
+            SubTaskImageLink,
+            {"SubTaskID": subtask_id, "ImageInstanceID": image_instance_id},
+        )

--- a/orm/eyened_orm/tests/test_form_annotation_repository.py
+++ b/orm/eyened_orm/tests/test_form_annotation_repository.py
@@ -1,0 +1,69 @@
+from eyened_orm import Creator, FormAnnotation, FormSchema, Patient, Project
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.form_annotation_repository import (
+    FormAnnotationRepository,
+)
+
+
+def _make_annotation(
+    session,
+    key: str,
+    *,
+    inactive: bool = False,
+    study_id: int | None = None,
+    image_instance_id: int | None = None,
+) -> FormAnnotation:
+    """Build the minimal FK graph a FormAnnotation requires; return the row."""
+    project = Project(ProjectName=f"P-{key}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{key}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    schema = FormSchema(SchemaName=f"S-{key}")
+    session.add(schema)
+    session.flush()
+    creator = Creator(CreatorName=f"c-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    ann = FormAnnotation(
+        FormSchemaID=schema.FormSchemaID,
+        PatientID=patient.PatientID,
+        CreatorID=creator.CreatorID,
+        StudyID=study_id,
+        ImageInstanceID=image_instance_id,
+        Inactive=inactive,
+        FormData={"k": "v"},
+    )
+    session.add(ann)
+    session.flush()
+    return ann
+
+
+def test_list_active_excludes_inactive_and_filters_by_schema(session):
+    """list_active drops Inactive rows and applies the form_schema_id filter."""
+    keep = _make_annotation(session, "keep")
+    _make_annotation(session, "gone", inactive=True)
+    repo = FormAnnotationRepository()
+
+    rows = repo.list_active(session)
+    ids = {r.FormAnnotationID for r in rows}
+    assert keep.FormAnnotationID in ids
+    assert all(not r.Inactive for r in rows)
+
+    by_schema = repo.list_active(session, form_schema_id=keep.FormSchemaID)
+    assert [r.FormAnnotationID for r in by_schema] == [keep.FormAnnotationID]
+
+    assert repo.list_active(session, form_schema_id=999_999) == []
+
+
+def test_get_with_tag_links_found_and_missing(session):
+    """get_with_tag_links returns the row (tag links loaded) or None if absent."""
+    ann = _make_annotation(session, "one")
+    repo = FormAnnotationRepository()
+
+    got = repo.get_with_tag_links(session, ann.FormAnnotationID)
+    assert got is not None and got.FormAnnotationID == ann.FormAnnotationID
+    assert list(got.FormAnnotationTagLinks) == []  # eager-loaded, empty
+
+    assert repo.get_with_tag_links(session, 999_999) is None

--- a/orm/eyened_orm/tests/test_image_instance_repository.py
+++ b/orm/eyened_orm/tests/test_image_instance_repository.py
@@ -1,0 +1,81 @@
+import datetime
+
+from eyened_orm import (
+    DeviceInstance,
+    DeviceModel,
+    ImageInstance,
+    Patient,
+    Project,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal Series/Device graph an ImageInstance FK-requires.
+
+    Returns the new ImageInstanceID.
+    """
+    project = Project(ProjectName=f"P-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer=f"Mf-{public_id}", ManufacturerModelName=f"M-{public_id}")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{public_id}",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_get_full_graph_by_public_id_resolves_graph_and_digit_fallback(session):
+    """Resolve by PublicID (all eager-load branches on), else by numeric PK string."""
+    image_id = _make_image(session, "pub-str")
+    _make_image(session, "9999")  # a PublicID that is itself a digit string
+    repo = ImageInstanceRepository()
+    # all flags True so the conditional selectinload branches are exercised
+    kw = dict(
+        with_segmentations=True,
+        with_form_annotations=True,
+        with_model_segmentations=True,
+    )
+
+    by_public = repo.get_full_graph_by_public_id(session, "pub-str", **kw)
+    assert by_public is not None and by_public.ImageInstanceID == image_id
+    assert by_public.Series.Study.Patient.Project is not None  # base graph loaded
+
+    # A numeric string that is not a PublicID falls back to session.get(int)
+    by_pk = repo.get_full_graph_by_public_id(session, str(image_id), **kw)
+    assert by_pk is not None and by_pk.ImageInstanceID == image_id
+
+    assert repo.get_full_graph_by_public_id(session, "no-such-id", **kw) is None
+
+
+def test_get_with_storage_by_public_id_found_and_missing(session):
+    """get_with_storage_by_public_id resolves by PublicID, or None if absent."""
+    image_id = _make_image(session, "pub-store")
+    repo = ImageInstanceRepository()
+
+    item = repo.get_with_storage_by_public_id(session, "pub-store")
+    assert item is not None and item.ImageInstanceID == image_id
+
+    assert repo.get_with_storage_by_public_id(session, "missing") is None

--- a/orm/eyened_orm/tests/test_segmentation_repository.py
+++ b/orm/eyened_orm/tests/test_segmentation_repository.py
@@ -40,7 +40,7 @@ def _make_segmentation(
     series = Series(StudyID=study.StudyID)
     session.add(series)
     session.flush()
-    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    model = DeviceModel(Manufacturer=f"Mf-{key}", ManufacturerModelName=f"M-{key}")
     session.add(model)
     session.flush()
     device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")

--- a/orm/eyened_orm/tests/test_segmentation_repository.py
+++ b/orm/eyened_orm/tests/test_segmentation_repository.py
@@ -1,0 +1,94 @@
+from datetime import date, datetime
+
+from eyened_orm import (
+    Creator,
+    DeviceInstance,
+    DeviceModel,
+    Feature,
+    ImageInstance,
+    Patient,
+    Project,
+    Segmentation,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.segmentation import DataRepresentation, Datatype
+from eyened_orm.repositories.segmentation_repository import SegmentationRepository
+
+
+def _make_segmentation(
+    session,
+    key: str,
+    *,
+    inactive: bool = False,
+    feature_id: int | None = None,
+    reference_segmentation_id: int | None = None,
+) -> Segmentation:
+    """Build the minimal, dimensionally-consistent FK graph a Segmentation
+    requires (Project→Patient→Study→Series→Device→ImageInstance + Creator +
+    Feature) and return a dense 1x4x4 row matching the image shape."""
+    project = Project(ProjectName=f"P-{key}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{key}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=date.today())
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=f"img-{key}",
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{key}",
+        Rows_y=4,
+        Columns_x=4,
+    )
+    session.add(image)
+    session.flush()
+    creator = Creator(CreatorName=f"c-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    if feature_id is None:
+        feature = Feature(FeatureName=f"feat-{key}")
+        session.add(feature)
+        session.flush()
+        feature_id = feature.FeatureID
+    seg = Segmentation(
+        ImageInstanceID=image.ImageInstanceID,
+        FeatureID=feature_id,
+        CreatorID=creator.CreatorID,
+        DataType=Datatype.R8UI,
+        DataRepresentation=DataRepresentation.Binary,
+        Depth=1,
+        Height=4,
+        Width=4,
+        ReferenceSegmentationID=reference_segmentation_id,
+        Inactive=inactive,
+        DateInserted=datetime.now(),
+    )
+    session.add(seg)
+    session.flush()
+    return seg
+
+
+def test_get_with_tag_links_found_and_missing(session):
+    """get_with_tag_links returns the row (tag links eager-loaded) or None."""
+    seg = _make_segmentation(session, "one")
+    repo = SegmentationRepository()
+
+    got = repo.get_with_tag_links(session, seg.SegmentationID)
+    assert got is not None and got.SegmentationID == seg.SegmentationID
+    assert list(got.SegmentationTagLinks) == []  # eager-loaded, empty
+
+    assert repo.get_with_tag_links(session, 999_999) is None

--- a/orm/eyened_orm/tests/test_task_repository.py
+++ b/orm/eyened_orm/tests/test_task_repository.py
@@ -219,3 +219,53 @@ def test_list_for_task_with_images_loads_links(session):
     assert [link.ImageInstance.PublicID for link in rows[0].SubTaskImageLinks] == [
         "pub-1"
     ]
+
+
+def test_get_with_images_loads_link_chain(session):
+    """get_with_images returns the subtask with its image links eager-loaded."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    st = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    image_id = _make_image(session, "pub-1")
+    from eyened_orm import SubTaskImageLink
+
+    session.add(
+        SubTaskImageLink(SubTaskID=st.SubTaskID, ImageInstanceID=image_id, ImageIndex=0)
+    )
+    session.flush()
+
+    loaded = SubTaskRepository().get_with_images(session, st.SubTaskID)
+
+    assert loaded is not None
+    assert [link.ImageInstance.PublicID for link in loaded.SubTaskImageLinks] == ["pub-1"]
+
+
+def test_resolve_image_instance_id_found_and_missing(session):
+    """resolve_image_instance_id maps a PublicID to its int id, or None if absent."""
+    image_id = _make_image(session, "pub-42")
+    repo = SubTaskRepository()
+
+    assert repo.resolve_image_instance_id(session, "pub-42") == image_id
+    assert repo.resolve_image_instance_id(session, "nope") is None
+
+
+def test_next_image_index_starts_at_zero_then_increments(session):
+    """next_image_index is 0 for a subtask with no links, else max(ImageIndex)+1."""
+    creator = _creator(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, creator.CreatorID)
+    st = _make_subtask(session, task.TaskID, SubTaskState.NotStarted)
+    image_id = _make_image(session, "pub-1")
+    repo = SubTaskRepository()
+
+    assert repo.next_image_index(session, st.SubTaskID) == 0
+
+    from eyened_orm import SubTaskImageLink
+
+    session.add(
+        SubTaskImageLink(SubTaskID=st.SubTaskID, ImageInstanceID=image_id, ImageIndex=3)
+    )
+    session.flush()
+
+    assert repo.next_image_index(session, st.SubTaskID) == 4

--- a/orm/eyened_orm/utils/sqlite_testdb.py
+++ b/orm/eyened_orm/utils/sqlite_testdb.py
@@ -90,7 +90,11 @@ def engine():
 
 @pytest.fixture(scope="function")
 def SessionLocal(engine):
-    return sessionmaker(bind=engine, future=True, expire_on_commit=False, class_=Session)
+    # expire_on_commit=True mirrors the production session factory
+    # (orm/eyened_orm/db.py uses SQLAlchemy's default True), so tests reproduce
+    # production's commit-time expiry: state loaded before a commit is reloaded
+    # from the DB on next access, rather than lingering stale in the identity map.
+    return sessionmaker(bind=engine, future=True, expire_on_commit=True, class_=Session)
 
 
 @pytest.fixture(scope="function")

--- a/server/routes/form_annotations.py
+++ b/server/routes/form_annotations.py
@@ -1,85 +1,40 @@
 from typing import List, Optional
 
-from eyened_orm import (
-    FormAnnotation,
-    FormAnnotationTagLink,
-    ImageInstance,
-    ImageInstanceTagLink,
-    Study,
-    StudyTagLink,
-    Tag,
-)
-from eyened_orm.tag import TagType
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from sqlalchemy import select
-from sqlalchemy.orm import Session, selectinload
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
 
 from ..db import get_db
-from ..utils.db_logging import get_db_logger
 from ..dtos.dto_converter import DTOConverter
 from ..dtos.dtos_aux import ObjectTagPATCH, ObjectTagPOST, TagMeta
-from ..dtos.dtos_main import FormAnnotationGET, FormAnnotationPATCH, FormAnnotationPUT
+from ..dtos.dtos_main import (
+    FormAnnotationGET,
+    FormAnnotationPATCH,
+    FormAnnotationPUT,
+)
+from ..services.acting_user import ActingUser
+from ..services.form_annotation_service import (
+    FormAnnotationService,
+    get_form_annotation_service,
+)
 from .auth import CurrentUser, get_current_user
 
 router = APIRouter()
 
 
-def _resolve_image_instance_id(db: Session, image_id: Optional[str]) -> Optional[int]:
-    if image_id is None:
-        return None
-    item = (
-        db.query(ImageInstance)
-        .filter(ImageInstance.PublicID == image_id)
-        .first()
-    )
-    if item:
-        return item.ImageInstanceID
-    raise HTTPException(status_code=404, detail="ImageInstance not found")
-
 @router.post("/form-annotations", response_model=FormAnnotationGET)
 async def create_form_annotation(
     annotation: FormAnnotationPUT,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    # Map DTO snake_case to ORM PascalCase fields
-    payload = annotation.dict()
-    image_instance_id = _resolve_image_instance_id(db, payload.get("image_id"))
-    new_annotation = FormAnnotation(
-        FormSchemaID=payload.get("form_schema_id"),
-        PatientID=payload.get("patient_id"),
-        StudyID=payload.get("study_id"),
-        ImageInstanceID=image_instance_id,
-        Laterality=payload.get("laterality"),
-        CreatorID=current_user.id,
-        SubTaskID=payload.get("sub_task_id"),
-        FormData=payload.get("form_data"),
-        FormAnnotationReferenceID=payload.get("form_annotation_reference_id"),
+    """Create a form annotation."""
+    item = service.create(
+        db,
+        actor=ActingUser(id=current_user.id, username=current_user.username),
+        **annotation.dict(),
     )
-
-    db.add(new_annotation)
-    db.commit()
-    db.refresh(new_annotation)
-    
-    # Log form annotation creation
-    logger = get_db_logger()
-    if logger:
-        logger.log_insert(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint="POST /api/form-annotations",
-            entity="FormAnnotation",
-            entity_id=new_annotation.FormAnnotationID,
-            fields={
-                "form_schema_id": new_annotation.FormSchemaID,
-                "patient_id": new_annotation.PatientID,
-                "study_id": new_annotation.StudyID,
-                "image_instance_id": new_annotation.ImageInstanceID,
-                "sub_task_id": new_annotation.SubTaskID,
-            },
-        )
-    
-    return DTOConverter.form_annotation_to_get(new_annotation)
+    return DTOConverter.form_annotation_to_get(item)
 
 
 @router.get("/form-annotations", response_model=List[FormAnnotationGET])
@@ -90,70 +45,31 @@ async def get_form_annotations(
     form_schema_id: Optional[int] = None,
     sub_task_id: Optional[int] = None,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    query = (
-        select(FormAnnotation)
-        .filter(~FormAnnotation.Inactive)
-        .options(
-            selectinload(FormAnnotation.FormAnnotationTagLinks).selectinload(
-                FormAnnotationTagLink.Tag
-            ),
-            selectinload(FormAnnotation.FormAnnotationTagLinks).selectinload(
-                FormAnnotationTagLink.Creator
-            ),
-            selectinload(FormAnnotation.Study)
-            .selectinload(Study.StudyTagLinks)
-            .selectinload(StudyTagLink.Tag),
-            selectinload(FormAnnotation.Study)
-            .selectinload(Study.StudyTagLinks)
-            .selectinload(StudyTagLink.Creator),
-            selectinload(FormAnnotation.ImageInstance)
-            .selectinload(ImageInstance.ImageInstanceTagLinks)
-            .selectinload(ImageInstanceTagLink.Tag),
-            selectinload(FormAnnotation.ImageInstance)
-            .selectinload(ImageInstance.ImageInstanceTagLinks)
-            .selectinload(ImageInstanceTagLink.Creator),
-        )
+    """List active form annotations, optionally filtered."""
+    rows = service.list_annotations(
+        db,
+        patient_id=patient_id,
+        study_id=study_id,
+        image_id=image_id,
+        form_schema_id=form_schema_id,
+        sub_task_id=sub_task_id,
     )
-
-    if patient_id is not None:
-        query = query.filter(FormAnnotation.PatientID == patient_id)
-    if study_id is not None:
-        query = query.filter(FormAnnotation.StudyID == study_id)
-    if image_id is not None:
-        resolved_id = _resolve_image_instance_id(db, image_id)
-        query = query.filter(FormAnnotation.ImageInstanceID == resolved_id)
-    if form_schema_id is not None:
-        query = query.filter(FormAnnotation.FormSchemaID == form_schema_id)
-    if sub_task_id is not None:
-        query = query.filter(FormAnnotation.SubTaskID == sub_task_id)
-
-    orm_rows = db.scalars(query).all()
-    return [DTOConverter.form_annotation_to_get(row) for row in orm_rows]
+    return [DTOConverter.form_annotation_to_get(row) for row in rows]
 
 
 @router.get("/form-annotations/{annotation_id}", response_model=FormAnnotationGET)
 async def get_form_annotation(
     annotation_id: int,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    annotation = db.get(
-        FormAnnotation,
-        annotation_id,
-        options=(
-            selectinload(FormAnnotation.FormAnnotationTagLinks).selectinload(
-                FormAnnotationTagLink.Tag
-            ),
-            selectinload(FormAnnotation.FormAnnotationTagLinks).selectinload(
-                FormAnnotationTagLink.Creator
-            ),
-        ),
-    )
-    if annotation is None:
-        raise HTTPException(status_code=404, detail="FormAnnotation not found")
-    return DTOConverter.form_annotation_to_get(annotation)
+    """Get a single form annotation by id."""
+    item = service.get_annotation(db, annotation_id)
+    return DTOConverter.form_annotation_to_get(item)
 
 
 @router.patch("/form-annotations/{annotation_id}", response_model=FormAnnotationGET)
@@ -161,90 +77,32 @@ async def update_form_annotation(
     annotation_id: int,
     annotation: FormAnnotationPATCH,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    existing_annotation = db.get(FormAnnotation, annotation_id)
-    if existing_annotation is None:
-        raise HTTPException(status_code=404, detail="FormAnnotation not found")
-
-    payload = annotation.dict(exclude_unset=True)
-
-    if "form_schema_id" in payload:
-        existing_annotation.FormSchemaID = payload["form_schema_id"]
-    if "patient_id" in payload:
-        existing_annotation.PatientID = payload["patient_id"]
-    if "study_id" in payload:
-        existing_annotation.StudyID = payload["study_id"]
-    if "image_id" in payload:
-        existing_annotation.ImageInstanceID = _resolve_image_instance_id(
-            db, payload["image_id"]
-        )
-    if "laterality" in payload:
-        existing_annotation.Laterality = payload["laterality"]
-    if "sub_task_id" in payload:
-        existing_annotation.SubTaskID = payload["sub_task_id"]
-    if "form_data" in payload:
-        existing_annotation.FormData = payload["form_data"]
-    if "form_annotation_reference_id" in payload:
-        existing_annotation.FormAnnotationReferenceID = payload[
-            "form_annotation_reference_id"
-        ]
-
-    db.commit()
-    db.refresh(existing_annotation)
-    
-    # Log form annotation update
-    logger = get_db_logger()
-    if logger:
-        changes = {k: f"{getattr(existing_annotation, k, None)} -> {v}" for k, v in payload.items()}
-        logger.log_update(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PATCH /api/form-annotations/{annotation_id}",
-            entity="FormAnnotation",
-            entity_id=annotation_id,
-            changes=changes if changes else None,
-        )
-    
-    return DTOConverter.form_annotation_to_get(existing_annotation)
+    """Partially update a form annotation."""
+    item = service.update(
+        db,
+        annotation_id,
+        annotation.dict(exclude_unset=True),
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
+    return DTOConverter.form_annotation_to_get(item)
 
 
 @router.delete("/form-annotations/{annotation_id}", status_code=204)
 async def delete_form_annotation(
     annotation_id: int,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    annotation = db.get(FormAnnotation, annotation_id)
-    if annotation is None:
-        raise HTTPException(status_code=404, detail="FormAnnotation not found")
-
-    # Save annotation data for logging before soft delete
-    deleted_data = {
-        "form_schema_id": annotation.FormSchemaID,
-        "patient_id": annotation.PatientID,
-        "study_id": annotation.StudyID,
-        "image_instance_id": annotation.ImageInstanceID,
-        "sub_task_id": annotation.SubTaskID,
-        "laterality": annotation.Laterality,
-        "creator_id": annotation.CreatorID,
-    }
-    
-    annotation.Inactive = True
-    db.commit()
-    
-    # Log form annotation deletion (soft delete)
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/form-annotations/{annotation_id}",
-            entity="FormAnnotation",
-            entity_id=annotation_id,
-            deleted_data=deleted_data,
-        )
-    
+    """Soft-delete a form annotation."""
+    service.soft_delete(
+        db,
+        annotation_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -252,13 +110,11 @@ async def delete_form_annotation(
 async def get_form_annotation_value(
     form_annotation_id: int,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    annotation = db.get(FormAnnotation, form_annotation_id)
-    if annotation is None:
-        raise HTTPException(status_code=404, detail="FormAnnotation not found")
-
-    return annotation.FormData
+    """Get a form annotation's raw FormData payload."""
+    return service.get_value(db, form_annotation_id)
 
 
 @router.put("/form-annotations/{form_annotation_id}/value", status_code=204)
@@ -266,28 +122,17 @@ async def update_form_annotation_value(
     form_annotation_id: int,
     request: Request,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    annotation = db.get(FormAnnotation, form_annotation_id)
-    if annotation is None:
-        raise HTTPException(status_code=404, detail="FormAnnotation not found")
-
+    """Overwrite a form annotation's FormData payload."""
     form_data = await request.json()
-    annotation.FormData = form_data
-    db.commit()
-    
-    # Log form annotation value update (simple one-line format for high-frequency operations)
-    logger = get_db_logger()
-    if logger:
-        logger.log_simple(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PUT /api/form-annotations/{form_annotation_id}/value",
-            operation="UPDATE",
-            entity="FormAnnotation",
-            entity_id=form_annotation_id,
-        )
-    
+    service.set_value(
+        db,
+        form_annotation_id,
+        form_data,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -296,65 +141,17 @@ async def tag_form_annotation(
     annotation_id: int,
     body: ObjectTagPOST,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ) -> TagMeta:
     """Attach a Tag to a FormAnnotation by tag ID (idempotent)."""
-    ann = db.get(FormAnnotation, annotation_id)
-    if not ann:
-        raise HTTPException(404, "FormAnnotation not found")
-    tag = db.get(Tag, body.tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    if tag.TagType != TagType.FormAnnotation:
-        raise HTTPException(400, "Tag type must be FormAnnotation")
-
-    link = db.get(
-        FormAnnotationTagLink, {"TagID": tag.TagID, "FormAnnotationID": annotation_id}
+    link = service.tag(
+        db,
+        annotation_id,
+        body.tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    if not link:
-        link = FormAnnotationTagLink(
-            TagID=tag.TagID,
-            FormAnnotationID=annotation_id,
-            CreatorID=current_user.id,
-            Comment=body.comment,
-        )
-        db.add(link)
-        db.commit()
-        db.refresh(link)
-        link.Tag = tag
-        
-        # Log tag link creation
-        logger = get_db_logger()
-        if logger:
-            logger.log_insert(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"POST /api/form-annotations/{annotation_id}/tags",
-                entity="FormAnnotationTagLink",
-                fields={
-                    "tag_id": tag.TagID,
-                    "form_annotation_id": annotation_id,
-                    "comment": body.comment,
-                },
-            )
-    else:
-        if body.comment is not None:
-            link.Comment = body.comment
-            db.commit()
-            db.refresh(link)
-            
-            # Log tag link update
-            logger = get_db_logger()
-            if logger:
-                logger.log_update(
-                    user=current_user.username,
-                    user_id=current_user.id,
-                    endpoint=f"POST /api/form-annotations/{annotation_id}/tags",
-                    entity="FormAnnotationTagLink",
-                    fields={"tag_id": tag.TagID, "form_annotation_id": annotation_id},
-                    changes={"comment": f"{link.Comment} -> {body.comment}"},
-                )
-
     return DTOConverter.link_to_tag_metadata(link)
 
 
@@ -363,83 +160,36 @@ async def untag_form_annotation(
     annotation_id: int,
     tag_id: int,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
     """Remove a Tag from a FormAnnotation (idempotent)."""
-    ann = db.get(FormAnnotation, annotation_id)
-    if not ann:
-        raise HTTPException(404, "FormAnnotation not found")
-    link = db.get(
-        FormAnnotationTagLink, {"TagID": tag_id, "FormAnnotationID": annotation_id}
+    service.untag(
+        db,
+        annotation_id,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    if link:
-        # Save link data for logging before deletion
-        deleted_data = {
-            "tag_id": tag_id,
-            "form_annotation_id": annotation_id,
-            "comment": link.Comment,
-            "creator_id": link.CreatorID,
-        }
-        
-        db.delete(link)
-        db.commit()
-        
-        # Log tag link deletion
-        logger = get_db_logger()
-        if logger:
-            logger.log_delete(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"DELETE /api/form-annotations/{annotation_id}/tags/{tag_id}",
-                entity="FormAnnotationTagLink",
-                fields={"tag_id": tag_id, "form_annotation_id": annotation_id},
-                deleted_data=deleted_data,
-            )
-    
     return Response(status_code=204)
 
 
-@router.patch("/form-annotations/{annotation_id}/tags/{tag_id}", response_model=TagMeta)
+@router.patch(
+    "/form-annotations/{annotation_id}/tags/{tag_id}", response_model=TagMeta
+)
 async def patch_form_annotation_tag(
     annotation_id: int,
     tag_id: int,
     body: ObjectTagPATCH,
     db: Session = Depends(get_db),
+    service: FormAnnotationService = Depends(get_form_annotation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ) -> TagMeta:
     """Update comment on an existing FormAnnotation tag link."""
-    ann = db.get(FormAnnotation, annotation_id)
-    if not ann:
-        raise HTTPException(404, "FormAnnotation not found")
-    tag = db.get(Tag, tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    if tag.TagType != TagType.FormAnnotation:
-        raise HTTPException(400, "Tag type must be FormAnnotation")
-
-    link = db.get(
-        FormAnnotationTagLink, {"TagID": tag_id, "FormAnnotationID": annotation_id}
+    link = service.patch_tag(
+        db,
+        annotation_id,
+        tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    if not link:
-        raise HTTPException(404, "Link not found")
-
-    if body.comment is not None:
-        old_comment = link.Comment
-        link.Comment = body.comment
-        db.commit()
-        db.refresh(link)
-        
-        # Log tag link update
-        logger = get_db_logger()
-        if logger:
-            logger.log_update(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"PATCH /api/form-annotations/{annotation_id}/tags/{tag_id}",
-                entity="FormAnnotationTagLink",
-                fields={"tag_id": tag_id, "form_annotation_id": annotation_id},
-                changes={"comment": f"{old_comment} -> {body.comment}"},
-            )
-    
-    link.Tag = tag
     return DTOConverter.link_to_tag_metadata(link)

--- a/server/routes/instances.py
+++ b/server/routes/instances.py
@@ -1,59 +1,21 @@
 from typing import Optional
 
-from eyened_orm import (
-    ImageInstance,
-    ImageStorage,
-    Tag,
-    ImageInstanceTagLink,
-    Series,
-    Study,
-    Patient,
-    DeviceInstance,
-    Segmentation,
-    ModelSegmentation,
-    FormAnnotation,
-)
-from eyened_orm.tag import SegmentationTagLink, FormAnnotationTagLink, TagType
 from eyened_orm.storage_access import resolve_image_data_ref, resolve_thumbnail_ref
 from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.orm import Session
 
-from sqlalchemy.orm import Session, selectinload
-
+from ..db import get_db
 from ..dtos.dto_converter import DTOConverter
 from ..dtos.dtos_instances import ImageGET
 from ..dtos.dtos_aux import ObjectTagPOST, ObjectTagPATCH, TagMeta
-
+from ..services.acting_user import ActingUser
+from ..services.image_instance_service import (
+    ImageInstanceService,
+    get_image_instance_service,
+)
 from .auth import CurrentUser, get_current_user, is_authenticated
-from ..db import get_db
-from ..utils.db_logging import get_db_logger
-from sqlalchemy.exc import NoResultFound
-
 
 router = APIRouter()
-
-
-def _get_image_instance_by_public_id(
-    db: Session, public_id: str
-) -> Optional[ImageInstance]:
-
-    try:
-        item = (
-            db.query(ImageInstance)
-            .options(
-                selectinload(ImageInstance.ImageStorages).selectinload(
-                    ImageStorage.StorageBackend
-                )
-            )
-            .filter(ImageInstance.PublicID == public_id)
-            .one()
-        )
-        return item
-    except NoResultFound:
-        print(f"Warning: ImageInstance {public_id} not found, trying to get by id")
-        item = db.get(ImageInstance, public_id)
-        if not item:
-            raise HTTPException(404, "ImageInstance not found")
-        return item
 
 
 @router.get("/instances/{instance_id}", response_model=ImageGET)
@@ -64,66 +26,17 @@ async def get_instance(
     with_model_segmentations: bool = False,
     with_tag_metadata: bool = False,
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    opts = [
-        # base graph
-        selectinload(ImageInstance.Series)
-        .selectinload(Series.Study)
-        .selectinload(Study.Patient)
-        .selectinload(Patient.Project),
-        selectinload(ImageInstance.DeviceInstance).selectinload(
-            DeviceInstance.DeviceModel
-        ),
-        selectinload(ImageInstance.Scan),
-        selectinload(ImageInstance.ImageStorages).selectinload(
-            ImageStorage.StorageBackend
-        ),
-        # instance tags
-        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
-            ImageInstanceTagLink.Tag
-        ),
-        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
-            ImageInstanceTagLink.Creator
-        ),
-    ]
-    if with_segmentations:
-        opts += [
-            selectinload(ImageInstance.Segmentations).selectinload(
-                Segmentation.Feature
-            ),
-            selectinload(ImageInstance.Segmentations).selectinload(
-                Segmentation.Creator
-            ),
-            selectinload(ImageInstance.Segmentations)
-            .selectinload(Segmentation.SegmentationTagLinks)
-            .selectinload(SegmentationTagLink.Tag),
-            selectinload(ImageInstance.Segmentations)
-            .selectinload(Segmentation.SegmentationTagLinks)
-            .selectinload(SegmentationTagLink.Creator),
-        ]
-    if with_form_annotations:
-        opts += [
-            selectinload(ImageInstance.FormAnnotations)
-            .selectinload(FormAnnotation.FormAnnotationTagLinks)
-            .selectinload(FormAnnotationTagLink.Tag),
-            selectinload(ImageInstance.FormAnnotations)
-            .selectinload(FormAnnotation.FormAnnotationTagLinks)
-            .selectinload(FormAnnotationTagLink.Creator),
-        ]
-    if with_model_segmentations:
-        opts += [
-            selectinload(ImageInstance.ModelSegmentations).selectinload(
-                ModelSegmentation.Model
-            ),
-            # optional if Model.Feature relationship is added later:
-            # selectinload(ImageInstance.ModelSegmentations).selectinload(ModelSegmentation.Model).selectinload(Model.Feature),
-        ]
-
-    item = db.get(ImageInstance, instance_id, options=tuple(opts))
-    if not item:
-        raise HTTPException(404, "ImageInstance not found")
-
+    """Get a single image instance by id, with optional related graphs."""
+    item = service.get_instance(
+        db,
+        instance_id,
+        with_segmentations=with_segmentations,
+        with_form_annotations=with_form_annotations,
+        with_model_segmentations=with_model_segmentations,
+    )
     return DTOConverter.image_instance_to_get(
         item,
         with_tag_metadata=with_tag_metadata,
@@ -141,73 +54,17 @@ async def get_public_image(
     with_model_segmentations: bool = False,
     with_tag_metadata: bool = False,
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    opts = [
-        # base graph
-        selectinload(ImageInstance.Series)
-        .selectinload(Series.Study)
-        .selectinload(Study.Patient)
-        .selectinload(Patient.Project),
-        selectinload(ImageInstance.DeviceInstance).selectinload(
-            DeviceInstance.DeviceModel
-        ),
-        selectinload(ImageInstance.Scan),
-        selectinload(ImageInstance.ImageStorages).selectinload(
-            ImageStorage.StorageBackend
-        ),
-        # instance tags
-        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
-            ImageInstanceTagLink.Tag
-        ),
-        selectinload(ImageInstance.ImageInstanceTagLinks).selectinload(
-            ImageInstanceTagLink.Creator
-        ),
-    ]
-    if with_segmentations:
-        opts += [
-            selectinload(ImageInstance.Segmentations).selectinload(
-                Segmentation.Feature
-            ),
-            selectinload(ImageInstance.Segmentations).selectinload(
-                Segmentation.Creator
-            ),
-            selectinload(ImageInstance.Segmentations)
-            .selectinload(Segmentation.SegmentationTagLinks)
-            .selectinload(SegmentationTagLink.Tag),
-            selectinload(ImageInstance.Segmentations)
-            .selectinload(Segmentation.SegmentationTagLinks)
-            .selectinload(SegmentationTagLink.Creator),
-        ]
-    if with_form_annotations:
-        opts += [
-            selectinload(ImageInstance.FormAnnotations)
-            .selectinload(FormAnnotation.FormAnnotationTagLinks)
-            .selectinload(FormAnnotationTagLink.Tag),
-            selectinload(ImageInstance.FormAnnotations)
-            .selectinload(FormAnnotation.FormAnnotationTagLinks)
-            .selectinload(FormAnnotationTagLink.Creator),
-        ]
-    if with_model_segmentations:
-        opts += [
-            selectinload(ImageInstance.ModelSegmentations).selectinload(
-                ModelSegmentation.Model
-            ),
-            # optional if Model.Feature relationship is added later:
-            # selectinload(ImageInstance.ModelSegmentations).selectinload(ModelSegmentation.Model).selectinload(Model.Feature),
-        ]
-
-    item = (
-        db.query(ImageInstance)
-        .options(*opts)
-        .filter(ImageInstance.PublicID == image_id)
-        .first()
+    """Get a single image instance by PublicID, with optional related graphs."""
+    item = service.get_by_public_id(
+        db,
+        image_id,
+        with_segmentations=with_segmentations,
+        with_form_annotations=with_form_annotations,
+        with_model_segmentations=with_model_segmentations,
     )
-    if not item and image_id.isdigit():
-        item = db.get(ImageInstance, int(image_id), options=tuple(opts))
-    if not item:
-        raise HTTPException(404, "ImageInstance not found")
-
     return DTOConverter.image_instance_to_get(
         item,
         with_tag_metadata=with_tag_metadata,
@@ -230,10 +87,10 @@ async def get_public_image_data(
     meta: bool = False,
     _: bool = Depends(is_authenticated),
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
 ):
-    item = _get_image_instance_by_public_id(db, image_id)
-    if not item:
-        raise HTTPException(404, "ImageInstance not found")
+    """Redirect to the stored image data for an instance (by PublicID)."""
+    item = service.get_for_storage(db, image_id)
     if index is not None and index < 0:
         raise HTTPException(400, "index must be >= 0")
     try:
@@ -249,11 +106,10 @@ async def get_public_image_thumbnail(
     size: int = 144,
     _: bool = Depends(is_authenticated),
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
 ):
-    item = _get_image_instance_by_public_id(db, image_id)
-    if not item:
-        raise HTTPException(404, "ImageInstance not found")
-
+    """Redirect to the stored thumbnail for an instance (by PublicID)."""
+    item = service.get_for_storage(db, image_id)
     try:
         ref = resolve_thumbnail_ref(item, size=size)
     except ValueError as e:
@@ -287,67 +143,17 @@ async def tag_instance(
     instance_id: str,
     body: ObjectTagPOST,
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
     current_user: CurrentUser = Depends(get_current_user),
 ) -> TagMeta:
     """Attach a Tag to an ImageInstance by tag ID (idempotent)."""
-    instance = _get_image_instance_by_public_id(db, instance_id)
-    if not instance:
-        raise HTTPException(404, "ImageInstance not found")
-    tag = db.get(Tag, body.tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    if tag.TagType != TagType.ImageInstance:
-        raise HTTPException(400, "Tag type must be ImageInstance")
-
-    link = db.get(
-        ImageInstanceTagLink,
-        {"TagID": tag.TagID, "ImageInstanceID": instance.ImageInstanceID},
+    link = service.tag_instance(
+        db,
+        instance_id,
+        body.tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    if not link:
-        link = ImageInstanceTagLink(
-            TagID=tag.TagID,
-            ImageInstanceID=instance.ImageInstanceID,
-            CreatorID=current_user.id,
-            Comment=body.comment,
-        )
-        db.add(link)
-        db.commit()
-        db.refresh(link)
-        link.Tag = tag  # optional: avoid Tag lazy-load
-
-        # Log tag link creation
-        logger = get_db_logger()
-        if logger:
-            logger.log_insert(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"POST /api/instances/{instance_id}/tags",
-                entity="ImageInstanceTagLink",
-                fields={
-                    "tag_id": tag.TagID,
-                    "image_instance_id": instance.ImageInstanceID,
-                    "comment": body.comment,
-                },
-            )
-    else:
-        if body.comment is not None:
-            old_comment = link.Comment
-            link.Comment = body.comment
-            db.commit()
-            db.refresh(link)
-
-            # Log tag link update
-            logger = get_db_logger()
-            if logger:
-                logger.log_update(
-                    user=current_user.username,
-                    user_id=current_user.id,
-                    endpoint=f"POST /api/instances/{instance_id}/tags",
-                    entity="ImageInstanceTagLink",
-                    fields={"tag_id": tag.TagID, "image_instance_id": instance_id},
-                    changes={"comment": f"{old_comment} -> {body.comment}"},
-                )
-
     return DTOConverter.link_to_tag_metadata(link)
 
 
@@ -357,47 +163,17 @@ async def patch_instance_tag(
     tag_id: int,
     body: ObjectTagPATCH,
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
     current_user: CurrentUser = Depends(get_current_user),
 ) -> TagMeta:
     """Update comment on an existing ImageInstance tag link."""
-    instance = _get_image_instance_by_public_id(db, instance_id)
-    if not instance:
-        raise HTTPException(404, "ImageInstance not found")
-    tag = db.get(Tag, tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    if tag.TagType != TagType.ImageInstance:
-        raise HTTPException(400, "Tag type must be ImageInstance")
-
-    link = db.get(
-        ImageInstanceTagLink,
-        {"TagID": tag_id, "ImageInstanceID": instance.ImageInstanceID},
+    link = service.patch_instance_tag(
+        db,
+        instance_id,
+        tag_id,
+        body.comment,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    if not link:
-        raise HTTPException(404, "Link not found")
-
-    if body.comment is not None:
-        old_comment = link.Comment
-        link.Comment = body.comment
-        db.commit()
-        db.refresh(link)
-
-        # Log tag link update
-        logger = get_db_logger()
-        if logger:
-            logger.log_update(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"PATCH /api/instances/{instance_id}/tags/{tag_id}",
-                entity="ImageInstanceTagLink",
-                fields={
-                    "tag_id": tag_id,
-                    "image_instance_id": instance.ImageInstanceID,
-                },
-                changes={"comment": f"{old_comment} -> {body.comment}"},
-            )
-
-    link.Tag = tag
     return DTOConverter.link_to_tag_metadata(link)
 
 
@@ -406,38 +182,14 @@ async def untag_instance(
     instance_id: str,
     tag_id: int,
     db: Session = Depends(get_db),
+    service: ImageInstanceService = Depends(get_image_instance_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
     """Remove a Tag from an ImageInstance (idempotent)."""
-    instance = _get_image_instance_by_public_id(db, instance_id)
-    if not instance:
-        raise HTTPException(404, "ImageInstance not found")
-    link = db.get(
-        ImageInstanceTagLink,
-        {"TagID": tag_id, "ImageInstanceID": instance.ImageInstanceID},
+    service.untag_instance(
+        db,
+        instance_id,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
-    if link:
-        # Save link data for logging before deletion
-        deleted_data = {
-            "tag_id": tag_id,
-            "image_instance_id": instance.ImageInstanceID,
-            "comment": link.Comment,
-            "creator_id": link.CreatorID,
-        }
-
-        db.delete(link)
-        db.commit()
-
-        # Log tag link deletion
-        logger = get_db_logger()
-        if logger:
-            logger.log_delete(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"DELETE /api/instances/{instance_id}/tags/{tag_id}",
-                entity="ImageInstanceTagLink",
-                fields={"tag_id": tag_id, "image_instance_id": instance_id},
-                deleted_data=deleted_data,
-            )
-
     return Response(status_code=204)

--- a/server/routes/segmentations.py
+++ b/server/routes/segmentations.py
@@ -1,20 +1,8 @@
-from datetime import datetime
 import gzip
 import io
 from typing import Annotated, Optional
 
 import numpy as np
-from eyened_orm import (
-    Segmentation,
-    ImageInstance,
-    Segmentation,
-    Datatype,
-    DataRepresentation,
-    ModelSegmentation,
-    Tag,
-    SegmentationTagLink,
-)
-from eyened_orm.tag import TagType
 from fastapi import (
     APIRouter,
     Depends,
@@ -25,188 +13,83 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from fastapi.responses import StreamingResponse
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session
 
 from ..db import get_db
-from ..utils.db_logging import get_db_logger
-from eyened_orm.segmentation_storage import read_segmentation_data, write_segmentation_data
-from .auth import CurrentUser, get_current_user
-from ..dtos.dtos_main import SegmentationGET, SegmentationPOST, SegmentationPATCH
 from ..dtos.dto_converter import DTOConverter
 from ..dtos.dtos_aux import ObjectTagPOST, TagMeta
+from ..dtos.dtos_main import SegmentationGET, SegmentationPATCH, SegmentationPOST
+from ..services.acting_user import ActingUser
+from ..services.segmentation_service import (
+    ModelSegmentationService,
+    SegmentationService,
+    get_model_segmentation_service,
+    get_segmentation_service,
+)
+from .auth import CurrentUser, get_current_user
 
 router = APIRouter()
 
-dtypes = {
-    Datatype.R8: np.uint8,
-    Datatype.R8UI: np.uint8,
-    Datatype.R16UI: np.uint16,
-    Datatype.R32UI: np.uint32,
-    Datatype.R32F: np.float32,
-}
-
-
-def _resolve_image_instance_id(db: Session, image_id: str) -> int:
-    item = (
-        db.query(ImageInstance)
-        .filter(ImageInstance.PublicID == image_id)
-        .first()
-    )
-    if item:
-        return item.ImageInstanceID
-    raise HTTPException(status_code=404, detail="ImageInstance not found")
-
 
 async def load_array(np_array: Optional[UploadFile]) -> Optional[np.ndarray]:
-    # Read and load numpy array
-    if np_array is not None:
-        data_content = await np_array.read()
-        if np_array.filename.endswith(".gz"):
-            with gzip.GzipFile(fileobj=io.BytesIO(data_content)) as f:
-                data_content = f.read()
-                print("uncompressed data_content", len(data_content))
-
-        data_buffer = io.BytesIO(data_content)
-        array = np.load(data_buffer)
-        # check that the data is 3D
-        if len(array.shape) != 3:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Segmentation is not 3D, got shape {array.shape}",
-            )
-        return array
+    """Read an uploaded (optionally gzipped) .npy into a 3D array, or None."""
+    if np_array is None:
+        return None
+    data_content = await np_array.read()
+    if np_array.filename.endswith(".gz"):
+        with gzip.GzipFile(fileobj=io.BytesIO(data_content)) as f:
+            data_content = f.read()
+    array = np.load(io.BytesIO(data_content))
+    if len(array.shape) != 3:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Segmentation is not 3D, got shape {array.shape}",
+        )
+    return array
 
 
-def create_empty_array(segmentation: Segmentation, image: ImageInstance) -> np.ndarray:
-    s_d, s_h, s_w = segmentation.shape
-    im_d, im_h, im_w = image.shape
-    shape = (s_d or im_d, s_h or im_h, s_w or im_w)
-    segmentation.Depth, segmentation.Height, segmentation.Width = shape
-    return np.zeros(shape, dtype=dtypes[segmentation.DataType])
+def _segmentation_data_response(arr: Optional[np.ndarray], filename: str) -> Response:
+    if arr is None:
+        return Response(status_code=204)
+    np_buf = io.BytesIO()
+    np.save(np_buf, arr)
+    gz = gzip.compress(np_buf.getvalue())
+    headers = {
+        "Content-Encoding": "gzip",
+        "Content-Disposition": f'inline; filename="{filename}"',
+        "Content-Length": str(len(gz)),
+    }
+    return Response(content=gz, media_type="application/octet-stream", headers=headers)
 
 
-
-
-# this endpoint uses multipart/form-data
-# to create an annotation and upload its data at the same time
-# it was implemented this way to ensure that the annotation data and metadata are consistent
-# if the annotation data (np_array) is not provided, an empty (zeros) annotation is created
-# once the annotation is created, its data can be updated using the PUT endpoint
-# but only by data with the same shape as the original annotation
 @router.post("/segmentations", response_model=SegmentationGET)
 async def create_segmentation(
     metadata: Annotated[str, Form()],
     np_array: Optional[UploadFile] = File(None),
     db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    # create a new segmentation
     dto = SegmentationPOST.model_validate_json(metadata)
-    image_instance_id = _resolve_image_instance_id(db, dto.image_id)
-
-    segmentation = Segmentation(
-        ImageInstanceID=image_instance_id,
-        FeatureID=dto.feature_id,
-        CreatorID=current_user.id,
-        SubTaskID=dto.subtask_id,
-        DataType=dto.data_type,
-        DataRepresentation=dto.data_representation,
-        Depth=dto.depth,
-        Height=dto.height,
-        Width=dto.width,
-        SparseAxis=dto.sparse_axis,
-        ImageProjectionMatrix=dto.image_projection_matrix,
-        ScanIndices=dto.scan_indices,
-        Threshold=dto.threshold,
-        ReferenceSegmentationID=dto.reference_segmentation_id,
-        DateInserted=datetime.now()
-    )
-
-    # creator can be different from the current_user and is passed in the params
-    # segmentation.CreatorID = current_user.id
-
-    image = ImageInstance.by_id(db, segmentation.ImageInstanceID)
-    if image is None:
-        raise HTTPException(
-            status_code=400, detail="Segmentation has no associated image"
-        )
-
     array = await load_array(np_array)
-    if array is None:
-        data = create_empty_array(segmentation, image)
-    else:
-        if segmentation.ScanIndices is None:
-            # full volume
-            data = array
-            if segmentation.shape != array.shape:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Segmentation shape {segmentation.shape} does not match array shape {array.shape}",
-                )
-        else:
-            # sparse volume
-            if segmentation.SparseAxis is None:
-                raise HTTPException(
-                    status_code=400, detail=f"SparseAxis is not set for sparse volume"
-                )
-
-            if len(segmentation.ScanIndices) != array.shape[segmentation.SparseAxis]:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"ScanIndices length {len(segmentation.ScanIndices)} does not match array sparse axis length {array.shape[segmentation.SparseAxis]}",
-                )
-
-            data = np.zeros(segmentation.shape, dtype=dtypes[segmentation.DataType])
-            for i, scan_index in enumerate(segmentation.ScanIndices):
-                data[scan_index] = array[i]
-
-    for dim, attr in zip(data.shape, ["Depth", "Height", "Width"]):
-        val = getattr(segmentation, attr)
-        if val is None:
-            # if the dimension is not set on the segmentation, set it to the array dimension
-            setattr(segmentation, attr, dim)
-        elif val != dim:
-            # if the dimension is set on the segmentation, it must match the array dimension
-            raise HTTPException(
-                status_code=400,
-                detail=f"Segmentation {attr} ({val}) does not match array {attr} ({dim})",
-            )
-
-    db.add(segmentation)
-    db.flush()
-
-    try:
-        write_segmentation_data(segmentation, data)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    db.commit()
-    db.refresh(segmentation)
-    
-    # Log segmentation creation
-    logger = get_db_logger()
-    if logger:
-        logger.log_insert(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint="POST /api/segmentations",
-            entity="Segmentation",
-            entity_id=segmentation.SegmentationID,
-            fields={
-                "image_instance_id": segmentation.ImageInstanceID,
-                "feature_id": segmentation.FeatureID,
-                "subtask_id": segmentation.SubTaskID,
-                "creator_id": segmentation.CreatorID,
-                "data_type": str(segmentation.DataType),
-                "data_representation": str(segmentation.DataRepresentation),
-                "shape": segmentation.shape,
-                "sparse_axis": segmentation.SparseAxis,
-                "threshold": segmentation.Threshold,
-                "reference_segmentation_id": segmentation.ReferenceSegmentationID,
-            },
-        )
-    
+    segmentation = service.create(
+        db,
+        image_id=dto.image_id,
+        feature_id=dto.feature_id,
+        subtask_id=dto.subtask_id,
+        data_type=dto.data_type,
+        data_representation=dto.data_representation,
+        depth=dto.depth,
+        height=dto.height,
+        width=dto.width,
+        sparse_axis=dto.sparse_axis,
+        image_projection_matrix=dto.image_projection_matrix,
+        scan_indices=dto.scan_indices,
+        threshold=dto.threshold,
+        reference_segmentation_id=dto.reference_segmentation_id,
+        array=array,
+        actor=ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.segmentation_to_get(segmentation)
 
 
@@ -214,20 +97,10 @@ async def create_segmentation(
 async def get_segmentation(
     segmentation_id: int,
     db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    item = db.get(
-        Segmentation,
-        segmentation_id,
-        options=(
-            selectinload(Segmentation.SegmentationTagLinks)
-                .selectinload(SegmentationTagLink.Tag),
-            selectinload(Segmentation.SegmentationTagLinks)
-                .selectinload(SegmentationTagLink.Creator),
-        ),
-    )
-    if item is None:
-        raise HTTPException(status_code=404, detail="Segmentation not found")
+    item = service.get_segmentation(db, segmentation_id)
     return DTOConverter.segmentation_to_get(item)
 
 
@@ -235,42 +108,14 @@ async def get_segmentation(
 async def delete_segmentation(
     segmentation_id: int,
     db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    segmentation = Segmentation.by_id(db, segmentation_id)
-    if segmentation is None:
-        raise HTTPException(status_code=404, detail="Segmentation not found")
-
-    # Save segmentation data for logging before soft delete
-    deleted_data = {
-        "image_instance_id": segmentation.ImageInstanceID,
-        "feature_id": segmentation.FeatureID,
-        "subtask_id": segmentation.SubTaskID,
-        "creator_id": segmentation.CreatorID,
-        "data_type": str(segmentation.DataType),
-        "data_representation": str(segmentation.DataRepresentation),
-        "shape": segmentation.shape,
-        "sparse_axis": segmentation.SparseAxis,
-        "threshold": segmentation.Threshold,
-        "reference_segmentation_id": segmentation.ReferenceSegmentationID,
-    }
-    
-    # db.delete(segmentation)
-    segmentation.Inactive = True
-    db.commit()
-    
-    # Log segmentation deletion (soft delete)
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/segmentations/{segmentation_id}",
-            entity="Segmentation",
-            entity_id=segmentation_id,
-            deleted_data=deleted_data,
-        )
-    
+    service.soft_delete(
+        db,
+        segmentation_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -281,49 +126,23 @@ async def update_segmentation_data(
     axis: Optional[int] = None,
     scan_nr: Optional[int] = None,
     db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    segmentation = Segmentation.by_id(db, segmentation_id)
-    if segmentation is None:
-        raise HTTPException(status_code=404, detail="Segmentation data not found")
-
     content_type = request.headers.get("Content-Type", "").lower()
     if content_type != "application/octet-stream":
         raise HTTPException(
             status_code=400, detail=f"Unsupported media type: {content_type}"
         )
-
-    data = await request.body()
-    np_image = np.load(io.BytesIO(data))
-
-    try:
-        write_segmentation_data(segmentation, np_image, axis=axis, slice_index=scan_nr)
-    except IndexError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    db.add(segmentation)
-    db.commit()
-
-    # return Response(status_code=204)
-
-    # return the updated segmentation
-    db.refresh(segmentation)
-    
-    # Log segmentation data update (simple one-line format for high-frequency operations)
-    logger = get_db_logger()
-    if logger:
-        logger.log_simple(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PUT /api/segmentations/{segmentation_id}/data",
-            operation="UPDATE",
-            entity="Segmentation",
-            entity_id=segmentation_id,
-        )
-    
-    return segmentation
+    np_image = np.load(io.BytesIO(await request.body()))
+    return service.write_data(
+        db,
+        segmentation_id,
+        np_image,
+        axis=axis,
+        scan_nr=scan_nr,
+        actor=ActingUser(id=current_user.id, username=current_user.username),
+    )
 
 
 @router.get("/segmentations/{segmentation_id}/data")
@@ -332,33 +151,11 @@ async def get_segmentation_data(
     axis: Optional[int] = None,
     scan_nr: Optional[int] = None,
     db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    segmentation = Segmentation.by_id(db, segmentation_id)
-    if segmentation is None:
-        raise HTTPException(status_code=404, detail="Segmentation data not found")
-
-    try:
-        arr = read_segmentation_data(segmentation, axis=axis, slice_index=scan_nr)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    if arr is None:
-        return Response(status_code=204)
-
-    np_buf = io.BytesIO()
-    np.save(np_buf, arr)
-    raw = np_buf.getvalue()
-    gz = gzip.compress(raw)
-
-    headers = {
-        "Content-Encoding": "gzip",
-        "Content-Disposition": 'inline; filename="segmentation.npy.gz"',
-        "Content-Length": str(len(gz)),
-    }
-    return Response(content=gz, media_type="application/octet-stream", headers=headers)
-
-
+    arr = service.read_data(db, segmentation_id, axis=axis, scan_nr=scan_nr)
+    return _segmentation_data_response(arr, "segmentation.npy.gz")
 
 
 @router.patch("/segmentations/{segmentation_id}", response_model=SegmentationGET)
@@ -366,158 +163,53 @@ async def patch_segmentation(
     segmentation_id: int,
     dto: SegmentationPATCH,
     db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    segmentation = Segmentation.by_id(db, segmentation_id)
-    if segmentation is None:
-        raise HTTPException(status_code=404, detail="Segmentation not found")
-
-    if dto.reference_segmentation_id is not None:
-        segmentation.ReferenceSegmentationID = dto.reference_segmentation_id
-    if dto.feature_id is not None:
-        segmentation.FeatureID = dto.feature_id
-    changes = {}
-    if dto.reference_segmentation_id is not None:
-        changes["reference_segmentation_id"] = f"{segmentation.ReferenceSegmentationID} -> {dto.reference_segmentation_id}"
-        segmentation.ReferenceSegmentationID = dto.reference_segmentation_id
-    if dto.feature_id is not None:
-        changes["feature_id"] = f"{segmentation.FeatureID} -> {dto.feature_id}"
-        segmentation.FeatureID = dto.feature_id
-    if dto.threshold is not None:
-        changes["threshold"] = f"{segmentation.Threshold} -> {dto.threshold}"
-        segmentation.Threshold = dto.threshold
-
-    db.commit()
-    db.refresh(segmentation)
-    
-    # Log segmentation update
-    logger = get_db_logger()
-    if logger:
-        logger.log_update(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PATCH /api/segmentations/{segmentation_id}",
-            entity="Segmentation",
-            entity_id=segmentation_id,
-            changes=changes if changes else None,
-        )
-    
+    segmentation = service.patch(
+        db,
+        segmentation_id,
+        reference_segmentation_id=dto.reference_segmentation_id,
+        feature_id=dto.feature_id,
+        threshold=dto.threshold,
+        actor=ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.segmentation_to_get(segmentation)
 
 
-#### CONSISTENCY CHECKS ####
-"""
-if image.is_2d and annotation.is_2d:
-    # one one-dimension should match
-    if image.l1_axis != annotation.l1_axis:
-        raise HTTPException(status_code=400, detail=f"Image length 1 axis {image.length_1_axis} does not match annotation length 1 axis {annotation.l1_axis}")
-    
-    if image.shape != annotation.shape and annotation.ImageProjectionMatrix is None:
-        raise HTTPException(status_code=400, detail=f"Image shape {image.shape} does not match annotation shape {annotation.shape} and ImageProjectionMatrix is not provided")
-    
-    annotation.ScanIndices = None
-    annotation.SparseAxis = None
-    
-elif image.is_3d and annotation.is_2d:
-    if annotation.ScanIndices is None or not isinstance(annotation.ScanIndices, int):
-        raise HTTPException(status_code=400, detail=f"ScanIndices must be an int for 2D annotations on 3D images")
-    
-    # scan index must be within the image shape
-    if annotation.ScanIndices >= image.shape[annotation.l1_axis]:
-        raise HTTPException(status_code=400, detail=f"ScanIndices {annotation.ScanIndices} is out of bounds for image shape {image.shape} along dimension {annotation.l1_axis}")
-    
-    # check if image and annotation match along dimensions other than the length 1 axis
-    if not annotation.shape_matches_image_shape and annotation.ImageProjectionMatrix is None:
-        raise HTTPException(status_code=400, detail=f"Annotation shape {annotation.shape} does not match image shape {image.shape} and ImageProjectionMatrix is not provided")
-    annotation.SparseAxis = None
-    
-elif image.is_3d and annotation.is_3d:
-    if image.shape != annotation.shape:
-        raise HTTPException(status_code=400, detail=f"3D annotation shape {annotation.shape} does not match image shape {image.shape}")
-    
-    # SparseAxis and ScanIndices can either be both present or both absent
-    if annotation.SparseAxis is not None and annotation.ScanIndices is None:
-        raise HTTPException(status_code=400, detail=f"SparseAxis is provided but ScanIndices is not")
-    if annotation.SparseAxis is None and annotation.ScanIndices is not None:
-        raise HTTPException(status_code=400, detail=f"ScanIndices is provided but SparseAxis is not")
-    
-    if annotation.ScanIndices is not None:
-        if not isinstance(annotation.ScanIndices, list):
-            raise HTTPException(status_code=400, detail=f"ScanIndices must be a list for sparse annotations")
-        
-        # scan indices must be unique and within the image bounds
-        for i in annotation.ScanIndices:
-            if i >= image.shape[annotation.SparseAxis]:
-                raise HTTPException(status_code=400, detail=f"Scan index {i} is out of bounds for image shape {image.shape} along dimension {annotation.SparseAxis}")
-        
-else:
-    raise HTTPException(status_code=400, detail=f"Image and annotation shapes are not compatible")
-"""
-
-
 @router.post("/segmentations/{segmentation_id}/tags", response_model=TagMeta)
-async def tag_segmentation(segmentation_id: int, body: ObjectTagPOST, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)) -> TagMeta:
+async def tag_segmentation(
+    segmentation_id: int,
+    body: ObjectTagPOST,
+    db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TagMeta:
     """Attach a Tag to a Segmentation by tag ID (idempotent)."""
-    seg = db.get(Segmentation, segmentation_id)
-    if not seg:
-        raise HTTPException(404, "Segmentation not found")
-    tag = db.get(Tag, body.tag_id)
-    if not tag:
-        raise HTTPException(404, "Tag not found")
-    if tag.TagType != TagType.Segmentation:
-        raise HTTPException(400, "Tag type must be Segmentation")
-
-    link = db.get(SegmentationTagLink, {"TagID": tag.TagID, "SegmentationID": segmentation_id})
-    if not link:
-        link = SegmentationTagLink(TagID=tag.TagID, SegmentationID=segmentation_id, CreatorID=current_user.id)
-        db.add(link); db.commit(); db.refresh(link)
-        link.Tag = tag
-        
-        # Log tag link creation
-        logger = get_db_logger()
-        if logger:
-            logger.log_insert(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"POST /api/segmentations/{segmentation_id}/tags",
-                entity="SegmentationTagLink",
-                fields={
-                    "tag_id": tag.TagID,
-                    "segmentation_id": segmentation_id,
-                },
-            )
-
+    link = service.tag(
+        db,
+        segmentation_id,
+        body.tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.link_to_tag_metadata(link)
 
+
 @router.delete("/segmentations/{segmentation_id}/tags/{tag_id}", status_code=204)
-async def untag_segmentation(segmentation_id: int, tag_id: int, db: Session = Depends(get_db), current_user: CurrentUser = Depends(get_current_user)):
+async def untag_segmentation(
+    segmentation_id: int,
+    tag_id: int,
+    db: Session = Depends(get_db),
+    service: SegmentationService = Depends(get_segmentation_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
     """Remove a Tag from a Segmentation (idempotent)."""
-    seg = db.get(Segmentation, segmentation_id)
-    if not seg:
-        raise HTTPException(404, "Segmentation not found")
-    link = db.get(SegmentationTagLink, {"TagID": tag_id, "SegmentationID": segmentation_id})
-    if link:
-        # Save link data for logging before deletion
-        deleted_data = {
-            "tag_id": tag_id,
-            "segmentation_id": segmentation_id,
-            "creator_id": link.CreatorID,
-        }
-        
-        db.delete(link); db.commit()
-        
-        # Log tag link deletion
-        logger = get_db_logger()
-        if logger:
-            logger.log_delete(
-                user=current_user.username,
-                user_id=current_user.id,
-                endpoint=f"DELETE /api/segmentations/{segmentation_id}/tags/{tag_id}",
-                entity="SegmentationTagLink",
-                fields={"tag_id": tag_id, "segmentation_id": segmentation_id},
-                deleted_data=deleted_data,
-            )
-    
+    service.untag(
+        db,
+        segmentation_id,
+        tag_id,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -527,31 +219,11 @@ async def get_model_segmentation_data(
     axis: Optional[int] = None,
     scan_nr: Optional[int] = None,
     db: Session = Depends(get_db),
+    service: ModelSegmentationService = Depends(get_model_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    model_segmentation = ModelSegmentation.by_id(db, model_segmentation_id)
-    if model_segmentation is None:
-        raise HTTPException(status_code=404, detail="ModelSegmentation data not found")
-
-    try:
-        arr = read_segmentation_data(model_segmentation, axis=axis, slice_index=scan_nr)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    if arr is None:
-        return Response(status_code=204)
-
-    np_buf = io.BytesIO()
-    np.save(np_buf, arr)
-    raw = np_buf.getvalue()
-    gz = gzip.compress(raw)
-
-    headers = {
-        "Content-Encoding": "gzip",
-        "Content-Disposition": 'inline; filename="model_segmentation.npy.gz"',
-        "Content-Length": str(len(gz)),
-    }
-    return Response(content=gz, media_type="application/octet-stream", headers=headers)
+    arr = service.read_data(db, model_segmentation_id, axis=axis, scan_nr=scan_nr)
+    return _segmentation_data_response(arr, "model_segmentation.npy.gz")
 
 
 @router.put("/model-segmentations/{model_segmentation_id}/data")
@@ -561,34 +233,15 @@ async def update_model_segmentation_data(
     axis: Optional[int] = None,
     scan_nr: Optional[int] = None,
     db: Session = Depends(get_db),
+    service: ModelSegmentationService = Depends(get_model_segmentation_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    model_segmentation = ModelSegmentation.by_id(db, model_segmentation_id)
-    if model_segmentation is None:
-        raise HTTPException(status_code=404, detail="ModelSegmentation data not found")
-
     content_type = request.headers.get("Content-Type", "").lower()
     if content_type != "application/octet-stream":
         raise HTTPException(
             status_code=400, detail=f"Unsupported media type: {content_type}"
         )
-
-    data = await request.body()
-    np_image = np.load(io.BytesIO(data))
-
-    try:
-        write_segmentation_data(
-            model_segmentation,
-            np_image,
-            axis=axis,
-            slice_index=scan_nr,
-        )
-    except IndexError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    db.add(model_segmentation)
-    db.commit()
-    db.refresh(model_segmentation)
-    return model_segmentation
+    np_image = np.load(io.BytesIO(await request.body()))
+    return service.write_data(
+        db, model_segmentation_id, np_image, axis=axis, scan_nr=scan_nr
+    )

--- a/server/routes/subtask.py
+++ b/server/routes/subtask.py
@@ -1,35 +1,28 @@
-from typing import Union, Optional
-from fastapi import APIRouter, Depends, HTTPException, Response
-from sqlalchemy import select, func, delete
-from sqlalchemy.orm import Session, selectinload
+from typing import Optional, Union
+
+from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel
-from eyened_orm import SubTask, SubTaskImageLink, ImageInstance, ImageStorage
+from sqlalchemy.orm import Session
+
+from eyened_orm.task import SubTaskState
+
 from ..db import get_db
-from ..utils.db_logging import get_db_logger
-from .auth import CurrentUser, get_current_user
-from ..dtos.dtos_tasks import (
-    SubTaskGET,
-    SubTaskWithImagesGET,
-)
 from ..dtos.dto_converter import DTOConverter
+from ..dtos.dtos_tasks import SubTaskGET, SubTaskWithImagesGET
+from ..services.acting_user import ActingUser
+from ..services.task_service import SubTaskService, get_subtask_service
+from .auth import CurrentUser, get_current_user
 
 router = APIRouter()
 
 
 class SubTaskPATCH(BaseModel):
     comments: Optional[str] = None
-    task_state: Optional[str] = None  # align with TaskState enum names
+    task_state: Optional[SubTaskState] = None
 
 
 class AddImageRequest(BaseModel):
     instance_id: str
-
-
-def _resolve_image_instance_id(db: Session, image_id: str) -> int:
-    item = db.query(ImageInstance).filter(ImageInstance.PublicID == image_id).first()
-    if item:
-        return item.ImageInstanceID
-    raise HTTPException(status_code=404, detail="ImageInstance not found")
 
 
 @router.get(
@@ -39,19 +32,11 @@ async def get_subtask(
     subtaskid: int,
     with_images: bool = False,
     db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    q = select(SubTask).where(SubTask.SubTaskID == subtaskid)
-    if with_images:
-        q = q.options(
-            selectinload(SubTask.SubTaskImageLinks)
-            .selectinload(SubTaskImageLink.ImageInstance)
-            .selectinload(ImageInstance.ImageStorages)
-            .selectinload(ImageStorage.StorageBackend)
-        )
-    st = db.execute(q).scalars().first()
-    if not st:
-        raise HTTPException(404, "SubTask not found")
+    """Get a single subtask, optionally with its images."""
+    st = service.get_subtask(db, subtaskid, with_images=with_images)
     if with_images:
         return DTOConverter.subtask_with_images_to_get(st)
     return DTOConverter.subtask_to_get(st)
@@ -62,33 +47,17 @@ async def patch_subtask(
     subtaskid: int,
     dto: SubTaskPATCH,
     db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    st = db.get(SubTask, subtaskid)
-    if not st:
-        raise HTTPException(404, "SubTask not found")
-    changes = {}
-    if dto.comments is not None:
-        changes["comments"] = f"{st.Comments} -> {dto.comments}"
-        st.Comments = dto.comments
-    if dto.task_state is not None:
-        changes["task_state"] = f"{st.TaskState} -> {dto.task_state}"
-        st.TaskState = dto.task_state
-    db.commit()
-    db.refresh(st)
-
-    # Log subtask update
-    logger = get_db_logger()
-    if logger:
-        logger.log_update(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"PATCH /api/subtasks/{subtaskid}",
-            entity="SubTask",
-            entity_id=subtaskid,
-            changes=changes if changes else None,
-        )
-
+    """Update a subtask's comments and/or state."""
+    st = service.update_subtask(
+        db,
+        subtaskid,
+        dto.comments,
+        dto.task_state,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return DTOConverter.subtask_to_get(st)
 
 
@@ -96,38 +65,15 @@ async def patch_subtask(
 async def delete_subtask(
     subtaskid: int,
     db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    # Get subtask data before deletion
-    st = db.get(SubTask, subtaskid)
-    if not st:
-        raise HTTPException(404, "SubTask not found")
-
-    # Save subtask data for logging before deletion
-    deleted_data = {
-        "task_id": st.TaskID,
-        "comments": st.Comments,
-        "task_state": str(st.TaskState) if st.TaskState else None,
-        "creator_id": st.CreatorID,
-    }
-
-    res = db.execute(delete(SubTask).where(SubTask.SubTaskID == subtaskid))
-    if res.rowcount == 0:
-        raise HTTPException(404, "SubTask not found")
-    db.commit()
-
-    # Log subtask deletion
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/subtasks/{subtaskid}",
-            entity="SubTask",
-            entity_id=subtaskid,
-            deleted_data=deleted_data,
-        )
-
+    """Delete a subtask."""
+    service.delete_subtask(
+        db,
+        subtaskid,
+        ActingUser(id=current_user.id, username=current_user.username),
+    )
     return Response(status_code=204)
 
 
@@ -136,66 +82,15 @@ async def add_subtask_image(
     subtaskid: int,
     body: AddImageRequest,
     db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    st = db.get(SubTask, subtaskid)
-    if not st:
-        raise HTTPException(404, "SubTask not found")
-    image_instance_id = _resolve_image_instance_id(db, body.instance_id)
-    inst = db.get(ImageInstance, image_instance_id)
-    if not inst:
-        raise HTTPException(404, "ImageInstance not found")
-    # Get the next available ImageIndex for this subtask
-    max_index = db.scalar(
-        select(func.max(SubTaskImageLink.ImageIndex)).where(
-            SubTaskImageLink.SubTaskID == subtaskid
-        )
-    )
-    if max_index is None:
-        max_index = -1
-    link = SubTaskImageLink(
-        SubTaskID=subtaskid,
-        ImageInstanceID=image_instance_id,
-        ImageIndex=max_index + 1,
-    )
-
-    try:
-        db.add(link)
-        db.commit()
-    except Exception as e:
-        print("Error adding image link:", e)
-        print(e)
-        db.rollback()
-        raise HTTPException(500, "Error adding image link")
-
-    # Log image link creation
-    logger = get_db_logger()
-    if logger:
-        logger.log_insert(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"POST /api/subtasks/{subtaskid}/images",
-            entity="SubTaskImageLink",
-            fields={
-                "subtask_id": subtaskid,
-                "image_instance_id": image_instance_id,
-            },
-        )
-
-    # Fetch the updated subtask with images
-    st = (
-        db.execute(
-            select(SubTask)
-            .where(SubTask.SubTaskID == subtaskid)
-            .options(
-                selectinload(SubTask.SubTaskImageLinks)
-                .selectinload(SubTaskImageLink.ImageInstance)
-                .selectinload(ImageInstance.ImageStorages)
-                .selectinload(ImageStorage.StorageBackend)
-            )
-        )
-        .scalars()
-        .first()
+    """Link an image to a subtask at the next available index."""
+    st = service.add_image(
+        db,
+        subtaskid,
+        body.instance_id,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
     return DTOConverter.subtask_with_images_to_get(st)
 
@@ -207,56 +102,14 @@ async def remove_subtask_image(
     subtaskid: int,
     instance_id: str,
     db: Session = Depends(get_db),
+    service: SubTaskService = Depends(get_subtask_service),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    # Get link data before deletion (for logging)
-    image_instance_id = _resolve_image_instance_id(db, instance_id)
-    link = db.get(
-        SubTaskImageLink, {"SubTaskID": subtaskid, "ImageInstanceID": image_instance_id}
-    )
-    if not link:
-        raise HTTPException(404, "Link not found")
-
-    deleted_data = {
-        "subtask_id": subtaskid,
-        "image_instance_id": image_instance_id,
-    }
-
-    res = db.execute(
-        delete(SubTaskImageLink).where(
-            SubTaskImageLink.SubTaskID == subtaskid,
-            SubTaskImageLink.ImageInstanceID == image_instance_id,
-        )
-    )
-    if res.rowcount == 0:
-        raise HTTPException(404, "Link not found")
-    db.commit()
-
-    # Log image link deletion
-    logger = get_db_logger()
-    if logger:
-        logger.log_delete(
-            user=current_user.username,
-            user_id=current_user.id,
-            endpoint=f"DELETE /api/subtasks/{subtaskid}/images/{instance_id}",
-            entity="SubTaskImageLink",
-            fields=deleted_data,
-            deleted_data=deleted_data,
-        )
-
-    # Fetch the updated subtask with images
-    st = (
-        db.execute(
-            select(SubTask)
-            .where(SubTask.SubTaskID == subtaskid)
-            .options(
-                selectinload(SubTask.SubTaskImageLinks)
-                .selectinload(SubTaskImageLink.ImageInstance)
-                .selectinload(ImageInstance.ImageStorages)
-                .selectinload(ImageStorage.StorageBackend)
-            )
-        )
-        .scalars()
-        .first()
+    """Unlink an image from a subtask."""
+    st = service.remove_image(
+        db,
+        subtaskid,
+        instance_id,
+        ActingUser(id=current_user.id, username=current_user.username),
     )
     return DTOConverter.subtask_with_images_to_get(st)

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -9,6 +9,10 @@ from .patient_service import PatientService
 from .study_service import StudyService
 from .tag_service import TagService
 from .task_service import SubTaskService, TaskService
+from .segmentation_service import (
+    ModelSegmentationService,
+    SegmentationService,
+)
 
 __all__ = [
     "ServiceError",
@@ -26,4 +30,6 @@ __all__ = [
     "TagService",
     "TaskService",
     "SubTaskService",
+    "SegmentationService",
+    "ModelSegmentationService",
 ]

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -2,6 +2,7 @@ from .acting_user import ActingUser
 from .device_service import DeviceService
 from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
 from .feature_service import FeatureService
+from .form_annotation_service import FormAnnotationService
 from .form_schema_service import FormSchemaService
 from .image_instance_service import ImageInstanceService
 from .patient_service import PatientService
@@ -17,9 +18,10 @@ __all__ = [
     "ActingUser",
     "DeviceService",
     "PatientService",
+    "FeatureService",
+    "FormAnnotationService",
     "FormSchemaService",
     "StudyService",
-    "FeatureService",
     "ImageInstanceService",
     "TagService",
     "TaskService",

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -6,7 +6,7 @@ from .form_schema_service import FormSchemaService
 from .patient_service import PatientService
 from .study_service import StudyService
 from .tag_service import TagService
-from .task_service import TaskService
+from .task_service import SubTaskService, TaskService
 
 __all__ = [
     "ServiceError",
@@ -21,4 +21,5 @@ __all__ = [
     "FeatureService",
     "TagService",
     "TaskService",
+    "SubTaskService",
 ]

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -3,6 +3,7 @@ from .device_service import DeviceService
 from .exceptions import BadRequestError, ConflictError, NotFoundError, ServiceError
 from .feature_service import FeatureService
 from .form_schema_service import FormSchemaService
+from .image_instance_service import ImageInstanceService
 from .patient_service import PatientService
 from .study_service import StudyService
 from .tag_service import TagService
@@ -19,6 +20,7 @@ __all__ = [
     "FormSchemaService",
     "StudyService",
     "FeatureService",
+    "ImageInstanceService",
     "TagService",
     "TaskService",
     "SubTaskService",

--- a/server/services/form_annotation_service.py
+++ b/server/services/form_annotation_service.py
@@ -14,7 +14,19 @@ from eyened_orm.repositories.image_instance_repository import (
 from eyened_orm.repositories.tag_repository import TagRepository
 
 from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
 from .exceptions import NotFoundError
+
+
+_FIELD_MAP = {
+    "form_schema_id": "FormSchemaID",
+    "patient_id": "PatientID",
+    "study_id": "StudyID",
+    "laterality": "Laterality",
+    "sub_task_id": "SubTaskID",
+    "form_data": "FormData",
+    "form_annotation_reference_id": "FormAnnotationReferenceID",
+}
 
 
 class FormAnnotationService:
@@ -95,6 +107,169 @@ class FormAnnotationService:
         if item is None:
             raise NotFoundError("FormAnnotation not found")
         return item.FormData
+
+    def create(
+        self,
+        session: Session,
+        *,
+        form_schema_id: int,
+        patient_id: int,
+        study_id: int | None,
+        image_id: str | None,
+        laterality: Any,
+        sub_task_id: int | None,
+        form_data: Any,
+        form_annotation_reference_id: int | None,
+        actor: ActingUser,
+    ) -> FormAnnotation:
+        """Create a FormAnnotation owned by the acting user.
+
+        Raises:
+            NotFoundError: If image_id is given but resolves to no instance.
+        """
+        image_instance_id = self._resolve_image_instance_id(session, image_id)
+        annotation = FormAnnotation(
+            FormSchemaID=form_schema_id,
+            PatientID=patient_id,
+            StudyID=study_id,
+            ImageInstanceID=image_instance_id,
+            Laterality=laterality,
+            CreatorID=actor.id,
+            SubTaskID=sub_task_id,
+            FormData=form_data,
+            FormAnnotationReferenceID=form_annotation_reference_id,
+        )
+        session.add(annotation)
+        session.commit()
+        session.refresh(annotation)
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/form-annotations",
+                entity="FormAnnotation",
+                entity_id=annotation.FormAnnotationID,
+                fields={
+                    "form_schema_id": annotation.FormSchemaID,
+                    "patient_id": annotation.PatientID,
+                    "study_id": annotation.StudyID,
+                    "image_instance_id": annotation.ImageInstanceID,
+                    "sub_task_id": annotation.SubTaskID,
+                },
+            )
+        return annotation
+
+    def update(
+        self,
+        session: Session,
+        annotation_id: int,
+        updates: dict[str, Any],
+        actor: ActingUser,
+    ) -> FormAnnotation:
+        """Apply the provided (snake_case-keyed) fields to an annotation.
+
+        ``updates`` carries only the fields the client set (the route's
+        ``exclude_unset`` dict); ``image_id`` is re-resolved to an
+        ImageInstanceID.
+
+        Raises:
+            NotFoundError: If the annotation, or a given image_id, is unknown.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        if "image_id" in updates:
+            annotation.ImageInstanceID = self._resolve_image_instance_id(
+                session, updates["image_id"]
+            )
+        for key, attr in _FIELD_MAP.items():
+            if key in updates:
+                setattr(annotation, attr, updates[key])
+
+        session.commit()
+        session.refresh(annotation)
+        if self.logger is not None:
+            # Decision #3: preserve the pre-refactor audit formatting quirk —
+            # snake_case getattr on the ORM object always yields None, so every
+            # logged change reads "None -> <new>". Behavior-preserving on
+            # purpose; not an API response. A reviewer may fix separately.
+            changes = {
+                key: f"{getattr(annotation, key, None)} -> {value}"
+                for key, value in updates.items()
+            }
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/form-annotations/{annotation_id}",
+                entity="FormAnnotation",
+                entity_id=annotation_id,
+                changes=changes if changes else None,
+            )
+        return annotation
+
+    def soft_delete(
+        self, session: Session, annotation_id: int, actor: ActingUser
+    ) -> None:
+        """Soft-delete an annotation (sets Inactive; row is kept).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        deleted_data = {
+            "form_schema_id": annotation.FormSchemaID,
+            "patient_id": annotation.PatientID,
+            "study_id": annotation.StudyID,
+            "image_instance_id": annotation.ImageInstanceID,
+            "sub_task_id": annotation.SubTaskID,
+            "laterality": annotation.Laterality,
+            "creator_id": annotation.CreatorID,
+        }
+        annotation.Inactive = True
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/form-annotations/{annotation_id}",
+                entity="FormAnnotation",
+                entity_id=annotation_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+    def set_value(
+        self,
+        session: Session,
+        annotation_id: int,
+        form_data: Any,
+        actor: ActingUser,
+    ) -> None:
+        """Overwrite an annotation's FormData payload (high-frequency op).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        annotation.FormData = form_data
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_simple(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PUT /api/form-annotations/{annotation_id}/value",
+                operation="UPDATE",
+                entity="FormAnnotation",
+                entity_id=annotation_id,
+            )
+        return None
 
 
 def get_form_annotation_service() -> FormAnnotationService:

--- a/server/services/form_annotation_service.py
+++ b/server/services/form_annotation_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import FormAnnotation
+from eyened_orm.repositories.form_annotation_repository import (
+    FormAnnotationRepository,
+)
+from eyened_orm.repositories.image_instance_repository import (
+    ImageInstanceRepository,
+)
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .exceptions import NotFoundError
+
+
+class FormAnnotationService:
+    """Business logic for FormAnnotation CRUD, values, and Tag links."""
+
+    def __init__(
+        self,
+        repository: FormAnnotationRepository,
+        image_repository: ImageInstanceRepository,
+        tag_repository: TagRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.images = image_repository
+        self.tags = tag_repository
+        self.logger = logger
+
+    def _resolve_image_instance_id(
+        self, session: Session, image_id: str | None
+    ) -> int | None:
+        """Map a PublicID to its ImageInstanceID (None passes through).
+
+        Raises:
+            NotFoundError: If a non-None image_id resolves to no instance.
+        """
+        if image_id is None:
+            return None
+        instance = self.images.get_by_public_id(session, image_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+        return instance.ImageInstanceID
+
+    def list_annotations(
+        self,
+        session: Session,
+        *,
+        patient_id: int | None,
+        study_id: int | None,
+        image_id: str | None,
+        form_schema_id: int | None,
+        sub_task_id: int | None,
+    ) -> list[FormAnnotation]:
+        """List active annotations matching the filters (resolving image_id).
+
+        Raises:
+            NotFoundError: If image_id is given but resolves to no instance.
+        """
+        image_instance_id = self._resolve_image_instance_id(session, image_id)
+        return self.repository.list_active(
+            session,
+            patient_id=patient_id,
+            study_id=study_id,
+            image_instance_id=image_instance_id,
+            form_schema_id=form_schema_id,
+            sub_task_id=sub_task_id,
+        )
+
+    def get_annotation(
+        self, session: Session, annotation_id: int
+    ) -> FormAnnotation:
+        """Return an annotation by id (with tag links loaded).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        item = self.repository.get_with_tag_links(session, annotation_id)
+        if item is None:
+            raise NotFoundError("FormAnnotation not found")
+        return item
+
+    def get_value(self, session: Session, annotation_id: int) -> Any:
+        """Return an annotation's raw FormData payload.
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        item = self.repository.get_by_id(session, annotation_id)
+        if item is None:
+            raise NotFoundError("FormAnnotation not found")
+        return item.FormData
+
+
+def get_form_annotation_service() -> FormAnnotationService:
+    """Default FormAnnotationService wiring for FastAPI ``Depends()``."""
+    return FormAnnotationService(
+        FormAnnotationRepository(),
+        ImageInstanceRepository(),
+        TagRepository(),
+        logger=get_db_logger(),
+    )

--- a/server/services/form_annotation_service.py
+++ b/server/services/form_annotation_service.py
@@ -4,7 +4,8 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from eyened_orm import FormAnnotation
+from eyened_orm import FormAnnotation, FormAnnotationTagLink
+from eyened_orm.tag import TagType
 from eyened_orm.repositories.form_annotation_repository import (
     FormAnnotationRepository,
 )
@@ -15,7 +16,7 @@ from eyened_orm.repositories.tag_repository import TagRepository
 
 from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
 from .acting_user import ActingUser
-from .exceptions import NotFoundError
+from .exceptions import BadRequestError, NotFoundError
 
 
 _FIELD_MAP = {
@@ -269,6 +270,160 @@ class FormAnnotationService:
                 entity="FormAnnotation",
                 entity_id=annotation_id,
             )
+        return None
+
+    def tag(
+        self,
+        session: Session,
+        annotation_id: int,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> FormAnnotationTagLink:
+        """Attach a Tag to an annotation (idempotent; updates comment if re-tagged).
+
+        Raises:
+            NotFoundError: If the annotation or the tag does not exist.
+            BadRequestError: If the tag is not a FormAnnotation-type tag.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.FormAnnotation:
+            raise BadRequestError("Tag type must be FormAnnotation")
+
+        link = self.repository.get_tag_link(session, tag.TagID, annotation_id)
+        if link is None:
+            link = FormAnnotationTagLink(
+                TagID=tag.TagID,
+                FormAnnotationID=annotation_id,
+                CreatorID=actor.id,
+                Comment=comment,
+            )
+            session.add(link)
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/form-annotations/{annotation_id}/tags",
+                    entity="FormAnnotationTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "form_annotation_id": annotation_id,
+                        "comment": comment,
+                    },
+                )
+        elif comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/form-annotations/{annotation_id}/tags",
+                    entity="FormAnnotationTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "form_annotation_id": annotation_id,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag  # avoid a Tag lazy-load at DTO time
+        return link
+
+    def patch_tag(
+        self,
+        session: Session,
+        annotation_id: int,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> FormAnnotationTagLink:
+        """Update the comment on an existing annotation tag link.
+
+        Raises:
+            NotFoundError: If the annotation, tag, or link does not exist.
+            BadRequestError: If the tag is not a FormAnnotation-type tag.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.FormAnnotation:
+            raise BadRequestError("Tag type must be FormAnnotation")
+
+        link = self.repository.get_tag_link(session, tag_id, annotation_id)
+        if link is None:
+            raise NotFoundError("Link not found")
+
+        if comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=(
+                        f"PATCH /api/form-annotations/{annotation_id}"
+                        f"/tags/{tag_id}"
+                    ),
+                    entity="FormAnnotationTagLink",
+                    fields={
+                        "tag_id": tag_id,
+                        "form_annotation_id": annotation_id,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag
+        return link
+
+    def untag(
+        self, session: Session, annotation_id: int, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Remove a Tag from an annotation (idempotent; no error if not linked).
+
+        Raises:
+            NotFoundError: If the annotation does not exist.
+        """
+        annotation = self.repository.get_by_id(session, annotation_id)
+        if annotation is None:
+            raise NotFoundError("FormAnnotation not found")
+
+        link = self.repository.get_tag_link(session, tag_id, annotation_id)
+        if link is not None:
+            deleted_data = {
+                "tag_id": tag_id,
+                "form_annotation_id": annotation_id,
+                "comment": link.Comment,
+                "creator_id": link.CreatorID,
+            }
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=(
+                        f"DELETE /api/form-annotations/{annotation_id}"
+                        f"/tags/{tag_id}"
+                    ),
+                    entity="FormAnnotationTagLink",
+                    fields={"tag_id": tag_id, "form_annotation_id": annotation_id},
+                    deleted_data=deleted_data,
+                )
         return None
 
 

--- a/server/services/image_instance_service.py
+++ b/server/services/image_instance_service.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from eyened_orm import ImageInstance
+from eyened_orm import ImageInstance, ImageInstanceTagLink
 from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
 from eyened_orm.repositories.tag_repository import TagRepository
+from eyened_orm.tag import TagType
 
 from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
-from .exceptions import NotFoundError
+from .acting_user import ActingUser
+from .exceptions import BadRequestError, NotFoundError
 
 
 class ImageInstanceService:
@@ -83,6 +85,160 @@ class ImageInstanceService:
         if item is None:
             raise NotFoundError("ImageInstance not found")
         return item
+
+    def tag_instance(
+        self,
+        session: Session,
+        public_id: str,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> ImageInstanceTagLink:
+        """Attach a Tag to an instance (idempotent; updates comment if re-tagged).
+
+        Raises:
+            NotFoundError: If the instance or the tag does not exist.
+            BadRequestError: If the tag is not an ImageInstance-type tag.
+        """
+        instance = self.repository.get_with_storage_by_public_id(session, public_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.ImageInstance:
+            raise BadRequestError("Tag type must be ImageInstance")
+
+        link = self.repository.get_tag_link(
+            session, tag.TagID, instance.ImageInstanceID
+        )
+        if link is None:
+            link = ImageInstanceTagLink(
+                TagID=tag.TagID,
+                ImageInstanceID=instance.ImageInstanceID,
+                CreatorID=actor.id,
+                Comment=comment,
+            )
+            session.add(link)
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/instances/{public_id}/tags",
+                    entity="ImageInstanceTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "image_instance_id": instance.ImageInstanceID,
+                        "comment": comment,
+                    },
+                )
+        elif comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/instances/{public_id}/tags",
+                    entity="ImageInstanceTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "image_instance_id": public_id,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag  # avoid a Tag lazy-load at DTO time
+        return link
+
+    def patch_instance_tag(
+        self,
+        session: Session,
+        public_id: str,
+        tag_id: int,
+        comment: str | None,
+        actor: ActingUser,
+    ) -> ImageInstanceTagLink:
+        """Update the comment on an existing instance tag link.
+
+        Raises:
+            NotFoundError: If the instance, tag, or link does not exist.
+            BadRequestError: If the tag is not an ImageInstance-type tag.
+        """
+        instance = self.repository.get_with_storage_by_public_id(session, public_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.ImageInstance:
+            raise BadRequestError("Tag type must be ImageInstance")
+
+        link = self.repository.get_tag_link(
+            session, tag_id, instance.ImageInstanceID
+        )
+        if link is None:
+            raise NotFoundError("Link not found")
+
+        if comment is not None:
+            old_comment = link.Comment
+            link.Comment = comment
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_update(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"PATCH /api/instances/{public_id}/tags/{tag_id}",
+                    entity="ImageInstanceTagLink",
+                    fields={
+                        "tag_id": tag_id,
+                        "image_instance_id": instance.ImageInstanceID,
+                    },
+                    changes={"comment": f"{old_comment} -> {comment}"},
+                )
+
+        link.Tag = tag
+        return link
+
+    def untag_instance(
+        self, session: Session, public_id: str, tag_id: int, actor: ActingUser
+    ) -> None:
+        """Remove a Tag from an instance (idempotent; no error if not linked).
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        instance = self.repository.get_with_storage_by_public_id(session, public_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+
+        link = self.repository.get_tag_link(
+            session, tag_id, instance.ImageInstanceID
+        )
+        if link is not None:
+            deleted_data = {
+                "tag_id": tag_id,
+                "image_instance_id": instance.ImageInstanceID,
+                "comment": link.Comment,
+                "creator_id": link.CreatorID,
+            }
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"DELETE /api/instances/{public_id}/tags/{tag_id}",
+                    entity="ImageInstanceTagLink",
+                    fields={"tag_id": tag_id, "image_instance_id": public_id},
+                    deleted_data=deleted_data,
+                )
+        return None
 
 
 def get_image_instance_service() -> ImageInstanceService:

--- a/server/services/image_instance_service.py
+++ b/server/services/image_instance_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from eyened_orm import ImageInstance
+from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .exceptions import NotFoundError
+
+
+class ImageInstanceService:
+    """Business logic for ImageInstance reads and its Tag links."""
+
+    def __init__(
+        self,
+        repository: ImageInstanceRepository,
+        tag_repository: TagRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.tags = tag_repository
+        self.logger = logger
+
+    def get_instance(
+        self,
+        session: Session,
+        instance_id: int,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance:
+        """Return an instance by int id, with the requested eager-load graph.
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        item = self.repository.get_full_graph_by_id(
+            session,
+            instance_id,
+            with_segmentations=with_segmentations,
+            with_form_annotations=with_form_annotations,
+            with_model_segmentations=with_model_segmentations,
+        )
+        if item is None:
+            raise NotFoundError("ImageInstance not found")
+        return item
+
+    def get_by_public_id(
+        self,
+        session: Session,
+        image_id: str,
+        *,
+        with_segmentations: bool,
+        with_form_annotations: bool,
+        with_model_segmentations: bool,
+    ) -> ImageInstance:
+        """Return an instance by PublicID, with the requested eager-load graph.
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        item = self.repository.get_full_graph_by_public_id(
+            session,
+            image_id,
+            with_segmentations=with_segmentations,
+            with_form_annotations=with_form_annotations,
+            with_model_segmentations=with_model_segmentations,
+        )
+        if item is None:
+            raise NotFoundError("ImageInstance not found")
+        return item
+
+    def get_for_storage(self, session: Session, public_id: str) -> ImageInstance:
+        """Return the storage-loaded instance for a data/thumbnail request.
+
+        Raises:
+            NotFoundError: If the instance does not exist.
+        """
+        item = self.repository.get_with_storage_by_public_id(session, public_id)
+        if item is None:
+            raise NotFoundError("ImageInstance not found")
+        return item
+
+
+def get_image_instance_service() -> ImageInstanceService:
+    """Default ImageInstanceService wiring for FastAPI ``Depends()``."""
+    return ImageInstanceService(
+        ImageInstanceRepository(), TagRepository(), logger=get_db_logger()
+    )

--- a/server/services/segmentation_data_store.py
+++ b/server/services/segmentation_data_store.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Optional, Protocol
+
+import numpy as np
+from eyened_orm.segmentation_storage import (
+    read_segmentation_data,
+    write_segmentation_data,
+)
+
+
+class SegmentationDataStore(Protocol):
+    """Storage seam for segmentation binary data.
+
+    The Service depends only on this contract; the concrete store decides the
+    library. A future concurrency fix (a locking decorator, or a different
+    backend) is a new implementation swapped in ``get_segmentation_data_store``
+    without touching the Service, routes, or tests.
+    """
+
+    def read(
+        self,
+        segmentation,
+        *,
+        axis: Optional[int] = None,
+        slice_index: Optional[int] = None,
+    ) -> Optional[np.ndarray]: ...
+
+    def write(
+        self,
+        segmentation,
+        data: np.ndarray,
+        *,
+        axis: Optional[int] = None,
+        slice_index: Optional[int] = None,
+    ) -> int: ...
+
+
+class ZarrSegmentationDataStore:
+    """Production store: delegates to the zarr-backed ``segmentation_storage``
+    module functions — the exact calls the route made before this refactor, so
+    behavior is unchanged."""
+
+    def read(
+        self,
+        segmentation,
+        *,
+        axis: Optional[int] = None,
+        slice_index: Optional[int] = None,
+    ) -> Optional[np.ndarray]:
+        return read_segmentation_data(
+            segmentation, axis=axis, slice_index=slice_index
+        )
+
+    def write(
+        self,
+        segmentation,
+        data: np.ndarray,
+        *,
+        axis: Optional[int] = None,
+        slice_index: Optional[int] = None,
+    ) -> int:
+        return write_segmentation_data(
+            segmentation, data, axis=axis, slice_index=slice_index
+        )
+
+
+def get_segmentation_data_store() -> SegmentationDataStore:
+    """Default data store for FastAPI ``Depends()`` wiring."""
+    return ZarrSegmentationDataStore()

--- a/server/services/segmentation_service.py
+++ b/server/services/segmentation_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from eyened_orm import ImageInstance, ModelSegmentation, Segmentation
+from eyened_orm.segmentation import DataRepresentation, Datatype
+from eyened_orm.tag import SegmentationTagLink, TagType
+from eyened_orm.repositories.image_instance_repository import (
+    ImageInstanceRepository,
+)
+from eyened_orm.repositories.segmentation_repository import (
+    ModelSegmentationRepository,
+    SegmentationRepository,
+)
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from ..utils.db_logging import DatabaseModificationLogger, get_db_logger
+from .acting_user import ActingUser
+from .exceptions import BadRequestError, NotFoundError
+from .segmentation_data_store import (
+    SegmentationDataStore,
+    get_segmentation_data_store,
+)
+
+
+class SegmentationService:
+    """Business logic for Segmentation CRUD, binary data, and Tag links."""
+
+    def __init__(
+        self,
+        repository: SegmentationRepository,
+        image_repository: ImageInstanceRepository,
+        tag_repository: TagRepository,
+        data_store: SegmentationDataStore,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.images = image_repository
+        self.tags = tag_repository
+        self.store = data_store
+        self.logger = logger
+
+    def get_segmentation(
+        self, session: Session, segmentation_id: int
+    ) -> Segmentation:
+        """Return a segmentation by id (tag links loaded).
+
+        Raises:
+            NotFoundError: If the segmentation does not exist.
+        """
+        item = self.repository.get_with_tag_links(session, segmentation_id)
+        if item is None:
+            raise NotFoundError("Segmentation not found")
+        return item
+
+    def read_data(
+        self,
+        session: Session,
+        segmentation_id: int,
+        *,
+        axis: Optional[int] = None,
+        scan_nr: Optional[int] = None,
+    ) -> Optional[np.ndarray]:
+        """Return the stored array for a segmentation (None if none stored).
+
+        Raises:
+            NotFoundError: If the segmentation does not exist.
+            BadRequestError: If the store rejects the read parameters.
+        """
+        segmentation = self.repository.get_by_id(session, segmentation_id)
+        if segmentation is None:
+            raise NotFoundError("Segmentation data not found")
+        try:
+            return self.store.read(segmentation, axis=axis, slice_index=scan_nr)
+        except ValueError as e:
+            raise BadRequestError(str(e)) from e
+
+
+class ModelSegmentationService:
+    """Business logic for ModelSegmentation binary data endpoints."""
+
+    def __init__(
+        self,
+        repository: ModelSegmentationRepository,
+        data_store: SegmentationDataStore,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.repository = repository
+        self.store = data_store
+        self.logger = logger
+
+    def read_data(
+        self,
+        session: Session,
+        model_segmentation_id: int,
+        *,
+        axis: Optional[int] = None,
+        scan_nr: Optional[int] = None,
+    ) -> Optional[np.ndarray]:
+        """Return the stored array for a model segmentation (None if none).
+
+        Raises:
+            NotFoundError: If the model segmentation does not exist.
+            BadRequestError: If the store rejects the read parameters.
+        """
+        item = self.repository.get_by_id(session, model_segmentation_id)
+        if item is None:
+            raise NotFoundError("ModelSegmentation data not found")
+        try:
+            return self.store.read(item, axis=axis, slice_index=scan_nr)
+        except ValueError as e:
+            raise BadRequestError(str(e)) from e
+
+
+def get_segmentation_service() -> SegmentationService:
+    """Default SegmentationService wiring for FastAPI ``Depends()``."""
+    return SegmentationService(
+        SegmentationRepository(),
+        ImageInstanceRepository(),
+        TagRepository(),
+        get_segmentation_data_store(),
+        logger=get_db_logger(),
+    )
+
+
+def get_model_segmentation_service() -> ModelSegmentationService:
+    """Default ModelSegmentationService wiring for FastAPI ``Depends()``."""
+    return ModelSegmentationService(
+        ModelSegmentationRepository(),
+        get_segmentation_data_store(),
+        logger=get_db_logger(),
+    )

--- a/server/services/segmentation_service.py
+++ b/server/services/segmentation_service.py
@@ -79,6 +79,277 @@ class SegmentationService:
         except ValueError as e:
             raise BadRequestError(str(e)) from e
 
+    def create(
+        self,
+        session: Session,
+        *,
+        image_id: str,
+        feature_id: int,
+        subtask_id: int | None,
+        data_type: Datatype,
+        data_representation: DataRepresentation,
+        depth: int | None,
+        height: int | None,
+        width: int | None,
+        sparse_axis: int | None,
+        image_projection_matrix: list[list[float]] | None,
+        scan_indices: list[int] | None,
+        threshold: float | None,
+        reference_segmentation_id: int | None,
+        array: np.ndarray | None,
+        actor: ActingUser,
+    ) -> Segmentation:
+        """Create a Segmentation and write its (empty or provided) data.
+
+        Raises:
+            NotFoundError: If image_id resolves to no instance.
+            BadRequestError: If the array/shape is inconsistent or the store
+                rejects the write.
+        """
+        instance = self.images.get_by_public_id(session, image_id)
+        if instance is None:
+            raise NotFoundError("ImageInstance not found")
+
+        segmentation = Segmentation(
+            ImageInstanceID=instance.ImageInstanceID,
+            FeatureID=feature_id,
+            CreatorID=actor.id,
+            SubTaskID=subtask_id,
+            DataType=data_type,
+            DataRepresentation=data_representation,
+            Depth=depth,
+            Height=height,
+            Width=width,
+            SparseAxis=sparse_axis,
+            ImageProjectionMatrix=image_projection_matrix,
+            ScanIndices=scan_indices,
+            Threshold=threshold,
+            ReferenceSegmentationID=reference_segmentation_id,
+            DateInserted=datetime.now(),
+        )
+        data = self._assemble_data(segmentation, instance, array)
+
+        session.add(segmentation)
+        session.flush()
+        try:
+            self.store.write(segmentation, data)
+        except ValueError as e:
+            raise BadRequestError(str(e)) from e
+        session.commit()
+        session.refresh(segmentation)
+
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint="POST /api/segmentations",
+                entity="Segmentation",
+                entity_id=segmentation.SegmentationID,
+                fields={
+                    "image_instance_id": segmentation.ImageInstanceID,
+                    "feature_id": segmentation.FeatureID,
+                    "subtask_id": segmentation.SubTaskID,
+                    "creator_id": segmentation.CreatorID,
+                    "data_type": str(segmentation.DataType),
+                    "data_representation": str(segmentation.DataRepresentation),
+                    "shape": segmentation.shape,
+                    "sparse_axis": segmentation.SparseAxis,
+                    "threshold": segmentation.Threshold,
+                    "reference_segmentation_id": (
+                        segmentation.ReferenceSegmentationID
+                    ),
+                },
+            )
+        return segmentation
+
+    def _assemble_data(
+        self,
+        segmentation: Segmentation,
+        image: ImageInstance,
+        array: Optional[np.ndarray],
+    ) -> np.ndarray:
+        """Build the data volume to store, validating array vs. segmentation.
+
+        Reproduces the pre-refactor route logic; raises BadRequestError on any
+        shape inconsistency.
+        """
+        if array is None:
+            return self._create_empty_array(segmentation, image)
+
+        if segmentation.ScanIndices is None:
+            data = array
+            if segmentation.shape != array.shape:
+                raise BadRequestError(
+                    f"Segmentation shape {segmentation.shape} does not match "
+                    f"array shape {array.shape}"
+                )
+        else:
+            if segmentation.SparseAxis is None:
+                raise BadRequestError("SparseAxis is not set for sparse volume")
+            if len(segmentation.ScanIndices) != array.shape[
+                segmentation.SparseAxis
+            ]:
+                raise BadRequestError(
+                    f"ScanIndices length {len(segmentation.ScanIndices)} does "
+                    f"not match array sparse axis length "
+                    f"{array.shape[segmentation.SparseAxis]}"
+                )
+            data = np.zeros(segmentation.shape, dtype=segmentation.dtype)
+            for i, scan_index in enumerate(segmentation.ScanIndices):
+                data[scan_index] = array[i]
+
+        for dim, attr in zip(data.shape, ["Depth", "Height", "Width"]):
+            val = getattr(segmentation, attr)
+            if val is None:
+                setattr(segmentation, attr, dim)
+            elif val != dim:
+                raise BadRequestError(
+                    f"Segmentation {attr} ({val}) does not match array "
+                    f"{attr} ({dim})"
+                )
+        return data
+
+    def _create_empty_array(
+        self, segmentation: Segmentation, image: ImageInstance
+    ) -> np.ndarray:
+        """Zeros volume sized from the segmentation (falling back to image dims)."""
+        s_d, s_h, s_w = segmentation.shape
+        im_d, im_h, im_w = image.shape
+        shape = (s_d or im_d, s_h or im_h, s_w or im_w)
+        segmentation.Depth, segmentation.Height, segmentation.Width = shape
+        return np.zeros(shape, dtype=segmentation.dtype)
+
+    def write_data(
+        self,
+        session: Session,
+        segmentation_id: int,
+        data: np.ndarray,
+        *,
+        axis: Optional[int] = None,
+        scan_nr: Optional[int] = None,
+        actor: ActingUser,
+    ) -> Segmentation:
+        """Write (a slice of) a segmentation's binary data via the store.
+
+        Raises:
+            NotFoundError: If the segmentation does not exist.
+            BadRequestError: If the store rejects the write.
+        """
+        segmentation = self.repository.get_by_id(session, segmentation_id)
+        if segmentation is None:
+            raise NotFoundError("Segmentation data not found")
+        try:
+            self.store.write(
+                segmentation, data, axis=axis, slice_index=scan_nr
+            )
+        except (IndexError, ValueError) as e:
+            raise BadRequestError(str(e)) from e
+        session.add(segmentation)
+        session.commit()
+        session.refresh(segmentation)
+        if self.logger is not None:
+            self.logger.log_simple(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PUT /api/segmentations/{segmentation_id}/data",
+                operation="UPDATE",
+                entity="Segmentation",
+                entity_id=segmentation_id,
+            )
+        return segmentation
+
+    def soft_delete(
+        self, session: Session, segmentation_id: int, actor: ActingUser
+    ) -> None:
+        """Soft-delete a segmentation (sets Inactive; row is kept).
+
+        Raises:
+            NotFoundError: If the segmentation does not exist.
+        """
+        segmentation = self.repository.get_by_id(session, segmentation_id)
+        if segmentation is None:
+            raise NotFoundError("Segmentation not found")
+
+        deleted_data = {
+            "image_instance_id": segmentation.ImageInstanceID,
+            "feature_id": segmentation.FeatureID,
+            "subtask_id": segmentation.SubTaskID,
+            "creator_id": segmentation.CreatorID,
+            "data_type": str(segmentation.DataType),
+            "data_representation": str(segmentation.DataRepresentation),
+            "shape": segmentation.shape,
+            "sparse_axis": segmentation.SparseAxis,
+            "threshold": segmentation.Threshold,
+            "reference_segmentation_id": segmentation.ReferenceSegmentationID,
+        }
+        segmentation.Inactive = True
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/segmentations/{segmentation_id}",
+                entity="Segmentation",
+                entity_id=segmentation_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+    def patch(
+        self,
+        session: Session,
+        segmentation_id: int,
+        *,
+        reference_segmentation_id: int | None,
+        feature_id: int | None,
+        threshold: float | None,
+        actor: ActingUser,
+    ) -> Segmentation:
+        """Apply the provided (non-None) fields to a segmentation.
+
+        Preserves the pre-refactor audit quirk: reference/feature are applied
+        before the change-string is built, so they log ``<new> -> <new>`` while
+        threshold logs the true ``<old> -> <new>``. Audit-log-only; not an API
+        field. See deferred findings.
+
+        Raises:
+            NotFoundError: If the segmentation does not exist.
+        """
+        segmentation = self.repository.get_by_id(session, segmentation_id)
+        if segmentation is None:
+            raise NotFoundError("Segmentation not found")
+
+        if reference_segmentation_id is not None:
+            segmentation.ReferenceSegmentationID = reference_segmentation_id
+        if feature_id is not None:
+            segmentation.FeatureID = feature_id
+        changes: dict[str, str] = {}
+        if reference_segmentation_id is not None:
+            changes["reference_segmentation_id"] = (
+                f"{segmentation.ReferenceSegmentationID} -> "
+                f"{reference_segmentation_id}"
+            )
+            segmentation.ReferenceSegmentationID = reference_segmentation_id
+        if feature_id is not None:
+            changes["feature_id"] = f"{segmentation.FeatureID} -> {feature_id}"
+            segmentation.FeatureID = feature_id
+        if threshold is not None:
+            changes["threshold"] = f"{segmentation.Threshold} -> {threshold}"
+            segmentation.Threshold = threshold
+
+        session.commit()
+        session.refresh(segmentation)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/segmentations/{segmentation_id}",
+                entity="Segmentation",
+                entity_id=segmentation_id,
+                changes=changes if changes else None,
+            )
+        return segmentation
+
 
 class ModelSegmentationService:
     """Business logic for ModelSegmentation binary data endpoints."""
@@ -114,6 +385,33 @@ class ModelSegmentationService:
             return self.store.read(item, axis=axis, slice_index=scan_nr)
         except ValueError as e:
             raise BadRequestError(str(e)) from e
+
+    def write_data(
+        self,
+        session: Session,
+        model_segmentation_id: int,
+        data: np.ndarray,
+        *,
+        axis: Optional[int] = None,
+        scan_nr: Optional[int] = None,
+    ) -> ModelSegmentation:
+        """Write (a slice of) a model segmentation's binary data via the store.
+
+        Raises:
+            NotFoundError: If the model segmentation does not exist.
+            BadRequestError: If the store rejects the write.
+        """
+        item = self.repository.get_by_id(session, model_segmentation_id)
+        if item is None:
+            raise NotFoundError("ModelSegmentation data not found")
+        try:
+            self.store.write(item, data, axis=axis, slice_index=scan_nr)
+        except (IndexError, ValueError) as e:
+            raise BadRequestError(str(e)) from e
+        session.add(item)
+        session.commit()
+        session.refresh(item)
+        return item
 
 
 def get_segmentation_service() -> SegmentationService:

--- a/server/services/segmentation_service.py
+++ b/server/services/segmentation_service.py
@@ -350,6 +350,95 @@ class SegmentationService:
             )
         return segmentation
 
+    def tag(
+        self,
+        session: Session,
+        segmentation_id: int,
+        tag_id: int,
+        actor: ActingUser,
+    ) -> SegmentationTagLink:
+        """Attach a Tag to a segmentation (idempotent).
+
+        Behavior-preserving: the client-supplied comment is NOT stored (matches
+        the pre-refactor handler). See deferred findings.
+
+        Raises:
+            NotFoundError: If the segmentation or the tag does not exist.
+            BadRequestError: If the tag is not a Segmentation-type tag.
+        """
+        segmentation = self.repository.get_by_id(session, segmentation_id)
+        if segmentation is None:
+            raise NotFoundError("Segmentation not found")
+        tag = self.tags.get_by_id(session, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag not found")
+        if tag.TagType != TagType.Segmentation:
+            raise BadRequestError("Tag type must be Segmentation")
+
+        link = self.repository.get_tag_link(session, tag.TagID, segmentation_id)
+        if link is None:
+            link = SegmentationTagLink(
+                TagID=tag.TagID,
+                SegmentationID=segmentation_id,
+                CreatorID=actor.id,
+            )
+            session.add(link)
+            session.commit()
+            session.refresh(link)
+            if self.logger is not None:
+                self.logger.log_insert(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=f"POST /api/segmentations/{segmentation_id}/tags",
+                    entity="SegmentationTagLink",
+                    fields={
+                        "tag_id": tag.TagID,
+                        "segmentation_id": segmentation_id,
+                    },
+                )
+
+        link.Tag = tag  # avoid a Tag lazy-load at DTO time
+        return link
+
+    def untag(
+        self,
+        session: Session,
+        segmentation_id: int,
+        tag_id: int,
+        actor: ActingUser,
+    ) -> None:
+        """Remove a Tag from a segmentation (idempotent; no error if unlinked).
+
+        Raises:
+            NotFoundError: If the segmentation does not exist.
+        """
+        segmentation = self.repository.get_by_id(session, segmentation_id)
+        if segmentation is None:
+            raise NotFoundError("Segmentation not found")
+
+        link = self.repository.get_tag_link(session, tag_id, segmentation_id)
+        if link is not None:
+            deleted_data = {
+                "tag_id": tag_id,
+                "segmentation_id": segmentation_id,
+                "creator_id": link.CreatorID,
+            }
+            session.delete(link)
+            session.commit()
+            if self.logger is not None:
+                self.logger.log_delete(
+                    user=actor.username,
+                    user_id=actor.id,
+                    endpoint=(
+                        f"DELETE /api/segmentations/{segmentation_id}"
+                        f"/tags/{tag_id}"
+                    ),
+                    entity="SegmentationTagLink",
+                    fields={"tag_id": tag_id, "segmentation_id": segmentation_id},
+                    deleted_data=deleted_data,
+                )
+        return None
+
 
 class ModelSegmentationService:
     """Business logic for ModelSegmentation binary data endpoints."""

--- a/server/services/task_service.py
+++ b/server/services/task_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from eyened_orm import SubTask, Task
+from eyened_orm import SubTask, SubTaskImageLink, Task
 from eyened_orm.task import SubTaskState, TaskState
 from eyened_orm.repositories.task_repository import SubTaskRepository, TaskRepository
 
@@ -331,6 +331,90 @@ class SubTaskService:
                 deleted_data=deleted_data,
             )
         return None
+
+    def add_image(
+        self,
+        session: Session,
+        subtask_id: int,
+        image_public_id: str,
+        actor: ActingUser,
+    ) -> SubTask:
+        """Link an image (by PublicID) to a subtask at the next ImageIndex.
+
+        Raises:
+            NotFoundError: If the subtask or the image does not exist.
+        """
+        if self.subtasks.get_by_id(session, subtask_id) is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+        image_instance_id = self.subtasks.resolve_image_instance_id(
+            session, image_public_id
+        )
+        if image_instance_id is None:
+            raise NotFoundError("ImageInstance not found")
+
+        link = SubTaskImageLink(
+            SubTaskID=subtask_id,
+            ImageInstanceID=image_instance_id,
+            ImageIndex=self.subtasks.next_image_index(session, subtask_id),
+        )
+        session.add(link)
+        session.commit()
+        # Mirror production's commit-time expiry so the re-query below returns the
+        # current image set even when the session uses expire_on_commit=False.
+        session.expire_all()
+        if self.logger is not None:
+            self.logger.log_insert(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"POST /api/subtasks/{subtask_id}/images",
+                entity="SubTaskImageLink",
+                fields={
+                    "subtask_id": subtask_id,
+                    "image_instance_id": image_instance_id,
+                },
+            )
+        return self.subtasks.get_with_images(session, subtask_id)
+
+    def remove_image(
+        self,
+        session: Session,
+        subtask_id: int,
+        image_public_id: str,
+        actor: ActingUser,
+    ) -> SubTask:
+        """Unlink an image (by PublicID) from a subtask.
+
+        Raises:
+            NotFoundError: If the image or the (subtask, image) link is absent.
+        """
+        image_instance_id = self.subtasks.resolve_image_instance_id(
+            session, image_public_id
+        )
+        if image_instance_id is None:
+            raise NotFoundError("ImageInstance not found")
+        link = self.subtasks.get_image_link(session, subtask_id, image_instance_id)
+        if link is None:
+            raise NotFoundError("Link not found")
+
+        session.delete(link)
+        session.commit()
+        # Mirror production's commit-time expiry so the re-query below returns the
+        # current image set even when the session uses expire_on_commit=False.
+        session.expire_all()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=(
+                    f"DELETE /api/subtasks/{subtask_id}/images/{image_public_id}"
+                ),
+                entity="SubTaskImageLink",
+                deleted_data={
+                    "subtask_id": subtask_id,
+                    "image_instance_id": image_instance_id,
+                },
+            )
+        return self.subtasks.get_with_images(session, subtask_id)
 
 
 def get_task_service() -> TaskService:

--- a/server/services/task_service.py
+++ b/server/services/task_service.py
@@ -359,9 +359,6 @@ class SubTaskService:
         )
         session.add(link)
         session.commit()
-        # Mirror production's commit-time expiry so the re-query below returns the
-        # current image set even when the session uses expire_on_commit=False.
-        session.expire_all()
         if self.logger is not None:
             self.logger.log_insert(
                 user=actor.username,
@@ -398,9 +395,6 @@ class SubTaskService:
 
         session.delete(link)
         session.commit()
-        # Mirror production's commit-time expiry so the re-query below returns the
-        # current image set even when the session uses expire_on_commit=False.
-        session.expire_all()
         if self.logger is not None:
             self.logger.log_delete(
                 user=actor.username,

--- a/server/services/task_service.py
+++ b/server/services/task_service.py
@@ -235,8 +235,111 @@ class TaskService:
         return rows[0], nxt
 
 
+class SubTaskService:
+    """Business logic for individual subtasks and their image links."""
+
+    def __init__(
+        self,
+        subtask_repository: SubTaskRepository,
+        logger: DatabaseModificationLogger | None = None,
+    ) -> None:
+        self.subtasks = subtask_repository
+        self.logger = logger
+
+    def get_subtask(
+        self, session: Session, subtask_id: int, *, with_images: bool
+    ) -> SubTask:
+        """Return a subtask, image-loaded iff ``with_images``.
+
+        Raises:
+            NotFoundError: If the subtask does not exist.
+        """
+        subtask = (
+            self.subtasks.get_with_images(session, subtask_id)
+            if with_images
+            else self.subtasks.get_by_id(session, subtask_id)
+        )
+        if subtask is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+        return subtask
+
+    def update_subtask(
+        self,
+        session: Session,
+        subtask_id: int,
+        comments: str | None,
+        task_state: SubTaskState | None,
+        actor: ActingUser,
+    ) -> SubTask:
+        """Update a subtask's comments/state (each optional).
+
+        Raises:
+            NotFoundError: If the subtask does not exist.
+        """
+        subtask = self.subtasks.get_by_id(session, subtask_id)
+        if subtask is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+
+        changes: dict[str, str] = {}
+        if comments is not None:
+            changes["comments"] = f"{subtask.Comments} -> {comments}"
+            subtask.Comments = comments
+        if task_state is not None:
+            changes["task_state"] = f"{subtask.TaskState} -> {task_state}"
+            subtask.TaskState = task_state
+
+        session.commit()
+        session.refresh(subtask)
+        if self.logger is not None:
+            self.logger.log_update(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"PATCH /api/subtasks/{subtask_id}",
+                entity="SubTask",
+                entity_id=subtask_id,
+                changes=changes if changes else None,
+            )
+        return subtask
+
+    def delete_subtask(
+        self, session: Session, subtask_id: int, actor: ActingUser
+    ) -> None:
+        """Delete a subtask (its image links cascade at the DB level).
+
+        Raises:
+            NotFoundError: If the subtask does not exist.
+        """
+        subtask = self.subtasks.get_by_id(session, subtask_id)
+        if subtask is None:
+            raise NotFoundError(f"SubTask {subtask_id} not found")
+
+        deleted_data = {
+            "task_id": subtask.TaskID,
+            "comments": subtask.Comments,
+            "task_state": str(subtask.TaskState) if subtask.TaskState else None,
+            "creator_id": subtask.CreatorID,
+        }
+        session.delete(subtask)
+        session.commit()
+        if self.logger is not None:
+            self.logger.log_delete(
+                user=actor.username,
+                user_id=actor.id,
+                endpoint=f"DELETE /api/subtasks/{subtask_id}",
+                entity="SubTask",
+                entity_id=subtask_id,
+                deleted_data=deleted_data,
+            )
+        return None
+
+
 def get_task_service() -> TaskService:
     """Default TaskService wiring for FastAPI ``Depends()``."""
     return TaskService(
         TaskRepository(), SubTaskRepository(), logger=get_db_logger()
     )
+
+
+def get_subtask_service() -> SubTaskService:
+    """Default SubTaskService wiring for FastAPI ``Depends()``."""
+    return SubTaskService(SubTaskRepository(), logger=get_db_logger())

--- a/server/tests/test_form_annotation_service.py
+++ b/server/tests/test_form_annotation_service.py
@@ -12,8 +12,10 @@ from eyened_orm import (
     Project,
     Series,
     Study,
+    Tag,
 )
 from eyened_orm.project import ExternalEnum
+from eyened_orm.tag import TagType
 from eyened_orm.repositories.form_annotation_repository import (
     FormAnnotationRepository,
 )
@@ -23,7 +25,7 @@ from eyened_orm.repositories.image_instance_repository import (
 from eyened_orm.repositories.tag_repository import TagRepository
 
 from server.services.acting_user import ActingUser
-from server.services.exceptions import NotFoundError
+from server.services.exceptions import BadRequestError, NotFoundError
 from server.services.form_annotation_service import FormAnnotationService
 
 
@@ -253,3 +255,127 @@ def test_set_value_unknown_raises_not_found(session):
     """set_value on a missing annotation raises NotFoundError (-> 404)."""
     with pytest.raises(NotFoundError):
         _service().set_value(session, 999_999, {}, _actor(session))
+
+
+def _make_tag(session, creator_id: int, tag_type: TagType = TagType.FormAnnotation) -> Tag:
+    tag = Tag(
+        TagName=f"t-{tag_type.name}-{creator_id}",
+        TagDescription="d",
+        TagType=tag_type,
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_tag_creates_link(session):
+    """tag links a FormAnnotation tag and returns the link."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    link = _service().tag(
+        session, ann.FormAnnotationID, tag.TagID, "hi", actor
+    )
+
+    assert link.TagID == tag.TagID
+    assert link.Comment == "hi"
+    assert link.Tag.TagID == tag.TagID
+
+
+def test_tag_unknown_annotation_raises_not_found(session):
+    """tag on a missing annotation is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag(session, 999_999, tag.TagID, None, actor)
+
+
+def test_tag_unknown_tag_raises_not_found(session):
+    """tag with an unknown tag id is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t2")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag(session, ann.FormAnnotationID, 999_999, None, actor)
+
+
+def test_tag_wrong_type_raises_bad_request(session):
+    """tag with a non-FormAnnotation tag raises BadRequestError (-> 400)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t3")
+    tag = _make_tag(session, actor.id, tag_type=TagType.ImageInstance)
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().tag(session, ann.FormAnnotationID, tag.TagID, None, actor)
+
+
+def test_tag_existing_updates_comment(session):
+    """A second tag with a comment updates the existing link, not duplicates."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t4")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+
+    service.tag(session, ann.FormAnnotationID, tag.TagID, "first", actor)
+    link = service.tag(session, ann.FormAnnotationID, tag.TagID, "second", actor)
+
+    assert link.Comment == "second"
+
+
+def test_patch_tag_updates_comment(session):
+    """patch_tag overwrites the comment on an existing link."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t5")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag(session, ann.FormAnnotationID, tag.TagID, "old", actor)
+
+    link = service.patch_tag(session, ann.FormAnnotationID, tag.TagID, "new", actor)
+
+    assert link.Comment == "new"
+
+
+def test_patch_tag_unknown_link_raises_not_found(session):
+    """patch_tag with no existing link raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t6")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().patch_tag(session, ann.FormAnnotationID, tag.TagID, "x", actor)
+
+
+def test_untag_removes_link(session):
+    """untag deletes the link for that (annotation, tag)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t7")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag(session, ann.FormAnnotationID, tag.TagID, None, actor)
+
+    service.untag(session, ann.FormAnnotationID, tag.TagID, actor)
+
+    assert (
+        FormAnnotationRepository().get_tag_link(
+            session, tag.TagID, ann.FormAnnotationID
+        )
+        is None
+    )
+
+
+def test_untag_absent_link_is_idempotent(session):
+    """untag with no link present is a no-op (no error)."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "t8")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    # Does not raise even though no link exists.
+    _service().untag(session, ann.FormAnnotationID, tag.TagID, actor)

--- a/server/tests/test_form_annotation_service.py
+++ b/server/tests/test_form_annotation_service.py
@@ -1,0 +1,149 @@
+import pytest
+
+from eyened_orm import (
+    Creator,
+    DeviceInstance,
+    DeviceModel,
+    FormAnnotation,
+    FormSchema,
+    ImageInstance,
+    Patient,
+    Project,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.form_annotation_repository import (
+    FormAnnotationRepository,
+)
+from eyened_orm.repositories.image_instance_repository import (
+    ImageInstanceRepository,
+)
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.exceptions import NotFoundError
+from server.services.form_annotation_service import FormAnnotationService
+
+
+def _service() -> FormAnnotationService:
+    return FormAnnotationService(
+        FormAnnotationRepository(),
+        ImageInstanceRepository(),
+        TagRepository(),
+    )
+
+
+def _make_patient_and_schema(session, key: str) -> tuple[int, int]:
+    """Create a Project/Patient + FormSchema; return (patient_id, schema_id)."""
+    project = Project(ProjectName=f"P-{key}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{key}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    schema = FormSchema(SchemaName=f"S-{key}")
+    session.add(schema)
+    session.flush()
+    return patient.PatientID, schema.FormSchemaID
+
+
+def _make_annotation(session, key: str, *, inactive: bool = False) -> FormAnnotation:
+    """Create a minimal active/inactive FormAnnotation; return the row."""
+    patient_id, schema_id = _make_patient_and_schema(session, key)
+    creator = Creator(CreatorName=f"c-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    ann = FormAnnotation(
+        FormSchemaID=schema_id,
+        PatientID=patient_id,
+        CreatorID=creator.CreatorID,
+        Inactive=inactive,
+        FormData={"answer": 1},
+    )
+    session.add(ann)
+    session.flush()
+    return ann
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal graph an ImageInstance FK-requires; return its id."""
+    project = Project(ProjectName=f"IP-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"IID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID)
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer="Mf", ManufacturerModelName="M")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{public_id}",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_list_annotations_excludes_inactive(session):
+    """list_annotations returns only active rows (no image_id filter)."""
+    keep = _make_annotation(session, "keep")
+    _make_annotation(session, "gone", inactive=True)
+    session.commit()
+
+    rows = _service().list_annotations(
+        session,
+        patient_id=None,
+        study_id=None,
+        image_id=None,
+        form_schema_id=None,
+        sub_task_id=None,
+    )
+
+    ids = {r.FormAnnotationID for r in rows}
+    assert keep.FormAnnotationID in ids
+    assert all(not r.Inactive for r in rows)
+
+
+def test_list_annotations_unknown_image_id_raises_not_found(session):
+    """An image_id filter that resolves to nothing raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().list_annotations(
+            session,
+            patient_id=None,
+            study_id=None,
+            image_id="no-such-image",
+            form_schema_id=None,
+            sub_task_id=None,
+        )
+
+
+def test_get_annotation_unknown_raises_not_found(session):
+    """Getting a missing annotation is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_annotation(session, 999_999)
+
+
+def test_get_value_returns_form_data(session):
+    """get_value returns the annotation's FormData payload."""
+    ann = _make_annotation(session, "val")
+    session.commit()
+
+    assert _service().get_value(session, ann.FormAnnotationID) == {"answer": 1}
+
+
+def test_get_value_unknown_raises_not_found(session):
+    """get_value on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_value(session, 999_999)

--- a/server/tests/test_form_annotation_service.py
+++ b/server/tests/test_form_annotation_service.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import date
 
 from eyened_orm import (
     Creator,
@@ -21,6 +22,7 @@ from eyened_orm.repositories.image_instance_repository import (
 )
 from eyened_orm.repositories.tag_repository import TagRepository
 
+from server.services.acting_user import ActingUser
 from server.services.exceptions import NotFoundError
 from server.services.form_annotation_service import FormAnnotationService
 
@@ -73,7 +75,7 @@ def _make_image(session, public_id: str) -> int:
     patient = Patient(PatientIdentifier=f"IID-{public_id}", ProjectID=project.ProjectID)
     session.add(patient)
     session.flush()
-    study = Study(PatientID=patient.PatientID)
+    study = Study(PatientID=patient.PatientID, StudyDate=date.today())
     session.add(study)
     session.flush()
     series = Series(StudyID=study.StudyID)
@@ -147,3 +149,107 @@ def test_get_value_unknown_raises_not_found(session):
     """get_value on a missing annotation raises NotFoundError (-> 404)."""
     with pytest.raises(NotFoundError):
         _service().get_value(session, 999_999)
+
+
+def _actor(session, key: str = "actor") -> ActingUser:
+    creator = Creator(CreatorName=f"u-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def test_create_resolves_image_and_persists(session):
+    """create resolves image_id and persists the row."""
+    actor = _actor(session)
+    patient_id, schema_id = _make_patient_and_schema(session, "c1")
+    image_id = _make_image(session, "img-1")
+    session.commit()
+
+    ann = _service().create(
+        session,
+        form_schema_id=schema_id,
+        patient_id=patient_id,
+        study_id=None,
+        image_id="img-1",
+        laterality=None,
+        sub_task_id=None,
+        form_data={"a": 1},
+        form_annotation_reference_id=None,
+        actor=actor,
+    )
+
+    assert ann.FormAnnotationID is not None
+    assert ann.ImageInstanceID == image_id
+
+
+def test_create_unknown_image_raises_not_found(session):
+    """create with an unresolvable image_id raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    patient_id, schema_id = _make_patient_and_schema(session, "c2")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().create(
+            session,
+            form_schema_id=schema_id,
+            patient_id=patient_id,
+            study_id=None,
+            image_id="no-image",
+            laterality=None,
+            sub_task_id=None,
+            form_data=None,
+            form_annotation_reference_id=None,
+            actor=actor,
+        )
+
+
+def test_update_applies_field(session):
+    """update applies a provided field to the annotation."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "u1")
+    session.commit()
+
+    updated = _service().update(
+        session, ann.FormAnnotationID, {"form_data": {"b": 2}}, actor
+    )
+
+    assert updated.FormData == {"b": 2}
+
+
+def test_update_unknown_raises_not_found(session):
+    """update on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().update(session, 999_999, {"form_data": {}}, _actor(session))
+
+
+def test_soft_delete_sets_inactive(session):
+    """soft_delete flags the row Inactive."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "d1")
+    session.commit()
+
+    _service().soft_delete(session, ann.FormAnnotationID, actor)
+
+    assert ann.Inactive is True
+
+
+def test_soft_delete_unknown_raises_not_found(session):
+    """soft_delete on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().soft_delete(session, 999_999, _actor(session))
+
+
+def test_set_value_overwrites_form_data(session):
+    """set_value overwrites the annotation's FormData payload."""
+    actor = _actor(session)
+    ann = _make_annotation(session, "v1")
+    session.commit()
+
+    _service().set_value(session, ann.FormAnnotationID, {"new": 9}, actor)
+
+    assert ann.FormData == {"new": 9}
+
+
+def test_set_value_unknown_raises_not_found(session):
+    """set_value on a missing annotation raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().set_value(session, 999_999, {}, _actor(session))

--- a/server/tests/test_image_instance_service.py
+++ b/server/tests/test_image_instance_service.py
@@ -1,0 +1,109 @@
+import datetime
+
+import pytest
+
+from eyened_orm import (
+    DeviceInstance,
+    DeviceModel,
+    ImageInstance,
+    Patient,
+    Project,
+    Series,
+    Study,
+)
+from eyened_orm.project import ExternalEnum
+from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.exceptions import NotFoundError
+from server.services.image_instance_service import ImageInstanceService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal graph an ImageInstance FK-requires; return its id."""
+    project = Project(ProjectName=f"P-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer=f"Mf-{public_id}", ManufacturerModelName=f"M-{public_id}")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description="d")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier=f"ds-{public_id}",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def _service(logger=None) -> ImageInstanceService:
+    return ImageInstanceService(
+        ImageInstanceRepository(), TagRepository(), logger=logger
+    )
+
+
+_READ_KW = dict(
+    with_segmentations=False,
+    with_form_annotations=False,
+    with_model_segmentations=False,
+)
+
+
+def test_get_instance_returns_it(session):
+    """get_instance returns the instance at the given id."""
+    image_id = _make_image(session, "pub-1")
+    session.commit()
+
+    got = _service().get_instance(session, image_id, **_READ_KW)
+
+    assert got.ImageInstanceID == image_id
+
+
+def test_get_instance_unknown_raises_not_found(session):
+    """Getting a missing instance is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_instance(session, 999_999, **_READ_KW)
+
+
+def test_get_by_public_id_unknown_raises_not_found(session):
+    """Resolving a missing PublicID is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_by_public_id(session, "nope", **_READ_KW)
+
+
+def test_get_for_storage_unknown_raises_not_found(session):
+    """get_for_storage on a missing PublicID raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_for_storage(session, "missing")

--- a/server/tests/test_image_instance_service.py
+++ b/server/tests/test_image_instance_service.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from eyened_orm import (
+    Creator,
     DeviceInstance,
     DeviceModel,
     ImageInstance,
@@ -10,12 +11,15 @@ from eyened_orm import (
     Project,
     Series,
     Study,
+    Tag,
 )
 from eyened_orm.project import ExternalEnum
 from eyened_orm.repositories.image_instance_repository import ImageInstanceRepository
 from eyened_orm.repositories.tag_repository import TagRepository
+from eyened_orm.tag import TagType
 
-from server.services.exceptions import NotFoundError
+from server.services.acting_user import ActingUser
+from server.services.exceptions import BadRequestError, NotFoundError
 from server.services.image_instance_service import ImageInstanceService
 
 
@@ -81,6 +85,25 @@ _READ_KW = dict(
 )
 
 
+def _actor(session) -> ActingUser:
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _make_tag(session, creator_id: int, tag_type: TagType = TagType.ImageInstance) -> Tag:
+    tag = Tag(
+        TagName=f"t-{tag_type.name}",
+        TagDescription="d",
+        TagType=tag_type,
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
 def test_get_instance_returns_it(session):
     """get_instance returns the instance at the given id."""
     image_id = _make_image(session, "pub-1")
@@ -107,3 +130,122 @@ def test_get_for_storage_unknown_raises_not_found(session):
     """get_for_storage on a missing PublicID raises NotFoundError (-> 404)."""
     with pytest.raises(NotFoundError):
         _service().get_for_storage(session, "missing")
+
+
+def test_tag_instance_creates_link(session):
+    """tag_instance links a tag to an instance and returns the link."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    link = _service().tag_instance(session, "pub-1", tag.TagID, "hi", actor)
+
+    assert link.TagID == tag.TagID
+    assert link.Comment == "hi"
+    assert link.Tag.TagID == tag.TagID
+
+
+def test_tag_instance_unknown_instance_raises_not_found(session):
+    """tag_instance on a missing instance is translated to NotFoundError."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag_instance(session, "nope", tag.TagID, None, actor)
+
+
+def test_tag_instance_unknown_tag_raises_not_found(session):
+    """tag_instance with an unknown tag id is translated to NotFoundError."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag_instance(session, "pub-1", 999_999, None, actor)
+
+
+def test_tag_instance_wrong_tag_type_raises_bad_request(session):
+    """tag_instance with a non-ImageInstance tag raises BadRequestError (-> 400)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id, tag_type=TagType.Segmentation)
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().tag_instance(session, "pub-1", tag.TagID, None, actor)
+
+
+def test_tag_instance_existing_updates_comment(session):
+    """A second tag_instance with a comment updates the existing link, not duplicates."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+
+    service.tag_instance(session, "pub-1", tag.TagID, "first", actor)
+    link = service.tag_instance(session, "pub-1", tag.TagID, "second", actor)
+
+    assert link.Comment == "second"
+
+
+def test_tag_instance_logs_insert(session):
+    """tag_instance emits one insert audit record for ImageInstanceTagLink."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).tag_instance(session, "pub-1", tag.TagID, None, actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "ImageInstanceTagLink"
+
+
+def test_patch_instance_tag_updates_comment(session):
+    """patch_instance_tag overwrites the comment on an existing link."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag_instance(session, "pub-1", tag.TagID, "old", actor)
+
+    link = service.patch_instance_tag(session, "pub-1", tag.TagID, "new", actor)
+
+    assert link.Comment == "new"
+
+
+def test_patch_instance_tag_unknown_link_raises_not_found(session):
+    """patch_instance_tag with no existing link raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().patch_instance_tag(session, "pub-1", tag.TagID, "x", actor)
+
+
+def test_untag_instance_removes_link(session):
+    """untag_instance deletes the link for that (instance, tag)."""
+    actor = _actor(session)
+    image_id = _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag_instance(session, "pub-1", tag.TagID, None, actor)
+
+    service.untag_instance(session, "pub-1", tag.TagID, actor)
+
+    assert ImageInstanceRepository().get_tag_link(session, tag.TagID, image_id) is None
+
+
+def test_untag_instance_absent_link_is_idempotent(session):
+    """untag_instance with no link present is a no-op (no error)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    # Does not raise even though no link exists.
+    _service().untag_instance(session, "pub-1", tag.TagID, actor)

--- a/server/tests/test_image_instance_service.py
+++ b/server/tests/test_image_instance_service.py
@@ -249,3 +249,30 @@ def test_untag_instance_absent_link_is_idempotent(session):
 
     # Does not raise even though no link exists.
     _service().untag_instance(session, "pub-1", tag.TagID, actor)
+
+
+def test_tag_instance_update_logs_raw_string_public_id(session):
+    """Tag update audit logs use raw-string public_id, not int ImageInstanceID."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    logger = FakeAuditLogger()
+    service = _service(logger)
+
+    service.tag_instance(session, "pub-1", tag.TagID, "first", actor)
+    service.tag_instance(session, "pub-1", tag.TagID, "second", actor)
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "ImageInstanceTagLink"
+    assert logger.updates[0]["fields"]["image_instance_id"] == "pub-1"
+
+
+def test_patch_instance_tag_wrong_tag_type_raises_bad_request(session):
+    """patch_instance_tag with a non-ImageInstance tag raises BadRequestError (-> 400)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    tag = _make_tag(session, actor.id, tag_type=TagType.Segmentation)
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().patch_instance_tag(session, "pub-1", tag.TagID, "x", actor)

--- a/server/tests/test_segmentation_service.py
+++ b/server/tests/test_segmentation_service.py
@@ -102,3 +102,197 @@ def test_model_read_data_unknown_raises_not_found(session):
     """ModelSegmentationService.read_data on a missing id raises NotFoundError."""
     with pytest.raises(NotFoundError):
         _model_service().read_data(session, 999_999)
+
+
+from eyened_orm.segmentation import DataRepresentation, Datatype
+
+
+def _image_public_id(session, key: str) -> str:
+    """Create a standalone segmentation and return its image's PublicID."""
+    seg = _make_segmentation(session, key)
+    return seg.ImageInstance.PublicID
+
+
+def test_create_persists_and_writes(session):
+    """create builds the row, writes via the store, and persists it."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "c0")
+    image_id = seg.ImageInstance.PublicID
+    session.commit()
+    store = FakeSegmentationDataStore()
+
+    created = _service(store).create(
+        session,
+        image_id=image_id,
+        feature_id=seg.FeatureID,
+        subtask_id=None,
+        data_type=Datatype.R8UI,
+        data_representation=DataRepresentation.Binary,
+        depth=1,
+        height=4,
+        width=4,
+        sparse_axis=None,
+        image_projection_matrix=None,
+        scan_indices=None,
+        threshold=None,
+        reference_segmentation_id=None,
+        array=np.zeros((1, 4, 4), dtype=np.uint8),
+        actor=actor,
+    )
+
+    assert created.SegmentationID is not None
+    assert created.ZarrArrayIndex == 0  # fake store assigned it
+
+
+def test_create_empty_array_fills_zeros(session):
+    """create with array=None fills a zeros volume from the image shape."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "c1")
+    image_id = seg.ImageInstance.PublicID
+    session.commit()
+
+    created = _service().create(
+        session,
+        image_id=image_id,
+        feature_id=seg.FeatureID,
+        subtask_id=None,
+        data_type=Datatype.R8UI,
+        data_representation=DataRepresentation.Binary,
+        depth=1,
+        height=4,
+        width=4,
+        sparse_axis=None,
+        image_projection_matrix=None,
+        scan_indices=None,
+        threshold=None,
+        reference_segmentation_id=None,
+        array=None,
+        actor=actor,
+    )
+
+    assert created.shape == (1, 4, 4)
+
+
+def test_create_unknown_image_raises_not_found(session):
+    """create with an unresolvable image_id raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "c2")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().create(
+            session,
+            image_id="no-such-image",
+            feature_id=seg.FeatureID,
+            subtask_id=None,
+            data_type=Datatype.R8UI,
+            data_representation=DataRepresentation.Binary,
+            depth=1,
+            height=4,
+            width=4,
+            sparse_axis=None,
+            image_projection_matrix=None,
+            scan_indices=None,
+            threshold=None,
+            reference_segmentation_id=None,
+            array=None,
+            actor=actor,
+        )
+
+
+def test_create_shape_mismatch_raises_bad_request(session):
+    """create with an array whose shape != the segmentation raises BadRequest."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "c3")
+    image_id = seg.ImageInstance.PublicID
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().create(
+            session,
+            image_id=image_id,
+            feature_id=seg.FeatureID,
+            subtask_id=None,
+            data_type=Datatype.R8UI,
+            data_representation=DataRepresentation.Binary,
+            depth=1,
+            height=4,
+            width=4,
+            sparse_axis=None,
+            image_projection_matrix=None,
+            scan_indices=None,
+            threshold=None,
+            reference_segmentation_id=None,
+            array=np.zeros((2, 4, 4), dtype=np.uint8),  # depth 2 != 1
+            actor=actor,
+        )
+
+
+def test_write_data_unknown_raises_not_found(session):
+    """write_data on a missing id raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().write_data(
+            session, 999_999, np.zeros((1, 4, 4), dtype=np.uint8), actor=_actor(session)
+        )
+
+
+def test_write_data_persists_zarr_index(session):
+    """write_data stores via the port and persists the ZarrArrayIndex."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "w1")
+    session.commit()
+    store = FakeSegmentationDataStore()
+
+    updated = _service(store).write_data(
+        session, seg.SegmentationID, np.zeros((1, 4, 4), dtype=np.uint8), actor=actor
+    )
+
+    assert updated.ZarrArrayIndex == 0
+
+
+def test_soft_delete_sets_inactive(session):
+    """soft_delete flags the row Inactive."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "d1")
+    session.commit()
+
+    _service().soft_delete(session, seg.SegmentationID, actor)
+
+    assert seg.Inactive is True
+
+
+def test_soft_delete_unknown_raises_not_found(session):
+    """soft_delete on a missing id raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().soft_delete(session, 999_999, _actor(session))
+
+
+def test_patch_applies_threshold_and_feature(session):
+    """patch updates threshold and feature_id on the row."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "p1")
+    other = _make_segmentation(session, "p1-feat")
+    session.commit()
+
+    updated = _service().patch(
+        session,
+        seg.SegmentationID,
+        reference_segmentation_id=None,
+        feature_id=other.FeatureID,
+        threshold=0.5,
+        actor=actor,
+    )
+
+    assert updated.Threshold == 0.5
+    assert updated.FeatureID == other.FeatureID
+
+
+def test_patch_unknown_raises_not_found(session):
+    """patch on a missing id raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().patch(
+            session,
+            999_999,
+            reference_segmentation_id=None,
+            feature_id=None,
+            threshold=1.0,
+            actor=_actor(session),
+        )

--- a/server/tests/test_segmentation_service.py
+++ b/server/tests/test_segmentation_service.py
@@ -296,3 +296,106 @@ def test_patch_unknown_raises_not_found(session):
             threshold=1.0,
             actor=_actor(session),
         )
+
+
+from eyened_orm import Tag
+from eyened_orm.tag import TagType
+
+
+def _make_tag(
+    session, creator_id: int, tag_type: TagType = TagType.Segmentation
+) -> Tag:
+    tag = Tag(
+        TagName=f"t-{tag_type.name}-{creator_id}",
+        TagDescription="d",
+        TagType=tag_type,
+        CreatorID=creator_id,
+    )
+    session.add(tag)
+    session.flush()
+    return tag
+
+
+def test_tag_creates_link(session):
+    """tag links a Segmentation-type tag and returns the link."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "t1")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    link = _service().tag(session, seg.SegmentationID, tag.TagID, actor)
+
+    assert link.TagID == tag.TagID
+    assert link.SegmentationID == seg.SegmentationID
+    assert link.Tag.TagID == tag.TagID
+
+
+def test_tag_unknown_segmentation_raises_not_found(session):
+    """tag on a missing segmentation raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag(session, 999_999, tag.TagID, actor)
+
+
+def test_tag_unknown_tag_raises_not_found(session):
+    """tag with an unknown tag id raises NotFoundError (-> 404)."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "t2")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().tag(session, seg.SegmentationID, 999_999, actor)
+
+
+def test_tag_wrong_type_raises_bad_request(session):
+    """tag with a non-Segmentation tag raises BadRequestError (-> 400)."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "t3")
+    tag = _make_tag(session, actor.id, tag_type=TagType.ImageInstance)
+    session.commit()
+    with pytest.raises(BadRequestError):
+        _service().tag(session, seg.SegmentationID, tag.TagID, actor)
+
+
+def test_tag_is_idempotent(session):
+    """A second tag with the same (seg, tag) returns the existing link, no dup."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "t4")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+
+    service.tag(session, seg.SegmentationID, tag.TagID, actor)
+    link = service.tag(session, seg.SegmentationID, tag.TagID, actor)
+
+    assert link.TagID == tag.TagID
+
+
+def test_untag_removes_link(session):
+    """untag deletes the link for that (segmentation, tag)."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "t5")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+    service = _service()
+    service.tag(session, seg.SegmentationID, tag.TagID, actor)
+
+    service.untag(session, seg.SegmentationID, tag.TagID, actor)
+
+    assert (
+        SegmentationRepository().get_tag_link(
+            session, tag.TagID, seg.SegmentationID
+        )
+        is None
+    )
+
+
+def test_untag_absent_link_is_idempotent(session):
+    """untag with no link present is a no-op (no error)."""
+    actor = _actor(session)
+    seg = _make_segmentation(session, "t6")
+    tag = _make_tag(session, actor.id)
+    session.commit()
+
+    _service().untag(session, seg.SegmentationID, tag.TagID, actor)

--- a/server/tests/test_segmentation_service.py
+++ b/server/tests/test_segmentation_service.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+
+from eyened_orm.repositories.image_instance_repository import (
+    ImageInstanceRepository,
+)
+from eyened_orm.repositories.segmentation_repository import (
+    ModelSegmentationRepository,
+    SegmentationRepository,
+)
+from eyened_orm.repositories.tag_repository import TagRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import BadRequestError, NotFoundError
+from server.services.segmentation_service import (
+    ModelSegmentationService,
+    SegmentationService,
+)
+
+from eyened_orm.tests.test_segmentation_repository import _make_segmentation
+
+
+class FakeSegmentationDataStore:
+    """In-memory stand-in for the zarr store (hand-rolled, per the codebase's
+    FakeClient/FakeResponse pattern). Records writes; mimics the real store's
+    None-on-empty read and ZarrArrayIndex assignment."""
+
+    def __init__(self) -> None:
+        self.data: dict[int, np.ndarray] = {}
+        self._next_index = 0
+
+    def write(self, segmentation, data, *, axis=None, slice_index=None) -> int:
+        index = self._next_index
+        self._next_index += 1
+        segmentation.ZarrArrayIndex = index
+        self.data[id(segmentation)] = data
+        return index
+
+    def read(self, segmentation, *, axis=None, slice_index=None):
+        if segmentation.ZarrArrayIndex is None:
+            return None
+        return self.data.get(id(segmentation))
+
+
+def _service(store: FakeSegmentationDataStore | None = None) -> SegmentationService:
+    return SegmentationService(
+        SegmentationRepository(),
+        ImageInstanceRepository(),
+        TagRepository(),
+        store or FakeSegmentationDataStore(),
+    )
+
+
+def _model_service(
+    store: FakeSegmentationDataStore | None = None,
+) -> ModelSegmentationService:
+    return ModelSegmentationService(
+        ModelSegmentationRepository(), store or FakeSegmentationDataStore()
+    )
+
+
+def _actor(session, key: str = "actor") -> ActingUser:
+    from eyened_orm import Creator
+
+    creator = Creator(CreatorName=f"u-{key}", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def test_get_segmentation_returns_row(session):
+    """get_segmentation returns the row (tag links loaded)."""
+    seg = _make_segmentation(session, "g1")
+    session.commit()
+
+    got = _service().get_segmentation(session, seg.SegmentationID)
+
+    assert got.SegmentationID == seg.SegmentationID
+
+
+def test_get_segmentation_unknown_raises_not_found(session):
+    """get_segmentation on a missing id raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_segmentation(session, 999_999)
+
+
+def test_read_data_unknown_raises_not_found(session):
+    """read_data on a missing id raises NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().read_data(session, 999_999)
+
+
+def test_read_data_empty_returns_none(session):
+    """read_data on a row with no stored array returns None (no storage hit)."""
+    seg = _make_segmentation(session, "r1")  # ZarrArrayIndex is None
+    session.commit()
+
+    assert _service().read_data(session, seg.SegmentationID) is None
+
+
+def test_model_read_data_unknown_raises_not_found(session):
+    """ModelSegmentationService.read_data on a missing id raises NotFoundError."""
+    with pytest.raises(NotFoundError):
+        _model_service().read_data(session, 999_999)

--- a/server/tests/test_subtask_service.py
+++ b/server/tests/test_subtask_service.py
@@ -1,0 +1,156 @@
+import pytest
+
+from eyened_orm import Creator, SubTask, Task, TaskDefinition
+from eyened_orm.task import SubTaskState, TaskState
+from eyened_orm.repositories.task_repository import SubTaskRepository
+
+from server.services.acting_user import ActingUser
+from server.services.exceptions import NotFoundError
+from server.services.task_service import SubTaskService
+
+
+class FakeAuditLogger:
+    """Records logging calls without touching the filesystem (no mock lib)."""
+
+    def __init__(self) -> None:
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def log_insert(self, **kwargs) -> None:
+        self.inserts.append(kwargs)
+
+    def log_update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    def log_delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
+
+
+def _actor(session) -> ActingUser:
+    creator = Creator(CreatorName="alice", IsHuman=True)
+    session.add(creator)
+    session.flush()
+    return ActingUser(id=creator.CreatorID, username=creator.CreatorName)
+
+
+def _task_def(session, name: str = "td") -> TaskDefinition:
+    td = TaskDefinition(TaskDefinitionName=name)
+    session.add(td)
+    session.flush()
+    return td
+
+
+def _make_task(session, td_id: int, creator_id: int, name: str = "T") -> Task:
+    task = Task(
+        TaskName=name,
+        TaskDefinitionID=td_id,
+        CreatorID=creator_id,
+        TaskState=TaskState.NotStarted,
+    )
+    session.add(task)
+    session.flush()
+    return task
+
+
+def _make_subtask(session, task_id: int, state: SubTaskState = SubTaskState.NotStarted) -> SubTask:
+    st = SubTask(TaskID=task_id, TaskState=state, Comments="orig")
+    session.add(st)
+    session.flush()
+    return st
+
+
+def _service(logger=None) -> SubTaskService:
+    return SubTaskService(SubTaskRepository(), logger=logger)
+
+
+def test_get_subtask_returns_it(session):
+    """get_subtask returns the subtask at the given id."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+
+    got = _service().get_subtask(session, st.SubTaskID, with_images=False)
+
+    assert got.SubTaskID == st.SubTaskID
+
+
+def test_get_subtask_unknown_raises_not_found(session):
+    """Getting a missing subtask is translated to NotFoundError (-> 404)."""
+    with pytest.raises(NotFoundError):
+        _service().get_subtask(session, 999_999, with_images=False)
+
+
+def test_update_subtask_changes_fields(session):
+    """update_subtask overwrites the provided comments and task_state."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+
+    updated = _service().update_subtask(
+        session, st.SubTaskID, "newcomment", SubTaskState.Ready, actor
+    )
+
+    assert updated.Comments == "newcomment"
+    assert updated.TaskState == SubTaskState.Ready
+
+
+def test_update_subtask_unknown_raises_not_found(session):
+    """Updating a missing subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().update_subtask(session, 999_999, "x", None, actor)
+
+
+def test_update_subtask_logs_update(session):
+    """update_subtask emits one update audit record for the SubTask entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).update_subtask(session, st.SubTaskID, "c", None, actor)
+
+    assert len(logger.updates) == 1
+    assert logger.updates[0]["entity"] == "SubTask"
+
+
+def test_delete_subtask_removes_it(session):
+    """delete_subtask removes the subtask row."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+
+    _service().delete_subtask(session, st.SubTaskID, actor)
+
+    assert SubTaskRepository().get_by_id(session, st.SubTaskID) is None
+
+
+def test_delete_subtask_unknown_raises_not_found(session):
+    """Deleting a missing subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    with pytest.raises(NotFoundError):
+        _service().delete_subtask(session, 999_999, actor)
+
+
+def test_delete_subtask_logs_delete(session):
+    """delete_subtask emits one delete audit record for the SubTask entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).delete_subtask(session, st.SubTaskID, actor)
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "SubTask"

--- a/server/tests/test_subtask_service.py
+++ b/server/tests/test_subtask_service.py
@@ -154,3 +154,176 @@ def test_delete_subtask_logs_delete(session):
 
     assert len(logger.deletes) == 1
     assert logger.deletes[0]["entity"] == "SubTask"
+
+
+def _make_image(session, public_id: str) -> int:
+    """Build the minimal Series/Device graph an ImageInstance FK-requires.
+
+    Returns the new ImageInstanceID (mirrors the helper in test_task_repository.py).
+    """
+    import datetime
+
+    from eyened_orm import (
+        DeviceInstance,
+        DeviceModel,
+        ImageInstance,
+        Patient,
+        Project,
+        Series,
+        Study,
+    )
+    from eyened_orm.project import ExternalEnum
+
+    project = Project(ProjectName=f"P-{public_id}", External=ExternalEnum.N)
+    session.add(project)
+    session.flush()
+    patient = Patient(PatientIdentifier=f"ID-{public_id}", ProjectID=project.ProjectID)
+    session.add(patient)
+    session.flush()
+    study = Study(PatientID=patient.PatientID, StudyDate=datetime.date(2020, 1, 1))
+    session.add(study)
+    session.flush()
+    series = Series(StudyID=study.StudyID)
+    session.add(series)
+    session.flush()
+    model = DeviceModel(Manufacturer=f"Mf-{public_id}", ManufacturerModelName=f"M-{public_id}")
+    session.add(model)
+    session.flush()
+    device = DeviceInstance(DeviceModelID=model.DeviceModelID, Description=f"d-{public_id}")
+    session.add(device)
+    session.flush()
+    image = ImageInstance(
+        PublicID=public_id,
+        SeriesID=series.SeriesID,
+        DeviceInstanceID=device.DeviceInstanceID,
+        DatasetIdentifier="ds",
+    )
+    session.add(image)
+    session.flush()
+    return image.ImageInstanceID
+
+
+def test_add_image_appends_link_at_next_index(session):
+    """add_image links the image to the subtask at the next ImageIndex."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+
+    updated = _service().add_image(session, st.SubTaskID, "pub-1", actor)
+
+    assert [link.ImageInstance.PublicID for link in updated.SubTaskImageLinks] == ["pub-1"]
+    assert [link.ImageIndex for link in updated.SubTaskImageLinks] == [0]
+
+
+def test_add_image_second_image_gets_next_index(session):
+    """A second add_image lands at ImageIndex 1, keeping insertion order."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    _make_image(session, "pub-2")
+    session.commit()
+    service = _service()
+
+    service.add_image(session, st.SubTaskID, "pub-1", actor)
+    updated = service.add_image(session, st.SubTaskID, "pub-2", actor)
+
+    assert [link.ImageIndex for link in updated.SubTaskImageLinks] == [0, 1]
+
+
+def test_add_image_unknown_subtask_raises_not_found(session):
+    """add_image on a missing subtask is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    _make_image(session, "pub-1")
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().add_image(session, 999_999, "pub-1", actor)
+
+
+def test_add_image_unknown_image_raises_not_found(session):
+    """add_image with an unknown PublicID is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().add_image(session, st.SubTaskID, "nope", actor)
+
+
+def test_add_image_logs_insert(session):
+    """add_image emits one insert audit record for the SubTaskImageLink entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+    logger = FakeAuditLogger()
+
+    _service(logger).add_image(session, st.SubTaskID, "pub-1", actor)
+
+    assert len(logger.inserts) == 1
+    assert logger.inserts[0]["entity"] == "SubTaskImageLink"
+
+
+def test_remove_image_deletes_the_link(session):
+    """remove_image deletes the link for that image, leaving the subtask empty."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+    service = _service()
+    service.add_image(session, st.SubTaskID, "pub-1", actor)
+
+    updated = service.remove_image(session, st.SubTaskID, "pub-1", actor)
+
+    assert updated.SubTaskImageLinks == []
+
+
+def test_remove_image_unknown_image_raises_not_found(session):
+    """remove_image with an unknown PublicID is translated to NotFoundError (-> 404)."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().remove_image(session, st.SubTaskID, "nope", actor)
+
+
+def test_remove_image_unlinked_image_raises_not_found(session):
+    """remove_image for an image not linked to the subtask raises NotFoundError."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")  # exists, but never linked
+    session.commit()
+    with pytest.raises(NotFoundError):
+        _service().remove_image(session, st.SubTaskID, "pub-1", actor)
+
+
+def test_remove_image_logs_delete(session):
+    """remove_image emits one delete audit record for the SubTaskImageLink entity."""
+    actor = _actor(session)
+    td = _task_def(session)
+    task = _make_task(session, td.TaskDefinitionID, actor.id)
+    st = _make_subtask(session, task.TaskID)
+    _make_image(session, "pub-1")
+    session.commit()
+    service = _service()
+    service.add_image(session, st.SubTaskID, "pub-1", actor)
+    logger = FakeAuditLogger()
+    SubTaskService(SubTaskRepository(), logger=logger).remove_image(
+        session, st.SubTaskID, "pub-1", actor
+    )
+
+    assert len(logger.deletes) == 1
+    assert logger.deletes[0]["entity"] == "SubTaskImageLink"


### PR DESCRIPTION
- New repository layer (framework-agnostic reads, Session args, returns domain objects or None, no HTTP concerns): SubTaskRepository, ImageInstanceRepository (+ tag-link lookups & PublicID resolver), FormAnnotationRepository, and Segmentation/ModelSegmentation repositories.
- New service layer (owns transaction boundaries, injected audit logging, raises domain exceptions like NotFoundError):
  - SubTaskService — subtask CRUD + image-link add/remove
  - ImageInstanceService — instance reads + tag add/patch/remove
  - FormAnnotationService — reads (list/get/value), CRUD, value mutations, tag add/patch/remove
  - SegmentationService — reads + data read/write/create/delete/patch via an injected SegmentationDataStore storage port, plus tag/untag
- Routes refactored to thin handlers that parse DTOs, map CurrentUser → ActingUser, delegate to services, and convert results via DTOConverter: subtask, instance, form-annotation, and segmentation endpoints.
- Storage port abstraction: zarr I/O for segmentations is now behind an injected SegmentationDataStore Protocol, making it testable and swappable.