### PR TITLE
WIP: image dimension validate + repair CLI (#149)

### DIFF
--- a/orm/eyened_orm/cli.py
+++ b/orm/eyened_orm/cli.py
@@ -13,6 +13,7 @@ Command utilities for the eyened ORM.
 
 The following commands are available:
 - update-thumbnails: Update thumbnails for all images in the database.
+- repair-image-dimensions: Fix Rows_y/Columns_x/NrOfFrames from on-disk pixels (filtered targets).
 - run-models: Run attribute inference models (cfi-roi, cfi-keypoints, cfi-odfd, cfi-quality) on a set of image IDs.
 - run-etdrs-model: Run ETDRS model processing on segmentations.
 - run-cfi-amd: Run CFI AMD segmentation models.
@@ -169,6 +170,48 @@ def create_user(username: str, password: str, is_human: bool, description: str |
             print(f"User created successfully")
         except ValueError as e:
             print(f"Error creating user: {e}")
+
+
+@eorm.command("repair-image-dimensions")
+@image_target_options(require_one=True)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report fixes without writing DB or AuditLog",
+)
+def repair_image_dimensions_cmd(
+    path,
+    image_ids,
+    project,
+    patient,
+    exclude,
+    modality,
+    include_inactive,
+    dry_run,
+):
+    """Set Rows_y / Columns_x / NrOfFrames from on-disk pixel arrays.
+
+    Skips images that already match. Skips (and reports) images with blocking
+    dependents (segmentations, CFROI, CFKeypoints). Writes AuditLog on each fix.
+    Requires a target scope (--image-ids, --path, --project, or --patient).
+    """
+    from eyened_orm.commands.repair_image_dimensions import run_repair_image_dimensions
+
+    database = get_database(confirmation=not dry_run)
+    spec = target_spec_from_cli(
+        path=path,
+        image_ids=image_ids,
+        project=project,
+        patient=patient,
+        exclude=exclude,
+        modality=modality,
+        include_inactive=include_inactive,
+    )
+    try:
+        run_repair_image_dimensions(database, spec, dry_run=dry_run)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
 
 
 @eorm.command()

--- a/orm/eyened_orm/commands/repair_image_dimensions.py
+++ b/orm/eyened_orm/commands/repair_image_dimensions.py
@@ -1,0 +1,170 @@
+"""Repair ImageInstance Rows_y / Columns_x / NrOfFrames from on-disk pixels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from eyened_orm import AuditLog, ImageInstance
+from eyened_orm.commands.targets import (
+    TargetSpec,
+    has_target_spec,
+    resolve_image_target,
+)
+from eyened_orm.image_dimensions import (
+    apply_dimensions,
+    blocking_dependents,
+    dimensions_compatible,
+    dimensions_from_array,
+    dimensions_from_instance,
+)
+
+if TYPE_CHECKING:
+    from eyened_orm import Database
+
+TRUSTED_PATH = "cli:repair-image-dimensions"
+
+
+@dataclass
+class RepairSummary:
+    ok: int = 0
+    fixed: int = 0
+    blocked: int = 0
+    errors: int = 0
+    blocked_ids: list[int] = field(default_factory=list)
+    error_ids: list[int] = field(default_factory=list)
+
+    def print(self) -> None:
+        print(
+            f"Summary: ok={self.ok} fixed={self.fixed} "
+            f"blocked={self.blocked} errors={self.errors}"
+        )
+        if self.blocked_ids:
+            print(f"Blocked IDs: {self.blocked_ids}")
+        if self.error_ids:
+            print(f"Error IDs: {self.error_ids}")
+
+
+def _project_id_for(image: ImageInstance) -> int | None:
+    try:
+        return image.Series.Study.Patient.ProjectID
+    except Exception:
+        return None
+
+
+def _record_audit(session, image: ImageInstance, changes: dict) -> None:
+    session.add(
+        AuditLog(
+            ActorID=None,
+            TrustedPath=TRUSTED_PATH,
+            Action="UPDATE",
+            Entity="ImageInstance",
+            EntityID=str(image.ImageInstanceID),
+            ProjectID=_project_id_for(image),
+            Changes=changes,
+        )
+    )
+
+
+def _needs_repair(image: ImageInstance, array_dims) -> bool:
+    if image.Rows_y is None or image.Columns_x is None:
+        return True
+    db_dims = dimensions_from_instance(image)
+    return bool(dimensions_compatible(db_dims, array_dims))
+
+
+def repair_image_dimensions_for_ids(
+    session,
+    image_ids: set[int] | list[int],
+    *,
+    dry_run: bool = False,
+) -> RepairSummary:
+    """Repair dimensions for the given ImageInstanceIDs. Caller owns commit."""
+    summary = RepairSummary()
+    ids = sorted(set(image_ids))
+    if not ids:
+        return summary
+
+    images = (
+        session.query(ImageInstance)
+        .filter(ImageInstance.ImageInstanceID.in_(ids))
+        .all()
+    )
+    by_id = {im.ImageInstanceID: im for im in images}
+
+    for image_id in ids:
+        image = by_id.get(image_id)
+        if image is None:
+            print(f"ImageInstance {image_id}: not found")
+            summary.errors += 1
+            summary.error_ids.append(image_id)
+            continue
+        try:
+            array = image.load_pixel_array()
+            array_dims = dimensions_from_array(array)
+            if not _needs_repair(image, array_dims):
+                summary.ok += 1
+                continue
+
+            blockers = blocking_dependents(image)
+            if blockers:
+                print(
+                    f"ImageInstance {image_id}: blocked ({', '.join(blockers)}); "
+                    f"db={dimensions_from_instance(image)} array={array_dims}"
+                )
+                summary.blocked += 1
+                summary.blocked_ids.append(image_id)
+                continue
+
+            changes = apply_dimensions(image, array_dims)
+            print(
+                f"ImageInstance {image_id}: "
+                f"{'would fix' if dry_run else 'fixed'} "
+                f"{changes['old']} -> {changes['new']}"
+            )
+            if dry_run:
+                image.Rows_y = changes["old"]["Rows_y"]
+                image.Columns_x = changes["old"]["Columns_x"]
+                image.NrOfFrames = changes["old"]["NrOfFrames"]
+            else:
+                _record_audit(session, image, changes)
+                session.flush()
+            summary.fixed += 1
+        except Exception as e:
+            print(f"ImageInstance {image_id}: error: {e}")
+            summary.errors += 1
+            summary.error_ids.append(image_id)
+
+    return summary
+
+
+def run_repair_image_dimensions(
+    database: Database,
+    spec: TargetSpec,
+    *,
+    dry_run: bool = False,
+) -> RepairSummary:
+    if not has_target_spec(spec):
+        raise ValueError(
+            "Provide at least one of --image-ids, --path, --project, or --patient"
+        )
+
+    total = RepairSummary()
+    with database.get_session() as session:
+        target = resolve_image_target(session, spec)
+        print(f"Target: {target.summary}")
+        part = repair_image_dimensions_for_ids(
+            session, target.image_ids, dry_run=dry_run
+        )
+        total.ok += part.ok
+        total.fixed += part.fixed
+        total.blocked += part.blocked
+        total.errors += part.errors
+        total.blocked_ids.extend(part.blocked_ids)
+        total.error_ids.extend(part.error_ids)
+        if dry_run:
+            session.rollback()
+        else:
+            session.commit()
+    total.print()
+    return total

--- a/orm/eyened_orm/image_dimensions.py
+++ b/orm/eyened_orm/image_dimensions.py
@@ -1,0 +1,182 @@
+"""ImageInstance dimension parsing, validation, and repair helpers.
+
+Pixels on disk are the source of truth. Reads must not mutate the ORM session;
+mismatches raise so callers repair via ``eorm repair-image-dimensions``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from eyened_orm.image_instance import ImageInstance
+
+__all__ = [
+    "ImageDimensionMismatchError",
+    "ImageDimensions",
+    "apply_dimensions",
+    "assert_dimensions_match",
+    "blocking_dependents",
+    "dimensions_compatible",
+    "dimensions_from_array",
+    "effective_n_frames",
+]
+
+
+@dataclass(frozen=True)
+class ImageDimensions:
+    """Canonical (depth, height, width) derived from a pixel array or DB columns."""
+
+    n_frames: Optional[int]  # None means single-frame / unspecified in array layout
+    rows_y: Optional[int]
+    columns_x: Optional[int]
+
+    @property
+    def shape_dhw(self) -> tuple[int, int, int]:
+        if self.rows_y is None or self.columns_x is None:
+            raise ValueError("Cannot build shape_dhw with unset Rows_y/Columns_x")
+        return (effective_n_frames(self.n_frames), self.rows_y, self.columns_x)
+
+
+class ImageDimensionMismatchError(ValueError):
+    """DB dimensions disagree with the loaded pixel array."""
+
+    def __init__(
+        self,
+        *,
+        image_instance_id: int | None,
+        db: ImageDimensions | None,
+        array: ImageDimensions,
+        detail: str,
+    ):
+        self.image_instance_id = image_instance_id
+        self.db = db
+        self.array = array
+        id_part = (
+            f"ImageInstance {image_instance_id}"
+            if image_instance_id is not None
+            else "ImageInstance"
+        )
+        super().__init__(
+            f"{id_part} dimension mismatch: {detail} "
+            f"(db={_fmt_dims(db)}, array={_fmt_dims(array)}). "
+            f"Run `eorm repair-image-dimensions` after clearing blocking dependents."
+        )
+
+
+def _fmt_dims(dims: ImageDimensions | None) -> str:
+    if dims is None:
+        return "(unset)"
+    return f"(NrOfFrames={dims.n_frames!r}, Rows_y={dims.rows_y}, Columns_x={dims.columns_x})"
+
+
+def effective_n_frames(n_frames: Optional[int]) -> int:
+    """Treat None as 1 for single-frame images."""
+    return 1 if n_frames is None else n_frames
+
+
+def dimensions_from_array(array: np.ndarray) -> ImageDimensions:
+    """Infer (frames, height, width) from a numpy pixel array.
+
+    Layout conventions match historical ``_update_image_dimensions``:
+    - 2D: (H, W) → single-frame
+    - 3D with last dim ≤ 4: (H, W, C) RGB/RGBA → single-frame
+    - 3D with last dim > 4: (D, H, W) volume
+    """
+    shape = array.shape
+    if len(shape) == 2:
+        h, w = shape
+        return ImageDimensions(n_frames=None, rows_y=int(h), columns_x=int(w))
+    if len(shape) == 3:
+        if shape[2] > 4:
+            n_frames, h, w = shape
+            return ImageDimensions(
+                n_frames=int(n_frames), rows_y=int(h), columns_x=int(w)
+            )
+        h, w, _ = shape
+        return ImageDimensions(n_frames=None, rows_y=int(h), columns_x=int(w))
+    raise ValueError(f"Unsupported pixel array shape: {shape}")
+
+
+def dimensions_from_instance(image: ImageInstance) -> ImageDimensions:
+    return ImageDimensions(
+        n_frames=image.NrOfFrames,
+        rows_y=image.Rows_y,  # type: ignore[arg-type]
+        columns_x=image.Columns_x,  # type: ignore[arg-type]
+    )
+
+
+def dimensions_compatible(db: ImageDimensions, array: ImageDimensions) -> list[str]:
+    """Return human-readable mismatch reasons (empty if compatible).
+
+    Unset DB height/width are not compared (incomplete metadata). Frame count
+    uses None↔1 equivalence.
+    """
+    errors: list[str] = []
+    if db.rows_y is not None and db.rows_y != array.rows_y:
+        errors.append(f"Rows_y {db.rows_y} != {array.rows_y}")
+    if db.columns_x is not None and db.columns_x != array.columns_x:
+        errors.append(f"Columns_x {db.columns_x} != {array.columns_x}")
+    if effective_n_frames(db.n_frames) != effective_n_frames(array.n_frames):
+        # Only complain when DB explicitly set frames, or array is multi-frame
+        if db.n_frames is not None or effective_n_frames(array.n_frames) > 1:
+            errors.append(
+                f"NrOfFrames {db.n_frames!r} != {array.n_frames!r}"
+            )
+    return errors
+
+
+def assert_dimensions_match(image: ImageInstance, array: np.ndarray) -> None:
+    """Raise if set DB dimensions disagree with ``array``. Does not mutate ``image``."""
+    array_dims = dimensions_from_array(array)
+    db_dims = ImageDimensions(
+        n_frames=image.NrOfFrames,
+        rows_y=image.Rows_y,  # may be None
+        columns_x=image.Columns_x,
+    )
+    errors = dimensions_compatible(db_dims, array_dims)
+    if errors:
+        raise ImageDimensionMismatchError(
+            image_instance_id=getattr(image, "ImageInstanceID", None),
+            db=db_dims,
+            array=array_dims,
+            detail="; ".join(errors),
+        )
+
+
+def apply_dimensions(image: ImageInstance, array_dims: ImageDimensions) -> dict:
+    """Set instance dimensions from array dims. Returns before/after for audit.
+
+    Single-frame arrays store ``NrOfFrames=1`` (explicit convention).
+    """
+    before = {
+        "Rows_y": image.Rows_y,
+        "Columns_x": image.Columns_x,
+        "NrOfFrames": image.NrOfFrames,
+    }
+    image.Rows_y = array_dims.rows_y
+    image.Columns_x = array_dims.columns_x
+    image.NrOfFrames = effective_n_frames(array_dims.n_frames)
+    after = {
+        "Rows_y": image.Rows_y,
+        "Columns_x": image.Columns_x,
+        "NrOfFrames": image.NrOfFrames,
+    }
+    return {"old": before, "new": after}
+
+
+def blocking_dependents(image: ImageInstance) -> list[str]:
+    """Reasons repair must not overwrite dimensions (operator must clear first)."""
+    reasons: list[str] = []
+    segs = getattr(image, "Segmentations", None) or []
+    active = [s for s in segs if not getattr(s, "Inactive", False)]
+    if active:
+        reasons.append(f"{len(active)} segmentation(s)")
+    if getattr(image, "CFROI", None) is not None:
+        reasons.append("CFROI")
+    if getattr(image, "CFKeypoints", None) is not None:
+        reasons.append("CFKeypoints")
+    return reasons

--- a/orm/eyened_orm/image_instance.py
+++ b/orm/eyened_orm/image_instance.py
@@ -562,58 +562,28 @@ class ImageInstance(AttributeValueLookupMixin, Base):
             arr = sitk.GetArrayFromImage(img)
         return arr
 
-    @property
-    def pixel_array(self) -> np.ndarray:
-        array = None
+    def load_pixel_array(self) -> np.ndarray:
+        """Load pixel data without validating or mutating DB dimensions."""
         format = self.primary_storage.Format
         if format == "dicom":
-            array = self._load_dicom_array()
-        elif format == "binary":
-            array = self._load_binary_array()
-        elif format == "png_series":
-            array = self._load_png_series_array()
-        elif format == "mhd":
-            array = self._load_mhd_array()
-        else:
-            # assuming image format that PIL can handle
-            array = self._load_single_image_array()
-        self._update_image_dimensions(array)
-        return array
+            return self._load_dicom_array()
+        if format == "binary":
+            return self._load_binary_array()
+        if format == "png_series":
+            return self._load_png_series_array()
+        if format == "mhd":
+            return self._load_mhd_array()
+        # assuming image format that PIL can handle
+        return self._load_single_image_array()
 
-    def _update_image_dimensions(self, array: np.ndarray):
-        shape = array.shape
-        h = None
-        w = None
-        n_frames = None
-        if len(shape) == 2:
-            h, w = shape
-        elif len(shape) == 3:
-            if shape[2] > 4:
-                n_frames, h, w = shape
-            else:
-                h, w, _ = shape
-        else:
-            print(f"Invalid shape: {shape}")
-        if self.Rows_y is None:
-            self.Rows_y = h
-        else:
-            if self.Rows_y != h:
-                print(f"Rows_y mismatch: {self.Rows_y} != {h}")
-        if self.Columns_x is None:
-            self.Columns_x = w
-        else:
-            if self.Columns_x != w:
-                print(f"Columns_x mismatch: {self.Columns_x} != {w}")
-        if self.NrOfFrames is None:
-            self.NrOfFrames = n_frames
-        else:
-            if self.NrOfFrames != n_frames:
-                if n_frames is None and self.NrOfFrames == 1:
-                    # we don't really have a convention for how to set NrOfFrames for single-frame images 
-                    # e.g. for CFI or other 2D images, both None and 1 seem valid
-                    pass
-                else:
-                    print(f"NrOfFrames mismatch: {self.NrOfFrames} != {n_frames}")
+    @property
+    def pixel_array(self) -> np.ndarray:
+        """Load pixels and assert DB dimensions match. Never writes to the session."""
+        from eyened_orm.image_dimensions import assert_dimensions_match
+
+        array = self.load_pixel_array()
+        assert_dimensions_match(self, array)
+        return array
 
     @property
     def bounds(self) -> Optional[CFIBounds]:

--- a/orm/eyened_orm/tests/test_image_dimensions.py
+++ b/orm/eyened_orm/tests/test_image_dimensions.py
@@ -1,0 +1,192 @@
+"""Tests for image dimension validation and repair."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from eyened_orm import AuditLog, ImageInstance
+from eyened_orm.commands.repair_image_dimensions import (
+    TRUSTED_PATH,
+    repair_image_dimensions_for_ids,
+)
+from eyened_orm.image_dimensions import (
+    ImageDimensionMismatchError,
+    apply_dimensions,
+    assert_dimensions_match,
+    blocking_dependents,
+    dimensions_compatible,
+    dimensions_from_array,
+    effective_n_frames,
+)
+from eyened_orm.utils.factories import (
+    make_creator,
+    make_device,
+    make_feature,
+    make_image,
+    make_patient,
+    make_project,
+    make_segmentation,
+    make_series,
+    make_storage_backend,
+    make_study,
+)
+from eyened_orm.utils.sqlite_testdb import session  # noqa: F401
+
+
+@pytest.fixture
+def image_graph(session):
+    backend = make_storage_backend(session)
+    project = make_project(session, "dim-proj")
+    patient = make_patient(session, project, "P1")
+    study = make_study(session, patient, datetime(2024, 1, 1).date())
+    series = make_series(session, study)
+    device = make_device(session, "d1")
+    return session, series, device, backend
+
+
+def test_dimensions_from_array_layouts():
+    assert dimensions_from_array(np.zeros((10, 20))).shape_dhw == (1, 10, 20)
+    assert dimensions_from_array(np.zeros((10, 20, 3))).shape_dhw == (1, 10, 20)
+    assert dimensions_from_array(np.zeros((5, 10, 20))).shape_dhw == (5, 10, 20)
+
+
+def test_none_frames_compatible_with_one():
+    from eyened_orm.image_dimensions import ImageDimensions
+
+    db = ImageDimensions(n_frames=1, rows_y=10, columns_x=20)
+    arr = ImageDimensions(n_frames=None, rows_y=10, columns_x=20)
+    assert dimensions_compatible(db, arr) == []
+    assert effective_n_frames(None) == 1
+
+
+def test_assert_raises_on_mismatch_without_mutating(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-mismatch")
+    image.Rows_y = 10
+    image.Columns_x = 20
+    session.flush()
+    array = np.zeros((8, 9, 3), dtype=np.uint8)
+    before = (image.Rows_y, image.Columns_x, image.NrOfFrames)
+    with pytest.raises(ImageDimensionMismatchError, match="Rows_y"):
+        assert_dimensions_match(image, array)
+    assert (image.Rows_y, image.Columns_x, image.NrOfFrames) == before
+
+
+def test_assert_allows_unset_db_fields(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-unset")
+    image.Rows_y = None
+    image.Columns_x = None
+    image.NrOfFrames = None
+    session.flush()
+    assert_dimensions_match(image, np.zeros((8, 9), dtype=np.uint8))
+    assert image.Rows_y is None
+
+
+def test_blocking_dependents(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-block")
+    assert blocking_dependents(image) == []
+    image.CFROI = {"hw": [4, 4]}
+    assert "CFROI" in blocking_dependents(image)
+    image.CFROI = None
+    image.CFKeypoints = {"fovea_xy": [1, 2]}
+    assert "CFKeypoints" in blocking_dependents(image)
+    image.CFKeypoints = None
+    creator = make_creator(session, "c1")
+    feature = make_feature(session, "f1")
+    make_segmentation(session, image, feature, creator)
+    session.refresh(image)
+    assert any("segmentation" in r for r in blocking_dependents(image))
+
+
+def test_repair_fixes_and_audits(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-fix")
+    image.Rows_y = 10
+    image.Columns_x = 20
+    session.flush()
+    array = np.zeros((8, 9, 3), dtype=np.uint8)
+
+    with patch.object(ImageInstance, "load_pixel_array", return_value=array):
+        summary = repair_image_dimensions_for_ids(
+            session, [image.ImageInstanceID], dry_run=False
+        )
+
+    assert summary.fixed == 1
+    assert image.Rows_y == 8 and image.Columns_x == 9 and image.NrOfFrames == 1
+    row = session.query(AuditLog).one()
+    assert row.TrustedPath == TRUSTED_PATH
+    assert row.Action == "UPDATE"
+    assert row.Entity == "ImageInstance"
+    assert row.EntityID == str(image.ImageInstanceID)
+    assert row.Changes["old"]["Rows_y"] == 10
+    assert row.Changes["new"]["Rows_y"] == 8
+
+
+def test_repair_skips_ok(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-ok")
+    image.Rows_y = 8
+    image.Columns_x = 9
+    image.NrOfFrames = 1
+    session.flush()
+    array = np.zeros((8, 9, 3), dtype=np.uint8)
+    with patch.object(ImageInstance, "load_pixel_array", return_value=array):
+        summary = repair_image_dimensions_for_ids(
+            session, [image.ImageInstanceID], dry_run=False
+        )
+    assert summary.ok == 1
+    assert session.query(AuditLog).count() == 0
+
+
+def test_repair_blocks_with_segmentation(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-seg")
+    # Keep factory default 4x4 so segmentation consistency checks pass
+    creator = make_creator(session, "c2")
+    feature = make_feature(session, "f2")
+    make_segmentation(session, image, feature, creator)
+    session.expire(image, ["Segmentations"])
+    array = np.zeros((8, 9), dtype=np.uint8)
+    with patch.object(ImageInstance, "load_pixel_array", return_value=array):
+        summary = repair_image_dimensions_for_ids(
+            session, [image.ImageInstanceID], dry_run=False
+        )
+    assert summary.blocked == 1
+    assert image.Rows_y == 4
+    assert session.query(AuditLog).count() == 0
+
+
+def test_repair_dry_run_does_not_persist(image_graph):
+    session, series, device, backend = image_graph
+    image = make_image(session, series, device, backend, "img-dry")
+    image.Rows_y = 10
+    image.Columns_x = 20
+    session.flush()
+    array = np.zeros((8, 9), dtype=np.uint8)
+    with patch.object(ImageInstance, "load_pixel_array", return_value=array):
+        summary = repair_image_dimensions_for_ids(
+            session, [image.ImageInstanceID], dry_run=True
+        )
+    assert summary.fixed == 1
+    assert image.Rows_y == 10
+    assert session.query(AuditLog).count() == 0
+
+
+def test_apply_dimensions_sets_frames_to_one_for_2d():
+    class _Img:
+        Rows_y = 1
+        Columns_x = 1
+        NrOfFrames = None
+
+    img = _Img()
+    changes = apply_dimensions(
+        img, dimensions_from_array(np.zeros((4, 5)))
+    )
+    assert img.NrOfFrames == 1
+    assert changes["new"]["NrOfFrames"] == 1


### PR DESCRIPTION
## Summary
- **WIP / draft** — stopgap for DB dims vs on-disk pixels; not the final geometry model.
- `pixel_array` no longer writes dims; mismatches raise `ImageDimensionMismatchError`.
- `eorm repair-image-dimensions` (filtered targets, `--dry-run`, AuditLog) for backfill when dependents allow.
- Specs note this should later align with **#149** (axis metadata + resolutions) and fold into the **importer**.

Related: #149 (primary), #21, #110. Issue scan: `docs/superpowers/specs/2026-08-05-image-dimension-issues-scan.md`.

## Test plan
- [x] `pytest orm/eyened_orm/tests/test_image_dimensions.py`
- [ ] Manual dry-run on a small `--image-ids` set against a writable env
- [ ] Decide merge timing vs #149 / importer work before marking ready for review


Made with [Cursor](https://cursor.com)