### PR TITLE
make index 0 default path resolution

### DIFF
--- a/orm/eyened_orm/storage_access.py
+++ b/orm/eyened_orm/storage_access.py
@@ -25,7 +25,7 @@ class StorageRef:
 def resolve_image_data_ref(
     image_instance,
     *,
-    index: int | None = None,
+    index: int | None = 0,
     meta: bool = False,
 ) -> StorageRef:
     storage = image_instance.primary_storage


### PR DESCRIPTION
Fixes #190

Sets the index 0 as default instead of None. For PNG series this means the first slice is fetched by default, instead of failing when no arguments are given. For other datatypes there should be no effects. 