### PR TITLE
ci: run backend tests in GitHub Actions (#118)

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -1,10 +1,19 @@
 name: Client CI
 on:
+  push:
+    branches: [main, development]
+    paths:
+      - 'client/**'
+      - '.github/workflows/client-ci.yml'
   pull_request:
     branches: [main, development]
     paths:
       - 'client/**'
       - '.github/workflows/client-ci.yml'
+
+concurrency:
+  group: client-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,0 +1,35 @@
+name: Server CI
+on:
+  push:
+    branches: [development, main]
+    paths:
+      - 'server/**'
+      - 'orm/**'
+      - 'pyproject.toml'
+      - '.github/workflows/server-ci.yml'
+  pull_request:
+    branches: [development, main]
+    paths:
+      - 'server/**'
+      - 'orm/**'
+      - 'pyproject.toml'
+      - '.github/workflows/server-ci.yml'
+
+concurrency:
+  group: server-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -e ./orm
+          pip install -r server/test-requirements.txt
+      - run: pytest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -22,12 +22,16 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
+          cache-dependency-path: |
+            server/requirements.txt
+            server/test-requirements.txt
       - run: |
           python -m pip install --upgrade pip
           pip install -e ./orm

--- a/docs/backlog/2026-07-16-backend-ruff-lint-followup.md
+++ b/docs/backlog/2026-07-16-backend-ruff-lint-followup.md
@@ -1,0 +1,47 @@
+# Follow-up: backend Python lint gate (ruff)
+
+- **Source:** Descoped from issue #118 (backend test CI) during design/planning,
+  2026-07-16. See [design spec](../superpowers/specs/2026-07-16-backend-ci-design.md).
+- **Related prior art:** PR #49 "WIP: Code linting checks" (unmerged ruff draft);
+  the frontend prettier sweep in `client-ci.yml` (its own dedicated effort, which
+  surfaced real bugs).
+
+#118 ships the **pytest** gate only. A ruff job was planned (Scope B) but a first run
+showed the cleanup is a sizeable, risky initiative that deserves its own focused PR
+rather than being bundled into the CI-wiring change.
+
+---
+
+## 1. Backend ruff lint + format gate
+
+**Status:** open
+
+**What:** Add a `lint-python` job to `.github/workflows/server-ci.yml` running
+`ruff check server orm` and `ruff format --check server orm` (read-only: no `--fix`),
+ruff version pinned, plus `[tool.ruff]` config in `pyproject.toml`. Bring the tree to
+a green baseline first, ratcheting rules up per-code.
+
+**Why:** Automated lint/format catches regressions and keeps the backend consistent,
+matching the frontend gate. Deferred because the baseline is large and mixing a
+mechanical sweep into #118 would bury the CI change and collide with in-flight
+branches (RBAC, search-refactor).
+
+**Measured baseline** (ruff 0.14.14, scope `server orm`, default E/F rules,
+on `development` @ 4a70c44):
+
+- `ruff check`: **125 errors** — 67 F401 unused-import, 17 F403 star-import,
+  11 F821 undefined-name, 10 F541 f-string, plus E711/E402/F841/E722/F811/E712/E721.
+  60 auto-fixable (`--fix`), 10 more with `--unsafe-fixes`.
+- `ruff format --check`: **121 files would be reformatted** (103 already clean).
+
+**How to approach (do NOT bulk `--fix`):**
+1. **Formatting PR (isolated, mechanical):** run `ruff format server orm` as one
+   commit once in-flight backend branches have merged; then add `ruff format --check`
+   to the job.
+2. **Lint PR(s), ratcheted:** start `[tool.ruff.lint] select` from the safe subset
+   (F541; F401 only after reviewing for intended re-exports), expanding `select`
+   per-code as each reaches zero.
+3. **Investigate, don't silence:** F403 star-imports and the 11 F821 undefined-names
+   may be **real latent bugs** — review individually.
+
+Job skeleton is captured in the design spec (§"Deferred: ruff job").

--- a/docs/backlog/2026-07-16-dependabot-vulnerabilities.md
+++ b/docs/backlog/2026-07-16-dependabot-vulnerabilities.md
@@ -1,0 +1,48 @@
+# Follow-up: Dependabot vulnerability alerts
+
+- **Source:** Surfaced on push during #118 CI work, 2026-07-16 — GitHub reported
+  **82 open Dependabot alerts** on the `development` (default) branch. Detail pulled
+  via `gh api /repos/Eyened/eyened-platform/dependabot/alerts`.
+
+**Status:** open
+
+**Pre-existing on `development`, unrelated to #118.** Severities are CVSS scores, not
+contextual — real exposure depends on whether each code path is reachable.
+
+## Breakdown (82 total: 28 high / 39 medium / 15 low; 75 npm / 7 pip)
+
+| Location | Count | What it is | Blast radius |
+|---|---:|---|---|
+| `docs/package-lock.json` | 51 | Astro docs-site toolchain | Lowest — static site generator |
+| `client/package-lock.json` | 24 | Frontend (Svelte/Vite) build deps | Mostly build-time |
+| `server/requirements.txt` | 7 | Backend runtime (FastAPI) | Highest — request path |
+
+## 1. Backend (pip) — all 7 are `python-multipart`  ← do this first
+
+Pinned at `python-multipart==0.0.20`; **all 7 fixed by ≤ 0.0.31**. FastAPI's form/
+multipart parser, reachable on any form or file-upload endpoint.
+
+- HIGH — Arbitrary File Write via non-default config (`<0.0.22`)
+- HIGH — DoS via unbounded multipart part headers (`<0.0.27`)
+- HIGH — DoS via quadratic querystring parsing with `;` separators (`<0.0.30`)
+- MEDIUM — DoS via large multipart preamble/epilogue (`<0.0.26`)
+- 3× LOW — parameter smuggling / negative Content-Length buffering (`<0.0.30`/`0.0.31`)
+
+**Fix:** `server/requirements.txt`: `python-multipart==0.0.20` → `>=0.0.31` (verify
+current latest). One line, patch-series bump, no API change — clears all 7 including 3 highs.
+
+## 2. Frontend + docs (npm) — 75, mostly tooling
+
+High-severity npm cluster in build/generator tooling, not shipped runtime:
+`vite` (4), `tar-fs` (4), `astro` (3), `devalue` (3), plus `rollup`, `@babel/*`,
+`picomatch`, `minimatch`, `h3`, `fast-uri`, `simple-git`, `defu`. Many transitive/dev-only.
+The 51 in the docs site are lowest concern.
+
+**Fix:** `npm audit fix` sweeps in `client/` and `docs/` as two separate PRs; escalate
+to manual major-version bumps only for what `--force` won't safely resolve.
+
+## Recommended sequencing
+
+1. `python-multipart` bump — its own small backend PR (highest value, lowest effort).
+2. `npm audit fix` for `client/`, then `docs/` — one PR each.
+3. Consider enabling Dependabot version-update PRs so this stops re-accumulating.

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -13,3 +13,4 @@ Keep entries short. When an item is picked up, link the PR/commit and mark it do
 ## Index
 
 - [PR #145 — RBAC Step 1 service layer](2026-07-16-pr145-rbac-step1-review.md)
+- [Backend Python lint gate (ruff) — follow-up to #118](2026-07-16-backend-ruff-lint-followup.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -14,3 +14,4 @@ Keep entries short. When an item is picked up, link the PR/commit and mark it do
 
 - [PR #145 — RBAC Step 1 service layer](2026-07-16-pr145-rbac-step1-review.md)
 - [Backend Python lint gate (ruff) — follow-up to #118](2026-07-16-backend-ruff-lint-followup.md)
+- [Dependabot vulnerability alerts](2026-07-16-dependabot-vulnerabilities.md)

--- a/docs/superpowers/plans/2026-07-16-backend-ci.md
+++ b/docs/superpowers/plans/2026-07-16-backend-ci.md
@@ -1,0 +1,249 @@
+# Backend CI (tests) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions gate that runs the backend pytest suite on push/PR into `development`/`main`, and align `client-ci.yml` to the same trigger + concurrency policy.
+
+**Architecture:** Native runner (Approach A) — `actions/setup-python` → `pip install -e ./orm` + `pip install -r server/test-requirements.txt` → `pytest`. No services/secrets (suite is in-memory SQLite). Two workflow files touched: a new `server-ci.yml` and an edit to the existing `client-ci.yml`.
+
+**Tech Stack:** GitHub Actions, Python 3.12, pytest 8.x, `actions/checkout@v7`, `actions/setup-python@v6`, `actionlint` (local validation).
+
+## Global Constraints
+
+- **Base branch:** `development`. Open the eventual PR into `development`.
+- **Python:** `3.12` (matches `dev/Dockerfile.server`). No matrix.
+- **Actions (current latest majors):** `actions/checkout@v7`, `actions/setup-python@v6`.
+- **Triggers:** `push` **and** `pull_request`, both scoped to `branches: [development, main]`, both path-filtered.
+- **Concurrency:** every workflow gets `concurrency: { group: <name>-${{ github.ref }}, cancel-in-progress: true }`.
+- **CI is read-only:** no job mutates committed source; the workflow never pushes back.
+- **Ruff/linting is OUT OF SCOPE** — tracked in `docs/backlog/2026-07-16-backend-ruff-lint-followup.md`.
+- **Commit trailer:** end every commit message with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Confirm a green test baseline in a clean Python 3.12 env
+
+Load-bearing prerequisite: the suite has never been proven green in a from-scratch, CI-like install. Do this **before** writing any workflow — if it is red, stop and surface it; a gate on a red suite would block every PR.
+
+**Files:**
+- Touches no repo files (throwaway venv only).
+
+- [ ] **Step 1: Create a fresh 3.12 venv (mirrors the runner)**
+
+```bash
+cd /home/kdatta/workspace/eyened-platform-worktrees/118-run-backend-tests-in-github-actions
+VENV=/tmp/claude-1011/-home-kdatta-workspace-eyened-platform/162d8da9-c212-4d6d-8907-8a8d47848481/scratchpad/ci-venv312
+rm -rf "$VENV"
+/usr/bin/python3.12 -m venv "$VENV"
+"$VENV/bin/python" -m pip install --upgrade pip
+```
+
+Expected: pip upgrades cleanly; `"$VENV/bin/python" --version` → `Python 3.12.x`.
+
+- [ ] **Step 2: Install exactly what CI installs**
+
+```bash
+"$VENV/bin/pip" install -e ./orm
+"$VENV/bin/pip" install -r server/test-requirements.txt
+```
+
+Expected: both succeed. `httpxyz>=0.31.2` and `numpy==2.0.0` resolve on 3.12 (they failed earlier only under Python 3.8).
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+"$VENV/bin/pytest" -q
+```
+
+Expected: **all tests pass, 0 failures / 0 errors** (a clean fresh install avoids the cross-worktree `ImportPathMismatchError` seen with the shared `dev/.venv`). Record the passing test count.
+
+- [ ] **Step 4: Decision gate (no commit — verification only)**
+
+- **All green** → proceed to Task 2.
+- **Any red** → STOP. Report the failures; do not add a CI gate on a red suite. Decide whether to fix tests first (new scope) or quarantine.
+
+---
+
+### Task 2: Add `.github/workflows/server-ci.yml` (test gate)
+
+**Files:**
+- Create: `.github/workflows/server-ci.yml`
+
+- [ ] **Step 1: Write the workflow file**
+
+```yaml
+name: Server CI
+on:
+  push:
+    branches: [development, main]
+    paths:
+      - 'server/**'
+      - 'orm/**'
+      - 'pyproject.toml'
+      - '.github/workflows/server-ci.yml'
+  pull_request:
+    branches: [development, main]
+    paths:
+      - 'server/**'
+      - 'orm/**'
+      - 'pyproject.toml'
+      - '.github/workflows/server-ci.yml'
+
+concurrency:
+  group: server-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -e ./orm
+          pip install -r server/test-requirements.txt
+      - run: pytest
+```
+
+- [ ] **Step 2: Install actionlint (workflow validator)**
+
+```bash
+cd /home/kdatta/workspace/eyened-platform-worktrees/118-run-backend-tests-in-github-actions
+BIN=/tmp/claude-1011/-home-kdatta-workspace-eyened-platform/162d8da9-c212-4d6d-8907-8a8d47848481/scratchpad/bin
+mkdir -p "$BIN"
+bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$BIN" 2>/dev/null && echo "actionlint at $BIN/actionlint"
+```
+
+If the download is blocked, fallback structural check:
+```bash
+/usr/bin/python3.12 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/server-ci.yml')); print('yaml OK')"
+```
+(If PyYAML is absent in the system 3.12, use the Task 1 venv's python.)
+
+- [ ] **Step 3: Validate the workflow**
+
+```bash
+"$BIN/actionlint" .github/workflows/server-ci.yml
+```
+Expected: **no output, exit 0** (actionlint prints nothing when clean). Fix any reported issue (unknown action version, YAML error, shell quoting) and re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/server-ci.yml
+git commit -m "ci(server): run backend pytest suite on push/PR into development,main
+
+New Server CI workflow: setup-python 3.12, pip install -e ./orm +
+test-requirements, pytest. push+pull_request scoped to base branches,
+path-filtered, cancel-in-progress. No services/secrets (in-memory SQLite).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Align `client-ci.yml` (add push trigger + concurrency)
+
+**Files:**
+- Modify: `.github/workflows/client-ci.yml`
+
+**Interfaces:**
+- Consumes: the existing `client-ci.yml` (currently `pull_request`-only, path-filtered, no concurrency). Steps must stay byte-for-byte unchanged.
+
+- [ ] **Step 1: Read the current file to anchor the edit**
+
+```bash
+cat .github/workflows/client-ci.yml
+```
+Confirm it currently begins with `on:` → `pull_request:` → `branches: [main, development]` + `paths: ['client/**', '.github/workflows/client-ci.yml']`, and has `defaults:` / `jobs:` below.
+
+- [ ] **Step 2: Add a `push` trigger mirroring the existing `pull_request` block**
+
+Replace the `on:` block so it reads (keep the exact `paths` list already present):
+
+```yaml
+on:
+  push:
+    branches: [main, development]
+    paths:
+      - 'client/**'
+      - '.github/workflows/client-ci.yml'
+  pull_request:
+    branches: [main, development]
+    paths:
+      - 'client/**'
+      - '.github/workflows/client-ci.yml'
+```
+
+- [ ] **Step 3: Add a concurrency block immediately after the `on:` block**
+
+```yaml
+concurrency:
+  group: client-ci-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Leave `defaults:`, `jobs:`, and all steps unchanged.
+
+- [ ] **Step 4: Validate**
+
+```bash
+cd /home/kdatta/workspace/eyened-platform-worktrees/118-run-backend-tests-in-github-actions
+BIN=/tmp/claude-1011/-home-kdatta-workspace-eyened-platform/162d8da9-c212-4d6d-8907-8a8d47848481/scratchpad/bin
+"$BIN/actionlint" .github/workflows/client-ci.yml
+git diff .github/workflows/client-ci.yml
+```
+Expected: actionlint exit 0; the diff shows **only** the added `push:` trigger and `concurrency:` block — no step changes. (Shell env vars do not persist across steps/tasks, so `BIN` is re-set here.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/client-ci.yml
+git commit -m "ci(client): also run on push to development,main + cancel-in-progress
+
+Aligns client CI with the new server CI trigger/concurrency policy so the
+integration branches get a post-merge run. Steps unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Prove the gate end-to-end on GitHub
+
+A workflow file is only truly validated by a real run. This task pushes the branch and opens the PR into `development`.
+
+**Files:**
+- No repo file changes.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin 118-run-backend-tests-in-github-actions
+```
+(The remote branch exists at the old fork point; since this branch was rebased onto `development` and never shared, a `--force-with-lease` is acceptable if the push is rejected as non-fast-forward: `git push --force-with-lease -u origin 118-run-backend-tests-in-github-actions`.)
+
+- [ ] **Step 2: Open a PR into `development`**
+
+Use the GitHub UI (no `gh` CLI on this host), base `development`, head `118-run-backend-tests-in-github-actions`. Title: `ci: run backend tests in GitHub Actions (#118)`. Body: link the design spec and note ruff is deferred to the backlog.
+
+- [ ] **Step 3: Confirm the live run**
+
+On the PR's Checks tab, confirm **Server CI / test** runs and **passes**, and that **Client CI** does *not* run for this PR (it only touches `.github/**`, `server/**`, `docs/**` — no `client/**`), demonstrating the path filter works.
+
+- [ ] **Step 4: Decision gate**
+
+- **Green** → done; request review.
+- **Red on the runner but green locally** → investigate the environment delta (Python patch, network install, cache) before merging; do not disable the check to force it green.
+
+---
+
+## Notes for the executor
+
+- Do **not** add `--fix`, `ruff`, formatting, or any source-mutating step — read-only CI is a hard constraint.
+- Do **not** add MySQL/Redis services or secrets — the suite is self-contained SQLite.
+- If Task 1 is red, the plan stops there; fixing the suite is a separate scope decision for the user.

--- a/docs/superpowers/specs/2026-07-16-backend-ci-design.md
+++ b/docs/superpowers/specs/2026-07-16-backend-ci-design.md
@@ -40,6 +40,19 @@ Python-3.8 install artifact and is **wrong** — it resolves fine on CI's Python
 depends on a third-party httpx *fork* in its auth path; whether that is intentional is
 a question for the team, not for this branch.
 
+## Design principle: CI is read-only
+
+No CI job may mutate committed source. All checks are report-only and the workflow
+never pushes to the repo:
+
+- `ruff check` runs **without `--fix`**; `ruff format` runs **with `--check`** — both
+  only report and fail, never rewrite files.
+- `pytest` does not modify source.
+- The only mutating command, plain `ruff format server orm`, is a **one-time local
+  commit** during implementation (§2) — never a workflow step.
+- `pip install -e ./orm` writes an ephemeral `*.egg-info/` build artifact into the
+  runner checkout; it is never committed or pushed and does not alter source.
+
 ## Approach (inherited, approved)
 
 **Approach A — native runner**: check out, `pip install` deps + pytest, run `pytest`

--- a/docs/superpowers/specs/2026-07-16-backend-ci-design.md
+++ b/docs/superpowers/specs/2026-07-16-backend-ci-design.md
@@ -1,0 +1,192 @@
+# Backend CI (tests + Python lint) — Design
+
+**Date:** 2026-07-16
+**Issue:** #118 — run backend tests in GitHub Actions
+**Base branch:** `development`
+**Status:** Approved design; implementation pending.
+
+## Goal
+
+Add a GitHub Actions gate that runs the backend **test suite** and **Python linting**
+on every pull request into `development`/`main` and on every push to those branches,
+using the same commands a developer runs locally. Keep the two frontend/backend gates
+stylistically consistent.
+
+## What already exists (context)
+
+- **Local test-runner enablement is already merged to `main`** (it was Task 0 of the
+  RBAC Step 1 plan; see `docs/superpowers/specs/2026-07-06-pr-test-ci-design.md`):
+  - `server/test-requirements.txt` → `-r requirements.txt` + `pytest==8.*`.
+  - `pyproject.toml` → correct `[tool.pytest.ini_options]` with
+    `pythonpath = ["."]` and `testpaths = ["server", "orm"]`.
+  - The suite uses an **in-memory SQLite** fixture (`orm/eyened_orm/utils/sqlite_testdb.py`)
+    with dummy DB creds set by `server/tests/conftest.py::pytest_configure` — **no live
+    MySQL, no services, no secrets** needed in CI.
+- **`client-ci.yml`** (frontend gate) is already merged and is the current house style:
+  one workflow per area, `actions/checkout@v7`, path-filtered.
+- **PR #49 ("WIP: Code linting checks")** is an unmerged draft that added a
+  `checks.yml` with a **ruff** Python-lint job and a TypeScript-lint job. Its
+  TypeScript half is superseded by `client-ci.yml`; its **ruff job is the useful part
+  we revive here**. It confirmed Python **3.12** and `actions/setup-python@v6`.
+
+### Dependency note (investigated, not a blocker)
+
+`server/requirements.txt` pins `httpxyz>=0.31.2`, imported in `server/config.py` and
+`server/routes/auth.py` (OIDC flows). Investigation (2026-07-16): `httpxyz` is a
+legitimate, **currently-available** "friendly fork" of `httpx` on PyPI (latest 0.31.2,
+2026-05-08; requires Python ≥3.9). An earlier "removed from PyPI" reading was a
+Python-3.8 install artifact and is **wrong** — it resolves fine on CI's Python 3.12.
+**Not a CI blocker and out of scope here.** The only neutral observation: the repo
+depends on a third-party httpx *fork* in its auth path; whether that is intentional is
+a question for the team, not for this branch.
+
+## Approach (inherited, approved)
+
+**Approach A — native runner**: check out, `pip install` deps + pytest, run `pytest`
+directly on `ubuntu-latest`. Chosen over a Docker-based stage for local/CI symmetry;
+the suite is pure in-memory SQLite so there is no prod-parity benefit to Docker today.
+Linting runs via `astral-sh/ruff-action`, matching PR #49's mechanism.
+
+## Design
+
+### 1. New workflow: `.github/workflows/server-ci.yml`
+
+Two jobs — `test` and `lint-python` — under a shared trigger.
+
+```yaml
+name: Server CI
+on:
+  push:
+    branches: [development, main]
+    paths:
+      - 'server/**'
+      - 'orm/**'
+      - 'pyproject.toml'
+      - '.github/workflows/server-ci.yml'
+  pull_request:
+    branches: [development, main]
+    paths:
+      - 'server/**'
+      - 'orm/**'
+      - 'pyproject.toml'
+      - '.github/workflows/server-ci.yml'
+
+concurrency:
+  group: server-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -e ./orm
+          pip install -r server/test-requirements.txt
+      - run: pytest
+
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.14.x"   # verify latest at implementation; pin for reproducibility
+          args: check server orm
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.14.x"
+          args: format --check server orm
+```
+
+**Rationale for key choices:**
+
+- **`push` + `pull_request`, both scoped to `[development, main]`.** PR runs test the
+  synthetic merge preview; the `push` runs test the *real* post-merge HEAD of the
+  integration branches. Because `development` is an active multi-PR integration branch,
+  the `push` run catches **merge-skew breakage** that PR-only cannot see (a stale PR
+  merging green but breaking `development`). Scoping `push` to the base branches means
+  feature-branch pushes do **not** double-run (only their PR run fires), so there is no
+  duplicate-run waste.
+- **`concurrency: cancel-in-progress`.** Cancels a still-running run when a newer commit
+  supersedes it on the same ref, saving CI minutes. Never crosses refs/PRs.
+- **Path filter** mirrors `client-ci.yml`, so backend CI skips on frontend-only PRs.
+  *Caveat:* if `server-ci` is later made a **required** status check, a path-skipped run
+  reports as skipped and branch protection can treat a required-but-skipped check as
+  unsatisfied. Handle at that point (e.g. a required "always-green" gate job) — not now.
+- **Two separate jobs** (not chained steps) so a lint failure and a test failure are
+  independently visible and can run in parallel.
+- **Ruff scoped to `server orm`** — excludes `dev/` scripts and `notebooks/` (Jupyter),
+  matching PR #49's intent to skip notebooks.
+
+### 2. Ruff baseline (make `lint-python` green without a giant fix-PR)
+
+Ruff has **never** been run on the backend, so `ruff check`/`format --check` could
+surface many findings. The gate must land green. Strategy:
+
+1. **Add `[tool.ruff]` config to root `pyproject.toml`** (alongside the pytest config):
+
+   ```toml
+   [tool.ruff]
+   target-version = "py312"
+   # line-length defaults to 88
+
+   [tool.ruff.lint]
+   select = ["E", "F"]   # ruff defaults; conservative starting set
+   ```
+
+   This makes a local `ruff check server orm` match CI exactly.
+
+2. **Measure first (execution step):** run `ruff format --check server orm` and
+   `ruff check server orm` and count findings.
+   - **Formatting:** apply `ruff format server orm` once as a single mechanical commit,
+     so `format --check` is green.
+   - **Lint (`check`):** if the residual finding count is small, fix them. If large,
+     narrow the initial `select` (or add `extend-ignore` / `per-file-ignores`) so the
+     gate is green now, and record a follow-up to ratchet rules up over time. **The
+     exact starting rule set is decided from the measured count, not guessed.**
+
+3. **Pin the ruff version** in the action (reproducible gate); verify the current latest
+   at implementation rather than trusting this doc's placeholder.
+
+### 3. Modify `.github/workflows/client-ci.yml`
+
+Bring it in line with the agreed trigger/concurrency policy:
+
+- Change trigger from `pull_request` only → **`push` + `pull_request`**, both scoped to
+  `[development, main]` with the existing `client/**` + workflow path filter.
+- Add a `concurrency: { group: client-ci-${{ github.ref }}, cancel-in-progress: true }`
+  block.
+
+No change to its steps.
+
+## Prerequisite / risk
+
+**The existing suite must be green in a clean Python-3.12 install before the gate is
+trusted.** Nobody has run it in a from-scratch CI-like environment (the shared
+`dev/.venv` is pre-populated, and a cross-worktree run hit an import-path artifact, not
+a real result). Implementation MUST first reproduce the CI recipe in a throwaway 3.12
+venv (`pip install -e ./orm` + `pip install -r server/test-requirements.txt` +
+`pytest`) and confirm green. If anything is red, surface and decide **before** enabling
+a gate that would block every PR.
+
+## Testing
+
+- Validate `server-ci.yml` and the `client-ci.yml` edit with a YAML/action linter
+  (e.g. `actionlint`) locally before pushing.
+- Prove the gate end-to-end by opening the #118 PR into `development` and confirming
+  both jobs run and pass on the real runner.
+
+## Out of scope
+
+- Docker-based test stage (Approach B) — revisit if tests ever exercise real MySQL.
+- Cloud CD / deployment changes.
+- Migrating dependency management to `pyproject`.
+- The `httpxyz` → upstream-`httpx` question (team decision; see note above).
+- Expanding the ruff rule set beyond the agreed green baseline (fast-follow).
+- Reviving PR #49's TypeScript-lint job (superseded by `client-ci.yml`).

--- a/docs/superpowers/specs/2026-07-16-backend-ci-design.md
+++ b/docs/superpowers/specs/2026-07-16-backend-ci-design.md
@@ -1,4 +1,4 @@
-# Backend CI (tests + Python lint) — Design
+# Backend CI (tests) — Design
 
 **Date:** 2026-07-16
 **Issue:** #118 — run backend tests in GitHub Actions
@@ -7,64 +7,54 @@
 
 ## Goal
 
-Add a GitHub Actions gate that runs the backend **test suite** and **Python linting**
-on every pull request into `development`/`main` and on every push to those branches,
-using the same commands a developer runs locally. Keep the two frontend/backend gates
-stylistically consistent.
+Add a GitHub Actions gate that runs the backend **test suite** on every pull request
+into `development`/`main` and on every push to those branches, using the same command a
+developer runs locally — and bring `client-ci.yml` in line with the same trigger and
+concurrency policy. **Python linting (ruff) is deferred** to a follow-up (see
+`docs/backlog/2026-07-16-backend-ruff-lint-followup.md`); §"Deferred: ruff job" keeps
+the job skeleton.
 
 ## What already exists (context)
 
-- **Local test-runner enablement is already merged to `main`** (it was Task 0 of the
-  RBAC Step 1 plan; see `docs/superpowers/specs/2026-07-06-pr-test-ci-design.md`):
+- **Local test-runner enablement is already merged** (Task 0 of the RBAC Step 1 plan;
+  see `docs/superpowers/specs/2026-07-06-pr-test-ci-design.md`):
   - `server/test-requirements.txt` → `-r requirements.txt` + `pytest==8.*`.
-  - `pyproject.toml` → correct `[tool.pytest.ini_options]` with
-    `pythonpath = ["."]` and `testpaths = ["server", "orm"]`.
+  - `pyproject.toml` → correct `[tool.pytest.ini_options]` with `pythonpath = ["."]`
+    and `testpaths = ["server", "orm"]`.
   - The suite uses an **in-memory SQLite** fixture (`orm/eyened_orm/utils/sqlite_testdb.py`)
     with dummy DB creds set by `server/tests/conftest.py::pytest_configure` — **no live
-    MySQL, no services, no secrets** needed in CI.
-- **`client-ci.yml`** (frontend gate) is already merged and is the current house style:
-  one workflow per area, `actions/checkout@v7`, path-filtered.
-- **PR #49 ("WIP: Code linting checks")** is an unmerged draft that added a
-  `checks.yml` with a **ruff** Python-lint job and a TypeScript-lint job. Its
-  TypeScript half is superseded by `client-ci.yml`; its **ruff job is the useful part
-  we revive here**. It confirmed Python **3.12** and `actions/setup-python@v6`.
+    MySQL, no services, no secrets** in CI.
+- **`client-ci.yml`** (frontend gate) is merged and is the current house style: one
+  workflow per area, `actions/checkout@v7`, path-filtered, PR-only trigger.
 
 ### Dependency note (investigated, not a blocker)
 
 `server/requirements.txt` pins `httpxyz>=0.31.2`, imported in `server/config.py` and
-`server/routes/auth.py` (OIDC flows). Investigation (2026-07-16): `httpxyz` is a
-legitimate, **currently-available** "friendly fork" of `httpx` on PyPI (latest 0.31.2,
-2026-05-08; requires Python ≥3.9). An earlier "removed from PyPI" reading was a
-Python-3.8 install artifact and is **wrong** — it resolves fine on CI's Python 3.12.
-**Not a CI blocker and out of scope here.** The only neutral observation: the repo
-depends on a third-party httpx *fork* in its auth path; whether that is intentional is
-a question for the team, not for this branch.
-
-## Design principle: CI is read-only
-
-No CI job may mutate committed source. All checks are report-only and the workflow
-never pushes to the repo:
-
-- `ruff check` runs **without `--fix`**; `ruff format` runs **with `--check`** — both
-  only report and fail, never rewrite files.
-- `pytest` does not modify source.
-- The only mutating command, plain `ruff format server orm`, is a **one-time local
-  commit** during implementation (§2) — never a workflow step.
-- `pip install -e ./orm` writes an ephemeral `*.egg-info/` build artifact into the
-  runner checkout; it is never committed or pushed and does not alter source.
+`server/routes/auth.py` (OIDC). `httpxyz` is a legitimate, **available** "friendly
+fork" of `httpx` on PyPI (latest 0.31.2, requires Python ≥3.9); it resolves fine on
+CI's Python 3.12. **Not a CI blocker, out of scope here.** Neutral observation only: the
+repo depends on a third-party httpx *fork* in its auth path — a team question, not this
+branch's.
 
 ## Approach (inherited, approved)
 
 **Approach A — native runner**: check out, `pip install` deps + pytest, run `pytest`
-directly on `ubuntu-latest`. Chosen over a Docker-based stage for local/CI symmetry;
-the suite is pure in-memory SQLite so there is no prod-parity benefit to Docker today.
-Linting runs via `astral-sh/ruff-action`, matching PR #49's mechanism.
+directly on `ubuntu-latest`. Chosen over a Docker-based stage for local/CI symmetry; the
+suite is pure in-memory SQLite so there is no prod-parity benefit to Docker today.
+
+## Design principle: CI is read-only
+
+No CI job may mutate committed source, and the workflow never pushes to the repo.
+`pytest` does not modify source. `pip install -e ./orm` writes an ephemeral `*.egg-info/`
+build artifact into the runner checkout; it is never committed or pushed and does not
+alter source. (When the deferred ruff job lands, it must likewise be read-only: `ruff
+check` without `--fix`, `ruff format --check`.)
 
 ## Design
 
 ### 1. New workflow: `.github/workflows/server-ci.yml`
 
-Two jobs — `test` and `lint-python` — under a shared trigger.
+One job — `test`.
 
 ```yaml
 name: Server CI
@@ -102,19 +92,6 @@ jobs:
           pip install -e ./orm
           pip install -r server/test-requirements.txt
       - run: pytest
-
-  lint-python:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "0.14.x"   # verify latest at implementation; pin for reproducibility
-          args: check server orm
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "0.14.x"
-          args: format --check server orm
 ```
 
 **Rationale for key choices:**
@@ -122,84 +99,72 @@ jobs:
 - **`push` + `pull_request`, both scoped to `[development, main]`.** PR runs test the
   synthetic merge preview; the `push` runs test the *real* post-merge HEAD of the
   integration branches. Because `development` is an active multi-PR integration branch,
-  the `push` run catches **merge-skew breakage** that PR-only cannot see (a stale PR
-  merging green but breaking `development`). Scoping `push` to the base branches means
-  feature-branch pushes do **not** double-run (only their PR run fires), so there is no
-  duplicate-run waste.
+  the `push` run catches **merge-skew breakage** that PR-only cannot see. Scoping `push`
+  to the base branches means feature-branch pushes do **not** double-run (only their PR
+  run fires) — no duplicate-run waste.
 - **`concurrency: cancel-in-progress`.** Cancels a still-running run when a newer commit
-  supersedes it on the same ref, saving CI minutes. Never crosses refs/PRs.
+  supersedes it on the same ref. Never crosses refs/PRs.
 - **Path filter** mirrors `client-ci.yml`, so backend CI skips on frontend-only PRs.
   *Caveat:* if `server-ci` is later made a **required** status check, a path-skipped run
   reports as skipped and branch protection can treat a required-but-skipped check as
-  unsatisfied. Handle at that point (e.g. a required "always-green" gate job) — not now.
-- **Two separate jobs** (not chained steps) so a lint failure and a test failure are
-  independently visible and can run in parallel.
-- **Ruff scoped to `server orm`** — excludes `dev/` scripts and `notebooks/` (Jupyter),
-  matching PR #49's intent to skip notebooks.
+  unsatisfied. Handle at that point (e.g. a required aggregating gate job) — not now.
+- **`python-version: "3.12"`** matches `dev/Dockerfile.server` (`python:3.12-slim`). No
+  matrix (YAGNI).
+- **`actions/checkout@v7` + `actions/setup-python@v6`** — current latest majors.
+- **`pip install -e ./orm`** (editable) mirrors how the suite resolves the ORM locally;
+  it is the only source of SQLAlchemy et al. and must be importable at collection time.
 
-### 2. Ruff baseline (make `lint-python` green without a giant fix-PR)
+### 2. Modify `.github/workflows/client-ci.yml`
 
-Ruff has **never** been run on the backend, so `ruff check`/`format --check` could
-surface many findings. The gate must land green. Strategy:
-
-1. **Add `[tool.ruff]` config to root `pyproject.toml`** (alongside the pytest config):
-
-   ```toml
-   [tool.ruff]
-   target-version = "py312"
-   # line-length defaults to 88
-
-   [tool.ruff.lint]
-   select = ["E", "F"]   # ruff defaults; conservative starting set
-   ```
-
-   This makes a local `ruff check server orm` match CI exactly.
-
-2. **Measure first (execution step):** run `ruff format --check server orm` and
-   `ruff check server orm` and count findings.
-   - **Formatting:** apply `ruff format server orm` once as a single mechanical commit,
-     so `format --check` is green.
-   - **Lint (`check`):** if the residual finding count is small, fix them. If large,
-     narrow the initial `select` (or add `extend-ignore` / `per-file-ignores`) so the
-     gate is green now, and record a follow-up to ratchet rules up over time. **The
-     exact starting rule set is decided from the measured count, not guessed.**
-
-3. **Pin the ruff version** in the action (reproducible gate); verify the current latest
-   at implementation rather than trusting this doc's placeholder.
-
-### 3. Modify `.github/workflows/client-ci.yml`
-
-Bring it in line with the agreed trigger/concurrency policy:
+Bring it in line with the agreed trigger/concurrency policy — **steps unchanged**:
 
 - Change trigger from `pull_request` only → **`push` + `pull_request`**, both scoped to
-  `[development, main]` with the existing `client/**` + workflow path filter.
-- Add a `concurrency: { group: client-ci-${{ github.ref }}, cancel-in-progress: true }`
-  block.
+  `[development, main]` with the existing `client/**` + workflow-file path filter.
+- Add:
+  ```yaml
+  concurrency:
+    group: client-ci-${{ github.ref }}
+    cancel-in-progress: true
+  ```
 
-No change to its steps.
+### Deferred: ruff job (follow-up, not in #118)
+
+A `lint-python` (ruff) job was planned but descoped after a first run measured a large
+baseline (125 `ruff check` errors, 121 files needing `ruff format`). Bundling that
+cleanup here would bury the CI change and collide with in-flight branches. Tracked in
+`docs/backlog/2026-07-16-backend-ruff-lint-followup.md`. Job skeleton for when it lands:
+
+```yaml
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v3
+        with: { version: "0.14.x", args: check server orm }   # no --fix (read-only)
+      - uses: astral-sh/ruff-action@v3
+        with: { version: "0.14.x", args: format --check server orm }
+```
 
 ## Prerequisite / risk
 
 **The existing suite must be green in a clean Python-3.12 install before the gate is
 trusted.** Nobody has run it in a from-scratch CI-like environment (the shared
-`dev/.venv` is pre-populated, and a cross-worktree run hit an import-path artifact, not
-a real result). Implementation MUST first reproduce the CI recipe in a throwaway 3.12
-venv (`pip install -e ./orm` + `pip install -r server/test-requirements.txt` +
-`pytest`) and confirm green. If anything is red, surface and decide **before** enabling
-a gate that would block every PR.
+`dev/.venv` is pre-populated; a cross-worktree run hit an import-path artifact, not a
+real result). Implementation MUST first reproduce the CI recipe in a throwaway 3.12 venv
+(`pip install -e ./orm` + `pip install -r server/test-requirements.txt` + `pytest`) and
+confirm green. If anything is red, surface and decide **before** enabling a gate that
+would block every PR.
 
 ## Testing
 
-- Validate `server-ci.yml` and the `client-ci.yml` edit with a YAML/action linter
-  (e.g. `actionlint`) locally before pushing.
-- Prove the gate end-to-end by opening the #118 PR into `development` and confirming
-  both jobs run and pass on the real runner.
+- Validate `server-ci.yml` and the `client-ci.yml` edit with `actionlint` locally
+  before pushing.
+- Prove the gate end-to-end by opening the #118 PR into `development` and confirming the
+  `test` job runs and passes on the real runner.
 
 ## Out of scope
 
+- Ruff / Python lint gate — deferred to `docs/backlog/2026-07-16-backend-ruff-lint-followup.md`.
 - Docker-based test stage (Approach B) — revisit if tests ever exercise real MySQL.
-- Cloud CD / deployment changes.
-- Migrating dependency management to `pyproject`.
+- Cloud CD / deployment changes; migrating dependency management to `pyproject`.
 - The `httpxyz` → upstream-`httpx` question (team decision; see note above).
-- Expanding the ruff rule set beyond the agreed green baseline (fast-follow).
-- Reviving PR #49's TypeScript-lint job (superseded by `client-ci.yml`).


### PR DESCRIPTION
Closes #118.

## What

Adds a GitHub Actions gate that runs the backend **pytest** suite, and aligns the frontend gate to the same trigger/concurrency policy.

- **New `.github/workflows/server-ci.yml`** — `setup-python@v6` (3.12) → `pip install -e ./orm` + `pip install -r server/test-requirements.txt` → `pytest`. No services/secrets (in-memory SQLite). `timeout-minutes: 15`, pip cache keyed on both requirements files.
- **`.github/workflows/client-ci.yml`** — adds a `push` trigger + `cancel-in-progress` concurrency (steps unchanged).

Both workflows: `push` **and** `pull_request` scoped to `[development, main]`, path-filtered, `cancel-in-progress`. The `push` runs on the base branches catch post-merge/merge-skew breakage that PR-only runs can't see; scoping `push` to base branches avoids duplicate feature-branch runs.

## Verification

- Full suite green in a clean Python 3.12 install: **276 passed, 0 failures**.
- `actionlint` v1.7.12 clean on both workflow files.
- CI is **read-only** — no source-mutating step, no push-back.

## Out of scope

- **Ruff / Python lint gate** deferred to `docs/backlog/2026-07-16-backend-ruff-lint-followup.md` (first run measured 125 lint findings + 121 files to reformat — its own focused PR).

Design: `docs/superpowers/specs/2026-07-16-backend-ci-design.md` · Plan: `docs/superpowers/plans/2026-07-16-backend-ci.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
