### PR TITLE
Reuse one Database engine per RQ worker process.

### DIFF
--- a/orm/eyened_orm/db.py
+++ b/orm/eyened_orm/db.py
@@ -48,7 +48,9 @@ class Database:
             self.database_settings = load_database_settings(database_settings)
 
         self.engine = create_engine(
-            create_connection_string(self.database_settings), pool_pre_ping=True
+            create_connection_string(self.database_settings),
+            pool_pre_ping=True,
+            pool_recycle=280,  # prohibit idle connections from being forcefully closed by the server and re-use instead
         )
         self._session_factory = sessionmaker(
             bind=self.engine,

--- a/server/utils/tasks.py
+++ b/server/utils/tasks.py
@@ -1,13 +1,31 @@
 """RQ worker entrypoints (must stay importable and use plain, pickle-friendly args)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from eyened_orm import Database
+
+_worker_database: Database | None = None
+
+
+def get_worker_database() -> Database:
+    """Return one shared Database/engine per RQ worker process."""
+    global _worker_database
+    if _worker_database is None:
+        from eyened_orm import Database
+
+        _worker_database = Database()
+    return _worker_database
+
 
 def run_thumbnail_update_job(failed: bool = False, print_errors: bool = False):
     """Same as ``eorm update-thumbnails`` (optional ``--failed`` / ``--print-errors``)."""
-    from eyened_orm import Database
     from eyened_orm.importer.thumbnails import run_update_thumbnails_job
 
     run_update_thumbnails_job(
-        Database(), include_failed=failed, print_errors=print_errors
+        get_worker_database(), include_failed=failed, print_errors=print_errors
     )
     return True
 
@@ -17,11 +35,10 @@ def run_thumbnail_update_for_image_ids_job(
     print_errors: bool = False,
 ):
     """Generate thumbnails only for the given ``ImageInstanceID``s."""
-    from eyened_orm import Database
     from eyened_orm.importer.thumbnails import run_update_thumbnails_for_image_ids_job
 
     run_update_thumbnails_for_image_ids_job(
-        Database(), image_ids, print_errors=print_errors
+        get_worker_database(), image_ids, print_errors=print_errors
     )
     return True
 
@@ -35,10 +52,9 @@ def run_cfi_model_for_image_ids(
     n_workers: int = 16,
 ):
     """Run one CFI attribute pipeline (``cfi-roi``, ``cfi-quality``, ...)."""
-    from eyened_orm import Database
     from eyened_orm.commands.model_processing import _get_device, run_cfi_attribute_pipeline
 
-    database = Database()
+    database = get_worker_database()
     device = _get_device(None)
     with database.get_session() as session:
         run_cfi_attribute_pipeline(
@@ -61,11 +77,10 @@ def run_cfi_amd_for_image_ids(
     n_workers: int = 12,
 ):
     """Run the CFI AMD segmentation processor (``cfi-amd`` queue)."""
-    from eyened_orm import Database
     from eyened_orm.commands.model_processing import _get_device
     from eyened_orm.inference.cfi_amd_segmentation import run_for_image_ids
 
-    database = Database()
+    database = get_worker_database()
     device = _get_device(None)
     with database.get_session() as session:
         run_for_image_ids(
@@ -104,7 +119,6 @@ def run_layer_segmentation_for_image_ids(
     """Run the OCT layer segmentation processor (``layer-segmentation`` queue)."""
     from rq import get_current_job
 
-    from eyened_orm import Database
     from eyened_orm.commands.model_processing import _get_device
     from eyened_orm.inference.layer_segmentation import run_for_image_ids
 
@@ -117,7 +131,7 @@ def run_layer_segmentation_for_image_ids(
             flush=True,
         )
 
-    database = Database()
+    database = get_worker_database()
     device = _get_device(None)
     with database.get_session() as session:
         run_for_image_ids(session, image_ids, device=device, overwrite=overwrite)


### PR DESCRIPTION
This adds a 'get_worker_database' function that reuses a module-level database engine. 
Workers should now reuse the same engine, instead of creating a new engine/pool for every job.