### PR TITLE
135 handle exception

### DIFF
--- a/orm/eyened_orm/utils/registration.py
+++ b/orm/eyened_orm/utils/registration.py
@@ -197,18 +197,24 @@ def run_registration(image_set, graph, new_transforms):
     ref_key = registration_image_key(reference)
 
     registrator = Registration()
-    registrator.set_reference(get_pixel_array(reference))
+
+    try:
+        registrator.set_reference(get_pixel_array(reference))
+    except Exception as err:
+        print(f"Error setting reference for {ref_key}: {err}")
+        return None, None
 
     for i in image_set:
         i_key = registration_image_key(i)
         if are_connected(ref_key, i_key, graph):
             continue
 
-        registrator.set_target(get_pixel_array(i))
+        print(
+            f"Running registration for {ref_key} -> {i_key} "
+        )
         try:
-            print(
-                f"Running registration for {ref_key} -> {i_key} "
-            )
+            registrator.set_target(get_pixel_array(i))
+
             transform = registrator.run()
             graph[ref_key].add(i_key)
             graph[i_key].add(ref_key)
@@ -221,7 +227,7 @@ def run_registration(image_set, graph, new_transforms):
             )
         except Exception as e:
             print(
-                f"Error running registration for {ref_key}, {i_key}: {e}"
+                f"Error running registration for {ref_key} -> {i_key}: {e}"
             )
 
     return registrator, reference

--- a/orm/setup.py
+++ b/orm/setup.py
@@ -37,7 +37,7 @@ setup(
         "pydantic-settings==2.7.1",
         "python-dotenv==1.*",
         "retinalysis-fundusprep>=0.5.4",
-        "retinalysis-registration>=0.1.6",
+        "retinalysis-registration>=1.0.0",
         "pyyaml==6.*",
         "google_crc32c==1.8.0",
         "simpleitk==2.*",


### PR DESCRIPTION
Fixes #135 eorm run-registration no longer aborts on a single bad image. Loading wrapped in exception handling so failures are logged per image pair and processing continues. Bumps retinalysis-registration to >=1.0.0.

A new registration model should be added to the database automatically (version 1.0.0). Existing registrations from older version should be picked up automatically, so rerunning will only add missing links in the registration graph.

Test plan:

- [ ] Reinstall ORM / rebuild server container so retinalysis-registration>=1.0.0 is picked up
- [ ] Run registration on previously failed cases