### PR TITLE
infer metadata from dicom -tested with heidelberg data

### DIFF
--- a/docs/src/content/docs/api/import.mdx
+++ b/docs/src/content/docs/api/import.mdx
@@ -7,6 +7,10 @@ sidebar:
 
 The API **registers** images that already exist on a storage backend — it does not upload file bytes. See **[Importing data](/eyened-platform/importing_data)**.
 
+::::note
+`POST /api/import/image` does **not** run DICOM header preparation (`read_dicom_header` / `link_oct_enface_series`). Supply PatientID, study date, modality, and series linking on the row yourself, or use the [ORM importer](/eyened-platform/orm/importer#row-preparation) with `PreparationOptions`.
+::::
+
 ### POST /api/import/image
 
 Import a single flat `ImportRow`.

--- a/docs/src/content/docs/import_metadata_fields.mdx
+++ b/docs/src/content/docs/import_metadata_fields.mdx
@@ -34,7 +34,7 @@ Each row is walked through the importer graph (`Project → Patient → Study �
 | Series | `series_instance_uid`, `series_id`, or `series_anonymous_identity` |
 | Device | `manufacturer` + `manufacturer_model_name` + `device_description`, or `device_model_id` / `device_id` |
 | Image file | `storage_backend_key` + `object_key` |
-| Image metadata | `modality` (required for the viewer; can be filled from DICOM when using [preparation](/eyened-platform/orm/importer#row-preparation)) |
+| Image metadata | `modality` (required for the viewer; can be partially filled from DICOM when using [preparation](/eyened-platform/orm/importer#row-preparation)) |
 
 **Patch an existing image** — provide `image_instance_id`, `public_id`, or `sop_instance_uid` plus only the fields you want to change.
 

--- a/docs/src/content/docs/import_metadata_fields.mdx
+++ b/docs/src/content/docs/import_metadata_fields.mdx
@@ -34,7 +34,7 @@ Each row is walked through the importer graph (`Project → Patient → Study �
 | Series | `series_instance_uid`, `series_id`, or `series_anonymous_identity` |
 | Device | `manufacturer` + `manufacturer_model_name` + `device_description`, or `device_model_id` / `device_id` |
 | Image file | `storage_backend_key` + `object_key` |
-| Image metadata | `modality` (required for the viewer) |
+| Image metadata | `modality` (required for the viewer; can be filled from DICOM when using [preparation](/eyened-platform/orm/importer#row-preparation)) |
 
 **Patch an existing image** — provide `image_instance_id`, `public_id`, or `sop_instance_uid` plus only the fields you want to change.
 
@@ -157,9 +157,19 @@ Files are referenced by storage backend + path within that backend (resolved via
 | `storage_backend_kind` | str | Property | Backend kind when **creating** a new backend |
 | `image_storage_id` | int | PK | Existing `ImageStorage` row |
 | `object_key` | str | Lookup | **Required for new images.** Path to the file within the backend (unique per backend) |
-| `image_storage_format` | str | Property | MIME or format string (`image/png`, `dicom`, …); often inferred from `object_key` during [preparation](/eyened-platform/orm/importer) |
+| `image_storage_format` | str | Property | MIME or format string (`image/png`, `dicom`, …); often inferred from `object_key` during [preparation](/eyened-platform/orm/importer#row-preparation) |
 | `image_storage_is_primary` | bool | Property | Whether this row is the primary storage location for the instance |
 | `image_storage_hash` | bytes | Property | SHA-256 digest (32 bytes) |
 | `image_storage_checksum` | str | Property | Checksum string (e.g. MD5 hex) |
+
+---
+
+## DICOM preparation (optional)
+
+With `PreparationOptions(read_dicom_header=True)` on the [ORM importer](/eyened-platform/orm/importer#row-preparation), missing fields above can be filled from the DICOM file at `storage_backend_key` + `object_key` (relative path under `EYENED_STORAGE_MOUNTS`). Explicit row/default values are never overwritten.
+
+Common auto-fills: `patient_identifier` ← `PatientID`, `study_date` ← `StudyDate`, `dicom_modality` / `modality` from DICOM `Modality` + `ImageType`, geometry and `resolution_*` (including OPT spacing from Shared Functional Groups `PixelMeasuresSequence`), series/SOP UIDs, laterality, acquisition datetime.
+
+`link_oct_enface_series=True` can rewrite enface `series_instance_uid` to match the linked OCT so both share one Series (Referenced SOP / FrameOfReferenceUID). See [OCT–enface series linking](/eyened-platform/orm/importer#octenface-series-linking).
 
 </div>

--- a/docs/src/content/docs/importing_data.mdx
+++ b/docs/src/content/docs/importing_data.mdx
@@ -26,7 +26,7 @@ Typical workflow:
 5. `run.apply()` then `session.commit()` — write to the database
 6. Optionally export the run to JSON for audit or undo
 
-Each row points to an image file via `storage_backend_key` and **relative** `object_key` within that backend. The file must already exist — import registers the path in the database; it does not copy or upload image bytes. Place files on the backend first (e.g. rsync to a local mount, or upload to S3 separately), then run the import. DICOM header reading uses `EYENED_STORAGE_MOUNTS[backend] / object_key` (or a custom `raw_loader`).
+Each row points to an image file via `storage_backend_key` and **relative** `object_key` within that backend. The file must already exist — import registers the path in the database; it does not copy or upload image bytes. Place files on the backend first, then run the import. DICOM header reading uses `EYENED_STORAGE_MOUNTS[backend] / object_key` (or a custom `raw_loader`).
 
 Full guide: **[ORM Importer](/eyened-platform/orm/importer)** (requires **[ORM setup](/eyened-platform/orm/getting_started)**).
 

--- a/docs/src/content/docs/importing_data.mdx
+++ b/docs/src/content/docs/importing_data.mdx
@@ -20,12 +20,13 @@ The **ORM importer** is the primary way to load data. Use it from Python or the 
 Typical workflow:
 
 1. Build `ImportRow` objects (or load from CSV)
-2. `plan_image_import(session, rows, ...)` — preview what will be created or matched
-3. `run.display_summary()` — review the plan
-4. `run.apply()` then `session.commit()` — write to the database
-5. Optionally export the run to JSON for audit or undo
+2. Optionally enable [row preparation](/eyened-platform/orm/importer#row-preparation) (`PreparationOptions`) — e.g. read DICOM headers for PatientID/StudyDate/modality/resolutions, or link OCT–enface into one series
+3. `plan_image_import(session, rows, ...)` — preview what will be created or matched
+4. `run.display_summary()` — review the plan
+5. `run.apply()` then `session.commit()` — write to the database
+6. Optionally export the run to JSON for audit or undo
 
-Each row points to an image file via `storage_backend_key` and `object_key`. The file must already exist on that backend — import registers the path in the database; it does not copy or upload image bytes. Place files on the backend first (e.g. rsync to a local mount, or upload to S3 separately), then run the import.
+Each row points to an image file via `storage_backend_key` and **relative** `object_key` within that backend. The file must already exist — import registers the path in the database; it does not copy or upload image bytes. Place files on the backend first (e.g. rsync to a local mount, or upload to S3 separately), then run the import. DICOM header reading uses `EYENED_STORAGE_MOUNTS[backend] / object_key` (or a custom `raw_loader`).
 
 Full guide: **[ORM Importer](/eyened-platform/orm/importer)** (requires **[ORM setup](/eyened-platform/orm/getting_started)**).
 

--- a/docs/src/content/docs/orm/importer.mdx
+++ b/docs/src/content/docs/orm/importer.mdx
@@ -12,6 +12,7 @@ The renewed ORM importer turns **flat rows** (`ImportRow`) into a consistent set
 At a high level:
 
 - Build a list of `ImportRow` objects (or load them from CSV)
+- Optionally enrich rows with [preparation](#row-preparation) (`PreparationOptions`: format inference, DICOM headers, OCT–enface series linking, hashes)
 - Plan the import with `plan_image_import(session, rows, ...)` (or `build_image_import_rows` + `plan_import`) to produce an `ImportRun`
 - Review the planned changes (`run.display_summary()` / `run.full_summary()`)
 - Apply the changes (`run.apply()`), then `session.commit()`
@@ -34,9 +35,9 @@ from eyened_orm.importer import plan_image_import, ImportRow
 
 defaults = {
     "project_external": "Y",
-    "manufacturer": "UNKOWN",
-    "manufacturer_model_name": "UNKOWN",
-    "device_description": "UNKOWN",
+    "manufacturer": "UNKNOWN",
+    "manufacturer_model_name": "UNKNOWN",
+    "device_description": "UNKNOWN",
     "dataset_identifier": "",  # deprecated, but required by schema
     "storage_backend_kind": "local",
 }
@@ -68,6 +69,76 @@ run.display_summary()  # human-friendly overview (HTML in notebooks)
 run.apply()
 session.commit()
 ```
+
+## Row preparation
+
+Before planning, `plan_image_import` / `build_image_import_rows` call `prepare_rows` to fill missing fields. Control this with `PreparationOptions` (pass as `options=` to those helpers).
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `infer_image_format` | `True` | Set `image_storage_format` from `object_key` (e.g. `.dcm` → `"dicom"`) |
+| `defaults` | `None` | Fill missing row fields from a dict |
+| `read_dicom_header` | `False` | Parse DICOM headers (no pixels) and merge missing ImportRow fields |
+| `link_oct_enface_series` | `False` | Co-locate OPT/OCT + enface under one `series_instance_uid` (needs header metadata) |
+| `read_image_header` | `False` | Read PNG/JPEG dimensions |
+| `compute_storage_hash` / `compute_storage_checksum` | `False` | SHA-256 / MD5 of file bytes |
+| `raw_loader` | `None` | Optional `Callable[[ImportRow], bytes \| None]` instead of storage mounts |
+
+**Merge rule:** preparation only fills fields that are still `None`. Values you set on the `ImportRow` (or in `defaults`) always win — for example an explicit `patient_identifier` overrides DICOM `PatientID`.
+
+**Reading files:** with `read_dicom_header` (or hashes), bytes are loaded via `EYENED_STORAGE_MOUNTS[storage_backend_key] / object_key`, or via `raw_loader`. Use a **relative** `object_key` under the mount (not an absolute path).
+
+```python
+from eyened_orm.importer import ImportRow, PreparationOptions, plan_image_import
+
+opts = PreparationOptions(
+    defaults=defaults,
+    infer_image_format=True,
+    read_dicom_header=True,
+    link_oct_enface_series=True,
+)
+run = plan_image_import(session, rows, options=opts)
+```
+
+### DICOM header fields
+
+When `read_dicom_header=True` and `image_storage_format == "dicom"`, `dicom_header_patches_from_bytes` may fill (among others):
+
+| DICOM source | ImportRow field |
+|--------------|-----------------|
+| `PatientID` | `patient_identifier` |
+| `StudyDate` | `study_date` |
+| `Modality` (+ heuristics) | `dicom_modality` and viewer `modality` |
+| `SOPInstanceUID` / `SOPClassUID` | `sop_instance_uid` / `sop_class_uid` |
+| `SeriesInstanceUID` / `StudyInstanceUID` / `SeriesNumber` | series fields |
+| `Rows` / `Columns` / `NumberOfFrames` | `height` / `width` / `depth` |
+| `PixelSpacing` / `SliceThickness` (top-level or Shared FG `PixelMeasuresSequence`) | `resolution_*` |
+| Laterality / acquisition datetime | `laterality` / `acquisition_date_time` |
+
+**Viewer modality heuristics** (Spectralis-oriented; leave `modality` unset when ambiguous):
+
+- `OPT` → `dicom_modality=OPT`, `modality=OCT` (OCTA is **not** auto-detected)
+- `OP` + `ImageType` containing `RED` → `InfraredReflectance`
+- `OP` + `ImageType` containing `AF` → `Autofluorescence`
+- `OP` without those subtypes → `dicom_modality=OP` only
+- Other DICOM modalities (e.g. `OT` device raw data) → neither modality field set; usually skip those files at row-building time
+
+Preparation logs **warnings** when OPT→OCT mapping is used, when OP has no viewer modality, or when series linking cannot run (see below).
+
+### OCT–enface series linking
+
+Some exports (notably Heidelberg) give each file its own `SeriesInstanceUID`, while OCT and the IR/AF localizer still belong together. They typically share `FrameOfReferenceUID`, and the OPT references the enface via `ReferencedImageSequence` / Ophthalmic Frame Location.
+
+With `link_oct_enface_series=True` (and `read_dicom_header=True` so that metadata is present), preparation:
+
+1. Finds OPT/OCT rows and their referenced enface SOP UIDs (FoR fallback if needed)
+2. Sets all members of each pair/group to the **OCT’s** `series_instance_uid`
+
+So they land in one `Series` for the viewer and for export localizer heuristics. Rows with an explicit `series_id` are left alone. Confirmed links still apply if `series_anonymous_identity` is set (otherwise distinct DICOM series UIDs would keep the pair apart).
+
+::::caution
+If `link_oct_enface_series=True` but headers are not read (`read_dicom_header=False`, unreadable mounts/`object_key`, or missing FoR/references), linking is a **no-op** and a warning is logged.
+::::
 
 ## Import from CSV
 
@@ -103,6 +174,8 @@ Primary keys take precedence when provided.
 When you don’t have a stable real-world identifier (for example no DICOM `series_instance_uid`), you can group rows **within the same import batch** using `*_anonymous_identity`.
 
 Rows with the same `series_anonymous_identity` will be grouped into the **same `Series`**.
+
+For DICOM OCT + enface that already have UIDs but should share a series, prefer [`link_oct_enface_series`](#octenface-series-linking) instead of inventing anonymous identities.
 
 ## Reviewing changes in detail
 
@@ -157,9 +230,10 @@ session.commit()
 - **Deduplication**: rows with the same lookup key are merged into one create + updates.
 - **Idempotency**: re-running the same import should not produce any changes.
 - **Primary-key precedence**: if `*_id` is provided, it wins over lookup keys (and allows renaming lookup fields).
+- **DICOM preparation**: PatientID/StudyDate/modality/resolutions and OCT–enface series linking (see tests in `orm/eyened_orm/importer/tests/test_preparation_dicom_and_hashes.py`).
 
 ::::note
 For a hands-on, runnable walkthrough, see the example notebook at
-`https://github.com/Eyened/eyened-platform/blob/main/orm/notebooks/importer_example.ipynb`.
+[`orm/notebooks/image_importer_tutorial.ipynb`](https://github.com/Eyened/eyened-platform/blob/main/orm/notebooks/image_importer_tutorial.ipynb).
+Task imports: [`orm/notebooks/task_importer_tutorial.ipynb`](https://github.com/Eyened/eyened-platform/blob/main/orm/notebooks/task_importer_tutorial.ipynb).
 ::::
-

--- a/orm/eyened_orm/importer/preparation/__init__.py
+++ b/orm/eyened_orm/importer/preparation/__init__.py
@@ -1,15 +1,19 @@
-from .dicom_meta import dicom_header_patches_from_bytes
+from .dicom_meta import LINK_META_KEYS, dicom_header_patches_from_bytes, strip_link_meta
 from .hashes import md5_hex, sha256_bytes
 from .io import infer_storage_format
 from .image_meta import raster_image_header_patches_from_bytes
 from .pipeline import PreparationOptions, prepare_rows
+from .series_link import link_oct_enface_series
 
 __all__ = [
+    "LINK_META_KEYS",
     "dicom_header_patches_from_bytes",
     "infer_storage_format",
+    "link_oct_enface_series",
     "md5_hex",
     "prepare_rows",
     "PreparationOptions",
     "raster_image_header_patches_from_bytes",
     "sha256_bytes",
+    "strip_link_meta",
 ]

--- a/orm/eyened_orm/importer/preparation/dicom_meta.py
+++ b/orm/eyened_orm/importer/preparation/dicom_meta.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import io
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 import pydicom
 from pydicom.valuerep import DA, TM
 
-from eyened_orm.image_instance import Laterality, ModalityType
+from eyened_orm.image_instance import Laterality, Modality, ModalityType
+
+# Keys used for OCT–enface linking; stripped before ImportRow validation.
+LINK_META_KEYS = frozenset(
+    {
+        "frame_of_reference_uid",
+        "referenced_sop_instance_uids",
+    }
+)
 
 
 def _str_or_none(val: Any) -> str | None:
@@ -38,6 +46,49 @@ def _dicom_modality(val: Any) -> ModalityType | None:
         return None
 
 
+def _image_type_tokens(ds: pydicom.dataset.FileDataset) -> set[str]:
+    raw = getattr(ds, "ImageType", None)
+    if raw is None:
+        return set()
+    # pydicom MultiValue is iterable but not a list/tuple
+    if isinstance(raw, str):
+        parts = raw.split("\\")
+    else:
+        try:
+            parts = [str(x) for x in raw]
+        except TypeError:
+            parts = str(raw).split("\\")
+    return {p.strip().upper() for p in parts if p and str(p).strip()}
+
+
+def _infer_modality(
+    dicom_modality: ModalityType | None, image_type: set[str]
+) -> Modality | None:
+    if dicom_modality is ModalityType.OPT:
+        return Modality.OCT
+    if dicom_modality is ModalityType.OP:
+        if "RED" in image_type:
+            return Modality.InfraredReflectance
+        if "AF" in image_type:
+            return Modality.Autofluorescence
+    return None
+
+
+def _parse_study_date(ds: pydicom.dataset.FileDataset) -> date | None:
+    d = getattr(ds, "StudyDate", None)
+    if not d:
+        return None
+    try:
+        if isinstance(d, DA):
+            return d
+        s = str(d).strip()
+        if len(s) >= 8:
+            return datetime.strptime(s[:8], "%Y%m%d").date()
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
 def _parse_acquisition_datetime(ds: pydicom.dataset.FileDataset) -> datetime | None:
     dt_val = getattr(ds, "AcquisitionDateTime", None)
     if dt_val:
@@ -64,14 +115,134 @@ def _parse_acquisition_datetime(ds: pydicom.dataset.FileDataset) -> datetime | N
         return None
 
 
+def _collect_referenced_sop_uids(ds: pydicom.dataset.FileDataset) -> list[str]:
+    """Collect ReferencedSOPInstanceUID values used to link OCT → enface."""
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _add(uid: Any) -> None:
+        s = _str_or_none(uid)
+        if s and s not in seen:
+            seen.add(s)
+            found.append(s)
+
+    def _from_seq(seq: Any) -> None:
+        if not seq:
+            return
+        for item in seq:
+            _add(getattr(item, "ReferencedSOPInstanceUID", None))
+            ofl = getattr(item, "OphthalmicFrameLocationSequence", None)
+            if ofl:
+                for loc in ofl:
+                    _add(getattr(loc, "ReferencedSOPInstanceUID", None))
+
+    _from_seq(getattr(ds, "ReferencedImageSequence", None))
+
+    shared = getattr(ds, "SharedFunctionalGroupsSequence", None)
+    if shared:
+        for fg in shared:
+            _from_seq(getattr(fg, "ReferencedImageSequence", None))
+
+    per_frame = getattr(ds, "PerFrameFunctionalGroupsSequence", None)
+    if per_frame:
+        # First frame is enough to identify the enface localizer.
+        _from_seq(getattr(per_frame[0], "OphthalmicFrameLocationSequence", None))
+        _from_seq(getattr(per_frame[0], "ReferencedImageSequence", None))
+
+    return found
+
+
+def strip_link_meta(state: dict[str, Any]) -> dict[str, Any]:
+    """Remove linker-only keys before ``ImportRow`` validation."""
+    return {k: v for k, v in state.items() if k not in LINK_META_KEYS}
+
+
+def _float_pair(val: Any) -> tuple[float, float] | None:
+    """Parse DICOM PixelSpacing-like values (MultiValue or backslash-separated)."""
+    if val is None:
+        return None
+    try:
+        if isinstance(val, str):
+            parts = [float(x) for x in val.split("\\") if x.strip()]
+        else:
+            parts = [float(x) for x in val]
+    except (TypeError, ValueError):
+        try:
+            parts = [float(x) for x in str(val).split("\\") if x.strip()]
+        except (TypeError, ValueError):
+            return None
+    if len(parts) < 2:
+        return None
+    return parts[0], parts[1]
+
+
+def _apply_pixel_spacing(out: dict[str, Any], spacing: Any) -> None:
+    """DICOM PixelSpacing is row\\col → resolution_vertical / resolution_horizontal."""
+    if out.get("resolution_horizontal") is not None and out.get("resolution_vertical") is not None:
+        return
+    pair = _float_pair(spacing)
+    if not pair:
+        return
+    row_spacing, col_spacing = pair
+    if out.get("resolution_vertical") is None:
+        out["resolution_vertical"] = row_spacing
+    if out.get("resolution_horizontal") is None:
+        out["resolution_horizontal"] = col_spacing
+
+
+def _apply_slice_thickness(out: dict[str, Any], thickness: Any) -> None:
+    if out.get("resolution_axial") is not None or thickness is None:
+        return
+    try:
+        out["resolution_axial"] = float(thickness)
+    except (TypeError, ValueError):
+        pass
+
+
+def _pixel_measures_from_functional_groups(
+    ds: pydicom.dataset.FileDataset,
+) -> tuple[Any, Any]:
+    """
+    Read PixelSpacing / SliceThickness from SharedFunctionalGroupsSequence
+    (common for Ophthalmic Tomography / multi-frame OPT).
+    """
+    spacing = None
+    thickness = None
+    shared = getattr(ds, "SharedFunctionalGroupsSequence", None)
+    if not shared:
+        return None, None
+    for fg in shared:
+        pm_seq = getattr(fg, "PixelMeasuresSequence", None)
+        if not pm_seq:
+            continue
+        pm = pm_seq[0]
+        if spacing is None:
+            spacing = getattr(pm, "PixelSpacing", None)
+        if thickness is None:
+            thickness = getattr(pm, "SliceThickness", None)
+        if spacing is not None and thickness is not None:
+            break
+    return spacing, thickness
+
+
 def dicom_header_patches_from_bytes(raw: bytes) -> dict[str, Any]:
     """
     Parse DICOM metadata without loading pixel data.
 
     Keys match ``ImportRow`` / ``InstancePOST`` field names where possible.
+    Also may include linker-only keys in ``LINK_META_KEYS``
+    (``frame_of_reference_uid``, ``referenced_sop_instance_uids``).
     """
     ds = pydicom.dcmread(io.BytesIO(raw), stop_before_pixels=True, force=True)
     out: dict[str, Any] = {}
+
+    pid = _str_or_none(getattr(ds, "PatientID", None))
+    if pid:
+        out["patient_identifier"] = pid
+
+    study_date = _parse_study_date(ds)
+    if study_date is not None:
+        out["study_date"] = study_date
 
     uid = _str_or_none(getattr(ds, "SOPInstanceUID", None))
     if uid:
@@ -83,6 +254,10 @@ def dicom_header_patches_from_bytes(raw: bytes) -> dict[str, Any]:
     dm = _dicom_modality(getattr(ds, "Modality", None))
     if dm is not None:
         out["dicom_modality"] = dm
+
+    modality = _infer_modality(dm, _image_type_tokens(ds))
+    if modality is not None:
+        out["modality"] = modality
 
     rows = getattr(ds, "Rows", None)
     cols = getattr(ds, "Columns", None)
@@ -141,21 +316,20 @@ def dicom_header_patches_from_bytes(raw: bytes) -> dict[str, Any]:
     if adt is not None:
         out["acquisition_date_time"] = adt
 
-    ps = getattr(ds, "PixelSpacing", None)
-    if ps is not None:
-        try:
-            parts = [float(x) for x in str(ps).split("\\") if x.strip()]
-            if len(parts) >= 2:
-                out["resolution_horizontal"] = parts[1]
-                out["resolution_vertical"] = parts[0]
-        except (TypeError, ValueError):
-            pass
+    _apply_pixel_spacing(out, getattr(ds, "PixelSpacing", None))
+    _apply_slice_thickness(out, getattr(ds, "SliceThickness", None))
 
-    st = getattr(ds, "SliceThickness", None)
-    if st is not None:
-        try:
-            out["resolution_axial"] = float(st)
-        except (TypeError, ValueError):
-            pass
+    # OPT volumes typically store measures in shared functional groups only
+    fg_spacing, fg_thickness = _pixel_measures_from_functional_groups(ds)
+    _apply_pixel_spacing(out, fg_spacing)
+    _apply_slice_thickness(out, fg_thickness)
+
+    for_uid = _str_or_none(getattr(ds, "FrameOfReferenceUID", None))
+    if for_uid:
+        out["frame_of_reference_uid"] = for_uid
+
+    refs = _collect_referenced_sop_uids(ds)
+    if refs:
+        out["referenced_sop_instance_uids"] = refs
 
     return out

--- a/orm/eyened_orm/importer/preparation/pipeline.py
+++ b/orm/eyened_orm/importer/preparation/pipeline.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Sequence
 
+from eyened_orm.image_instance import Modality, ModalityType
 from eyened_orm.importer.importer_dtos import ImportRow
 
 from . import steps
-from .dicom_meta import dicom_header_patches_from_bytes
+from .dicom_meta import dicom_header_patches_from_bytes, strip_link_meta
 from .hashes import md5_hex, sha256_bytes
 from .image_meta import raster_image_header_patches_from_bytes
+from .series_link import link_oct_enface_series
 from .storage_io import try_read_storage_object_bytes
+
+logger = logging.getLogger(__name__)
 
 
 def _merge_missing(state: dict[str, Any], patch: dict[str, Any]) -> None:
@@ -33,6 +38,7 @@ class PreparationOptions:
     defaults: Optional[dict[str, Any]] = None
     read_image_header: bool = False
     read_dicom_header: bool = False
+    link_oct_enface_series: bool = False
     compute_storage_hash: bool = False
     compute_storage_checksum: bool = False
     raw_loader: Optional[Callable[[ImportRow], bytes | None]] = None
@@ -48,12 +54,100 @@ def _needs_raw_bytes(opts: PreparationOptions) -> bool:
 
 
 def _load_raw_bytes(state: dict[str, Any], opts: PreparationOptions) -> bytes | None:
-    row = ImportRow.model_validate(state)
+    row = ImportRow.model_validate(strip_link_meta(state))
     if opts.raw_loader is not None:
         return opts.raw_loader(row)
     return try_read_storage_object_bytes(
         state.get("storage_backend_key"), state.get("object_key")
     )
+
+
+def _is_opt_dicom_modality(val: Any) -> bool:
+    return val is ModalityType.OPT or val == ModalityType.OPT.value
+
+
+def _is_op_dicom_modality(val: Any) -> bool:
+    return val is ModalityType.OP or val == ModalityType.OP.value
+
+
+def _warn_modality_heuristics(states: list[dict[str, Any]]) -> None:
+    """Warn about Spectralis-oriented OPT/OP → viewer-modality mapping limits."""
+    opt_as_oct = 0
+    op_without_viewer_modality = 0
+    for st in states:
+        if st.get("modality") is Modality.OCT and _is_opt_dicom_modality(
+            st.get("dicom_modality")
+        ):
+            opt_as_oct += 1
+        if _is_op_dicom_modality(st.get("dicom_modality")) and st.get("modality") is None:
+            op_without_viewer_modality += 1
+
+    if opt_as_oct:
+        logger.warning(
+            "Mapped %d DICOM OPT volume(s) to viewer modality OCT. "
+            "OCTA is not inferred automatically; set modality explicitly if needed.",
+            opt_as_oct,
+        )
+    if op_without_viewer_modality:
+        logger.warning(
+            "Left viewer modality unset for %d DICOM OP image(s) without a recognized "
+            "ImageType subtype (RED→InfraredReflectance, AF→Autofluorescence). "
+            "Set modality explicitly if needed.",
+            op_without_viewer_modality,
+        )
+
+
+def _warn_series_link_limitations(
+    opts: PreparationOptions,
+    states: list[dict[str, Any]],
+    *,
+    dicom_rows: int,
+    dicom_headers_read: int,
+    linked_groups: int,
+) -> None:
+    """Warn when OCT–enface series linking is enabled but likely ineffective."""
+    if not opts.read_dicom_header:
+        logger.warning(
+            "link_oct_enface_series=True but read_dicom_header=False; "
+            "linking needs DICOM FrameOfReferenceUID / ReferencedSOPInstanceUID "
+            "from header parsing and will be a no-op."
+        )
+        return
+
+    if dicom_rows and dicom_headers_read == 0:
+        logger.warning(
+            "link_oct_enface_series=True but no DICOM headers were read for %d "
+            "dicom row(s). Check EYENED_STORAGE_MOUNTS + relative object_key "
+            "(or pass PreparationOptions.raw_loader); series linking will be a no-op.",
+            dicom_rows,
+        )
+        return
+
+    if dicom_rows and dicom_headers_read < dicom_rows:
+        logger.warning(
+            "link_oct_enface_series=True but only %d/%d dicom row(s) had readable "
+            "headers; the rest could not be linked from DICOM metadata.",
+            dicom_headers_read,
+            dicom_rows,
+        )
+
+    if linked_groups == 0 and dicom_headers_read > 0:
+        has_oct = any(
+            _is_opt_dicom_modality(st.get("dicom_modality"))
+            or st.get("modality") is Modality.OCT
+            or st.get("modality") == Modality.OCT.value
+            for st in states
+        )
+        has_link_meta = any(
+            st.get("referenced_sop_instance_uids") or st.get("frame_of_reference_uid")
+            for st in states
+        )
+        if has_oct and not has_link_meta:
+            logger.warning(
+                "link_oct_enface_series=True but no FrameOfReferenceUID / "
+                "ReferencedSOPInstanceUID metadata was found on prepared rows; "
+                "OCT–enface series linking was a no-op."
+            )
 
 
 def prepare_rows(
@@ -72,6 +166,10 @@ def prepare_rows(
 
     Optional steps read bytes via ``EYENED_STORAGE_MOUNTS`` (``storage_backend_key`` +
     ``object_key``), or via ``PreparationOptions.raw_loader``.
+
+    When ``link_oct_enface_series`` is True (typically with ``read_dicom_header``),
+    OCT volumes and their referenced enface images are assigned a shared
+    ``series_instance_uid`` so they land in one Series.
     """
     if options is None:
         opts = PreparationOptions(
@@ -82,25 +180,35 @@ def prepare_rows(
         opts = options
 
     _defaults = opts.defaults or {}
-    prepared: list[ImportRow] = []
+    states: list[dict[str, Any]] = []
+    dicom_rows = 0
+    dicom_headers_read = 0
 
     for row in rows:
         state: dict[str, Any] = {**row.model_dump()}
 
         if opts.infer_image_format:
-            r = ImportRow.model_validate(state)
+            r = ImportRow.model_validate(strip_link_meta(state))
             _merge_missing(state, steps.step_infer_image_storage_format(r))
 
-        _merge_missing(state, steps.step_apply_defaults(ImportRow.model_validate(state), _defaults))
+        _merge_missing(
+            state,
+            steps.step_apply_defaults(
+                ImportRow.model_validate(strip_link_meta(state)), _defaults
+            ),
+        )
 
         raw: bytes | None = None
         if _needs_raw_bytes(opts):
             raw = _load_raw_bytes(state, opts)
 
         fmt = state.get("image_storage_format")
+        if fmt == "dicom":
+            dicom_rows += 1
 
         if opts.read_dicom_header and raw and fmt == "dicom":
             _merge_missing(state, dicom_header_patches_from_bytes(raw))
+            dicom_headers_read += 1
 
         if opts.read_image_header and raw and fmt in {"image/png", "image/jpeg"}:
             _merge_missing(state, raster_image_header_patches_from_bytes(raw))
@@ -117,6 +225,20 @@ def prepare_rows(
                 patch_c["image_storage_checksum"] = md5_hex(raw)
             _merge_missing(state, patch_c)
 
-        prepared.append(ImportRow.model_validate(state))
+        states.append(state)
 
-    return prepared
+    if opts.read_dicom_header:
+        _warn_modality_heuristics(states)
+
+    linked_groups = 0
+    if opts.link_oct_enface_series:
+        linked_groups = link_oct_enface_series(states)
+        _warn_series_link_limitations(
+            opts,
+            states,
+            dicom_rows=dicom_rows,
+            dicom_headers_read=dicom_headers_read,
+            linked_groups=linked_groups,
+        )
+
+    return [ImportRow.model_validate(strip_link_meta(s)) for s in states]

--- a/orm/eyened_orm/importer/preparation/series_link.py
+++ b/orm/eyened_orm/importer/preparation/series_link.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any
+
+from eyened_orm.image_instance import Modality, ModalityType
+
+
+def _is_oct_row(state: dict[str, Any]) -> bool:
+    dm = state.get("dicom_modality")
+    if dm is ModalityType.OPT or dm == ModalityType.OPT.value:
+        return True
+    modality = state.get("modality")
+    if modality is Modality.OCT or modality == Modality.OCT.value:
+        return True
+    if modality is Modality.OCTA or modality == Modality.OCTA.value:
+        return True
+    return False
+
+
+def _is_enface_candidate(state: dict[str, Any]) -> bool:
+    if _is_oct_row(state):
+        return False
+    dm = state.get("dicom_modality")
+    if dm is ModalityType.OP or dm == ModalityType.OP.value:
+        return True
+    modality = state.get("modality")
+    if modality is None:
+        return False
+    name = getattr(modality, "value", str(modality)).upper()
+    return any(tok in name for tok in ("INFRARED", "AUTOFLUORESCENCE", "FUNDUS", "REFLECTANCE"))
+
+
+def _protected_from_series_rewrite(state: dict[str, Any]) -> bool:
+    """Caller pinned an existing Series by PK; do not rewrite series_instance_uid."""
+    return state.get("series_id") is not None
+
+
+def link_oct_enface_series(states: list[dict[str, Any]]) -> int:
+    """
+    Co-locate each OPT/OCT volume with its enface localizer under one Series.
+
+    Mutates ``states`` in place: sets enface (and other group members')
+    ``series_instance_uid`` to the OCT row's ``series_instance_uid``.
+
+    Linking prefers ``referenced_sop_instance_uids`` on the OCT row; falls back
+    to shared ``frame_of_reference_uid`` among OCT + OP/enface candidates.
+
+    Confirmed links (Referenced SOP or shared FrameOfReferenceUID) are applied
+    even when ``series_anonymous_identity`` is set — otherwise distinct DICOM
+    SeriesInstanceUIDs would keep the pair in separate Series. Rows with an
+    explicit ``series_id`` are left alone.
+
+    Returns the number of OCT–enface groups whose ``series_instance_uid`` was
+    rewritten (0 if nothing changed).
+    """
+    by_sop: dict[str, list[int]] = {}
+    for i, st in enumerate(states):
+        sop = st.get("sop_instance_uid")
+        if sop:
+            by_sop.setdefault(str(sop), []).append(i)
+
+    groups: list[set[int]] = []
+    claimed: set[int] = set()
+
+    for i, st in enumerate(states):
+        if not _is_oct_row(st):
+            continue
+        if _protected_from_series_rewrite(st):
+            continue
+
+        members: set[int] = {i}
+        refs = st.get("referenced_sop_instance_uids") or []
+        for ref in refs:
+            for j in by_sop.get(str(ref), []):
+                if not _protected_from_series_rewrite(states[j]):
+                    members.add(j)
+
+        if len(members) == 1:
+            # FoR fallback: pair with enface candidates sharing FrameOfReferenceUID
+            for_uid = st.get("frame_of_reference_uid")
+            if for_uid:
+                for j, other in enumerate(states):
+                    if j == i or j in claimed:
+                        continue
+                    if _protected_from_series_rewrite(other):
+                        continue
+                    if other.get("frame_of_reference_uid") != for_uid:
+                        continue
+                    if _is_enface_candidate(other):
+                        members.add(j)
+
+        if len(members) < 2:
+            continue
+
+        target = st.get("series_instance_uid")
+        if target and all(
+            states[k].get("series_instance_uid") == target for k in members
+        ):
+            claimed.update(members)
+            continue
+
+        groups.append(members)
+        claimed.update(members)
+
+    rewritten = 0
+    for members in groups:
+        oct_indices = [k for k in members if _is_oct_row(states[k])]
+        target_uid = None
+        for k in oct_indices:
+            target_uid = states[k].get("series_instance_uid")
+            if target_uid:
+                break
+        if not target_uid:
+            for k in members:
+                target_uid = states[k].get("series_instance_uid")
+                if target_uid:
+                    break
+        if not target_uid:
+            continue
+
+        if all(states[k].get("series_instance_uid") == target_uid for k in members):
+            continue
+
+        for k in members:
+            if _protected_from_series_rewrite(states[k]):
+                continue
+            states[k]["series_instance_uid"] = target_uid
+        rewritten += 1
+
+    return rewritten

--- a/orm/eyened_orm/importer/tests/test_preparation_dicom_and_hashes.py
+++ b/orm/eyened_orm/importer/tests/test_preparation_dicom_and_hashes.py
@@ -1,28 +1,46 @@
 from __future__ import annotations
 
 import io
+from datetime import date
 
-from pydicom.dataset import FileDataset, FileMetaDataset
+import pytest
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
+from pydicom.sequence import Sequence
 from pydicom.uid import ExplicitVRLittleEndian
 
-from eyened_orm.image_instance import ModalityType
+from eyened_orm.image_instance import Modality, ModalityType
 from eyened_orm.importer.importer_dtos import ImportRow
 from eyened_orm.importer.preparation.dicom_meta import dicom_header_patches_from_bytes
 from eyened_orm.importer.preparation.hashes import md5_hex, sha256_bytes
 from eyened_orm.importer.preparation.pipeline import PreparationOptions, prepare_rows
 
 
-def _minimal_dicom_bytes() -> bytes:
+def _save_ds(ds: FileDataset) -> bytes:
+    buf = io.BytesIO()
+    ds.save_as(buf)
+    return buf.getvalue()
+
+
+def _base_file_dataset(
+    *,
+    sop_instance_uid: str,
+    sop_class_uid: str = "1.2.840.10008.5.1.4.1.1.7",
+) -> FileDataset:
     file_meta = FileMetaDataset()
     file_meta.FileMetaInformationVersion = b"\x00\x01"
-    file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.7"
-    file_meta.MediaStorageSOPInstanceUID = "1.2.3.4.5.6.7.8.9"
+    file_meta.MediaStorageSOPClassUID = sop_class_uid
+    file_meta.MediaStorageSOPInstanceUID = sop_instance_uid
     file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
     file_meta.ImplementationClassUID = "1.2.3.4.5"
 
     ds = FileDataset(None, {}, file_meta=file_meta, preamble=b"\0" * 128)
-    ds.SOPClassUID = file_meta.MediaStorageSOPClassUID
-    ds.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    ds.SOPClassUID = sop_class_uid
+    ds.SOPInstanceUID = sop_instance_uid
+    return ds
+
+
+def _minimal_dicom_bytes() -> bytes:
+    ds = _base_file_dataset(sop_instance_uid="1.2.3.4.5.6.7.8.9")
     ds.Modality = "OP"
     ds.Rows = 64
     ds.Columns = 128
@@ -31,10 +49,7 @@ def _minimal_dicom_bytes() -> bytes:
     ds.SeriesNumber = 3
     ds.SamplesPerPixel = 1
     ds.PhotometricInterpretation = "MONOCHROME2"
-
-    buf = io.BytesIO()
-    ds.save_as(buf)
-    return buf.getvalue()
+    return _save_ds(ds)
 
 
 def test_dicom_header_patches_from_bytes():
@@ -42,11 +57,122 @@ def test_dicom_header_patches_from_bytes():
     p = dicom_header_patches_from_bytes(raw)
     assert p["sop_instance_uid"] == "1.2.3.4.5.6.7.8.9"
     assert p["dicom_modality"] == ModalityType.OP
+    assert "modality" not in p  # OP without ImageType subtype
     assert p["height"] == 64
     assert p["width"] == 128
     assert p["series_instance_uid"] == "1.2.840.10008.1.2.3.4.5.6.1"
     assert p["study_instance_uid"] == "1.2.840.10008.1.2.3.4.5.6.2"
     assert p["series_number"] == 3
+
+
+def test_dicom_header_patient_study_and_modality_opt():
+    ds = _base_file_dataset(
+        sop_instance_uid="1.2.840.10008.1.2.3.opt",
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    ds.PatientID = "21715"
+    ds.StudyDate = "20250401"
+    ds.Modality = "OPT"
+    ds.ImageType = ["ORIGINAL", "PRIMARY"]
+    ds.NumberOfFrames = 37
+    ds.Rows = 496
+    ds.Columns = 512
+    ds.SeriesInstanceUID = "1.2.3.opt.series"
+    ds.StudyInstanceUID = "1.2.3.study"
+    ds.FrameOfReferenceUID = "1.2.3.for"
+    raw = _save_ds(ds)
+    p = dicom_header_patches_from_bytes(raw)
+    assert p["patient_identifier"] == "21715"
+    assert p["study_date"] == date(2025, 4, 1)
+    assert p["dicom_modality"] == ModalityType.OPT
+    assert p["modality"] == Modality.OCT
+    assert p["depth"] == 37
+    assert p["frame_of_reference_uid"] == "1.2.3.for"
+
+
+def test_dicom_header_modality_op_red_and_af():
+    for image_type, expected in (
+        (["ORIGINAL", "PRIMARY", "", "RED"], Modality.InfraredReflectance),
+        (["ORIGINAL", "PRIMARY", "", "AF"], Modality.Autofluorescence),
+    ):
+        ds = _base_file_dataset(sop_instance_uid=f"1.2.3.{image_type[-1]}")
+        ds.Modality = "OP"
+        ds.ImageType = image_type
+        ds.Rows = 768
+        ds.Columns = 768
+        ds.SeriesInstanceUID = "1.2.3.op.series"
+        p = dicom_header_patches_from_bytes(_save_ds(ds))
+        assert p["dicom_modality"] == ModalityType.OP
+        assert p["modality"] == expected
+
+
+def test_dicom_header_ot_skips_modality_fields():
+    ds = _base_file_dataset(sop_instance_uid="1.2.3.ot")
+    ds.PatientID = "P1"
+    ds.StudyDate = "20200101"
+    ds.Modality = "OT"
+    ds.SeriesInstanceUID = "1.2.3.ot.series"
+    p = dicom_header_patches_from_bytes(_save_ds(ds))
+    assert p["patient_identifier"] == "P1"
+    assert p["study_date"] == date(2020, 1, 1)
+    assert "dicom_modality" not in p
+    assert "modality" not in p
+
+
+def test_dicom_header_pixel_spacing_top_level():
+    ds = _base_file_dataset(sop_instance_uid="1.2.840.10008.1.2.3.op.ps")
+    ds.Modality = "OP"
+    ds.ImageType = ["ORIGINAL", "PRIMARY", "", "RED"]
+    ds.Rows = 768
+    ds.Columns = 768
+    ds.SeriesInstanceUID = "1.2.840.10008.1.2.3.op.ps.series"
+    ds.PixelSpacing = [0.021261, 0.021261]
+    p = dicom_header_patches_from_bytes(_save_ds(ds))
+    assert p["resolution_vertical"] == pytest.approx(0.021261)
+    assert p["resolution_horizontal"] == pytest.approx(0.021261)
+
+
+def test_dicom_header_pixel_measures_from_shared_functional_groups():
+    ds = _base_file_dataset(
+        sop_instance_uid="1.2.840.10008.1.2.3.opt.pm",
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    ds.Modality = "OPT"
+    ds.Rows = 496
+    ds.Columns = 512
+    ds.NumberOfFrames = 37
+    ds.SeriesInstanceUID = "1.2.840.10008.1.2.3.opt.pm.series"
+    pm = Dataset()
+    pm.PixelSpacing = [0.003872, 0.011891]
+    pm.SliceThickness = 0.125710
+    shared = Dataset()
+    shared.PixelMeasuresSequence = Sequence([pm])
+    ds.SharedFunctionalGroupsSequence = Sequence([shared])
+    p = dicom_header_patches_from_bytes(_save_ds(ds))
+    assert p["resolution_vertical"] == pytest.approx(0.003872)
+    assert p["resolution_horizontal"] == pytest.approx(0.011891)
+    assert p["resolution_axial"] == pytest.approx(0.125710)
+
+
+def test_dicom_header_referenced_sop_from_shared_fg():
+    enface_sop = "1.2.3.enface.sop"
+    ds = _base_file_dataset(
+        sop_instance_uid="1.2.3.opt.sop",
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    ds.Modality = "OPT"
+    ds.SeriesInstanceUID = "1.2.3.opt.series"
+    ds.FrameOfReferenceUID = "1.2.3.for"
+
+    ref_item = Dataset()
+    ref_item.ReferencedSOPClassUID = "1.2.840.10008.5.1.4.1.1.77.1.5.1"
+    ref_item.ReferencedSOPInstanceUID = enface_sop
+    shared = Dataset()
+    shared.ReferencedImageSequence = Sequence([ref_item])
+    ds.SharedFunctionalGroupsSequence = Sequence([shared])
+
+    p = dicom_header_patches_from_bytes(_save_ds(ds))
+    assert p["referenced_sop_instance_uids"] == [enface_sop]
 
 
 def test_prepare_rows_dicom_header_via_raw_loader():
@@ -72,6 +198,317 @@ def test_prepare_rows_dicom_header_via_raw_loader():
     assert out.sop_instance_uid == "1.2.3.4.5.6.7.8.9"
     assert out.width == 128
     assert out.height == 64
+
+
+def test_prepare_rows_fills_patient_study_modality_from_dicom():
+    ds = _base_file_dataset(
+        sop_instance_uid="1.2.3.opt",
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    ds.PatientID = "21715"
+    ds.StudyDate = "20250401"
+    ds.Modality = "OPT"
+    ds.SeriesInstanceUID = "1.2.3.series"
+    raw = _save_ds(ds)
+
+    def _loader(_row: ImportRow) -> bytes | None:
+        return raw
+
+    row = ImportRow(
+        project_name="p",
+        storage_backend_key="sb",
+        object_key="vol.dcm",
+        image_storage_format="dicom",
+    )
+    out = prepare_rows(
+        [row],
+        options=PreparationOptions(
+            infer_image_format=False,
+            read_dicom_header=True,
+            raw_loader=_loader,
+        ),
+    )[0]
+    assert out.patient_identifier == "21715"
+    assert out.study_date == date(2025, 4, 1)
+    assert out.dicom_modality == ModalityType.OPT
+    assert out.modality == Modality.OCT
+
+
+def test_prepare_rows_does_not_override_caller_patient_modality_series():
+    ds = _base_file_dataset(sop_instance_uid="1.2.3.opt")
+    ds.PatientID = "WRONG"
+    ds.StudyDate = "20200101"
+    ds.Modality = "OPT"
+    ds.SeriesInstanceUID = "1.2.3.from.dicom"
+    raw = _save_ds(ds)
+
+    def _loader(_row: ImportRow) -> bytes | None:
+        return raw
+
+    row = ImportRow(
+        project_name="p",
+        storage_backend_key="sb",
+        object_key="vol.dcm",
+        image_storage_format="dicom",
+        patient_identifier="RPE65014",
+        modality=Modality.OCTA,
+        series_instance_uid="1.2.3.caller",
+    )
+    out = prepare_rows(
+        [row],
+        options=PreparationOptions(
+            infer_image_format=False,
+            read_dicom_header=True,
+            raw_loader=_loader,
+        ),
+    )[0]
+    assert out.patient_identifier == "RPE65014"
+    assert out.modality == Modality.OCTA
+    assert out.series_instance_uid == "1.2.3.caller"
+    assert out.study_date == date(2020, 1, 1)  # still filled when missing
+
+
+def test_prepare_rows_link_oct_enface_via_referenced_sop():
+    enface_sop = "1.2.3.enface"
+    oct_sop = "1.2.3.oct"
+    oct_series = "1.2.3.oct.series"
+    enface_series = "1.2.3.enface.series"
+    for_uid = "1.2.3.for"
+
+    enface_ds = _base_file_dataset(
+        sop_instance_uid=enface_sop,
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.1",
+    )
+    enface_ds.Modality = "OP"
+    enface_ds.ImageType = ["ORIGINAL", "PRIMARY", "", "RED"]
+    enface_ds.SeriesInstanceUID = enface_series
+    enface_ds.FrameOfReferenceUID = for_uid
+    enface_ds.Rows = 768
+    enface_ds.Columns = 768
+    enface_raw = _save_ds(enface_ds)
+
+    oct_ds = _base_file_dataset(
+        sop_instance_uid=oct_sop,
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    oct_ds.Modality = "OPT"
+    oct_ds.SeriesInstanceUID = oct_series
+    oct_ds.FrameOfReferenceUID = for_uid
+    oct_ds.NumberOfFrames = 37
+    ref_item = Dataset()
+    ref_item.ReferencedSOPClassUID = "1.2.840.10008.5.1.4.1.1.77.1.5.1"
+    ref_item.ReferencedSOPInstanceUID = enface_sop
+    shared = Dataset()
+    shared.ReferencedImageSequence = Sequence([ref_item])
+    oct_ds.SharedFunctionalGroupsSequence = Sequence([shared])
+    oct_raw = _save_ds(oct_ds)
+
+    by_key = {"enface.dcm": enface_raw, "oct.dcm": oct_raw}
+
+    def _loader(row: ImportRow) -> bytes | None:
+        return by_key.get(row.object_key or "")
+
+    rows = [
+        ImportRow(
+            project_name="p",
+            storage_backend_key="sb",
+            object_key="enface.dcm",
+            image_storage_format="dicom",
+        ),
+        ImportRow(
+            project_name="p",
+            storage_backend_key="sb",
+            object_key="oct.dcm",
+            image_storage_format="dicom",
+        ),
+    ]
+    out = prepare_rows(
+        rows,
+        options=PreparationOptions(
+            infer_image_format=False,
+            read_dicom_header=True,
+            link_oct_enface_series=True,
+            raw_loader=_loader,
+        ),
+    )
+    assert out[0].sop_instance_uid == enface_sop
+    assert out[1].sop_instance_uid == oct_sop
+    assert out[0].series_instance_uid == oct_series
+    assert out[1].series_instance_uid == oct_series
+    assert out[0].modality == Modality.InfraredReflectance
+    assert out[1].modality == Modality.OCT
+
+
+def test_prepare_rows_link_oct_enface_via_frame_of_reference_fallback():
+    enface_sop = "1.2.3.enface.for"
+    oct_sop = "1.2.3.oct.for"
+    oct_series = "1.2.3.oct.series.for"
+    for_uid = "1.2.3.shared.for"
+
+    enface_ds = _base_file_dataset(sop_instance_uid=enface_sop)
+    enface_ds.Modality = "OP"
+    enface_ds.ImageType = ["ORIGINAL", "PRIMARY", "", "RED"]
+    enface_ds.SeriesInstanceUID = "1.2.3.enface.series.for"
+    enface_ds.FrameOfReferenceUID = for_uid
+    enface_raw = _save_ds(enface_ds)
+
+    oct_ds = _base_file_dataset(
+        sop_instance_uid=oct_sop,
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    oct_ds.Modality = "OPT"
+    oct_ds.SeriesInstanceUID = oct_series
+    oct_ds.FrameOfReferenceUID = for_uid
+    oct_raw = _save_ds(oct_ds)
+
+    by_key = {"e.dcm": enface_raw, "o.dcm": oct_raw}
+
+    def _loader(row: ImportRow) -> bytes | None:
+        return by_key.get(row.object_key or "")
+
+    out = prepare_rows(
+        [
+            ImportRow(
+                project_name="p",
+                storage_backend_key="sb",
+                object_key="e.dcm",
+                image_storage_format="dicom",
+            ),
+            ImportRow(
+                project_name="p",
+                storage_backend_key="sb",
+                object_key="o.dcm",
+                image_storage_format="dicom",
+            ),
+        ],
+        options=PreparationOptions(
+            infer_image_format=False,
+            read_dicom_header=True,
+            link_oct_enface_series=True,
+            raw_loader=_loader,
+        ),
+    )
+    assert out[0].series_instance_uid == oct_series
+    assert out[1].series_instance_uid == oct_series
+
+
+def test_prepare_rows_link_despite_series_anonymous_identity():
+    """FoR/ref-SOP confirmed pairs still share series_instance_uid even with anon id."""
+    enface_sop = "1.2.3.enface.anon"
+    oct_sop = "1.2.3.oct.anon"
+    oct_series = "1.2.3.oct.series.anon"
+    for_uid = "1.2.3.for.anon"
+
+    enface_ds = _base_file_dataset(sop_instance_uid=enface_sop)
+    enface_ds.Modality = "OP"
+    enface_ds.ImageType = ["ORIGINAL", "PRIMARY", "", "RED"]
+    enface_ds.SeriesInstanceUID = "1.2.3.enface.series.anon"
+    enface_ds.FrameOfReferenceUID = for_uid
+    enface_raw = _save_ds(enface_ds)
+
+    oct_ds = _base_file_dataset(sop_instance_uid=oct_sop)
+    oct_ds.Modality = "OPT"
+    oct_ds.SeriesInstanceUID = oct_series
+    oct_ds.FrameOfReferenceUID = for_uid
+    ref_item = Dataset()
+    ref_item.ReferencedSOPInstanceUID = enface_sop
+    shared = Dataset()
+    shared.ReferencedImageSequence = Sequence([ref_item])
+    oct_ds.SharedFunctionalGroupsSequence = Sequence([shared])
+    oct_raw = _save_ds(oct_ds)
+
+    by_key = {"e.dcm": enface_raw, "o.dcm": oct_raw}
+
+    def _loader(row: ImportRow) -> bytes | None:
+        return by_key.get(row.object_key or "")
+
+    out = prepare_rows(
+        [
+            ImportRow(
+                project_name="p",
+                storage_backend_key="sb",
+                object_key="e.dcm",
+                image_storage_format="dicom",
+                series_anonymous_identity=7,
+            ),
+            ImportRow(
+                project_name="p",
+                storage_backend_key="sb",
+                object_key="o.dcm",
+                image_storage_format="dicom",
+                series_anonymous_identity=7,
+            ),
+        ],
+        options=PreparationOptions(
+            infer_image_format=False,
+            read_dicom_header=True,
+            link_oct_enface_series=True,
+            raw_loader=_loader,
+        ),
+    )
+    assert out[0].series_instance_uid == oct_series
+    assert out[1].series_instance_uid == oct_series
+    assert out[0].series_anonymous_identity == 7
+    assert out[1].series_anonymous_identity == 7
+
+
+def test_prepare_rows_link_respects_explicit_series_id():
+    """Rows pinned to an existing series_id are not rewritten."""
+    enface_sop = "1.2.3.enface.sid"
+    oct_sop = "1.2.3.oct.sid"
+    for_uid = "1.2.3.for.sid"
+
+    enface_ds = _base_file_dataset(sop_instance_uid=enface_sop)
+    enface_ds.Modality = "OP"
+    enface_ds.ImageType = ["ORIGINAL", "PRIMARY", "", "RED"]
+    enface_ds.SeriesInstanceUID = "1.2.3.enface.series.sid"
+    enface_ds.FrameOfReferenceUID = for_uid
+    enface_raw = _save_ds(enface_ds)
+
+    oct_ds = _base_file_dataset(sop_instance_uid=oct_sop)
+    oct_ds.Modality = "OPT"
+    oct_ds.SeriesInstanceUID = "1.2.3.oct.series.sid"
+    oct_ds.FrameOfReferenceUID = for_uid
+    ref_item = Dataset()
+    ref_item.ReferencedSOPInstanceUID = enface_sop
+    shared = Dataset()
+    shared.ReferencedImageSequence = Sequence([ref_item])
+    oct_ds.SharedFunctionalGroupsSequence = Sequence([shared])
+    oct_raw = _save_ds(oct_ds)
+
+    by_key = {"e.dcm": enface_raw, "o.dcm": oct_raw}
+
+    def _loader(row: ImportRow) -> bytes | None:
+        return by_key.get(row.object_key or "")
+
+    out = prepare_rows(
+        [
+            ImportRow(
+                project_name="p",
+                storage_backend_key="sb",
+                object_key="e.dcm",
+                image_storage_format="dicom",
+                series_id=42,
+            ),
+            ImportRow(
+                project_name="p",
+                storage_backend_key="sb",
+                object_key="o.dcm",
+                image_storage_format="dicom",
+                series_id=42,
+            ),
+        ],
+        options=PreparationOptions(
+            infer_image_format=False,
+            read_dicom_header=True,
+            link_oct_enface_series=True,
+            raw_loader=_loader,
+        ),
+    )
+    assert out[0].series_instance_uid == "1.2.3.enface.series.sid"
+    assert out[1].series_instance_uid == "1.2.3.oct.series.sid"
+    assert out[0].series_id == 42
+    assert out[1].series_id == 42
 
 
 def test_prepare_rows_hashes_via_raw_loader():
@@ -118,3 +555,97 @@ def test_prepare_rows_does_not_override_existing_hash():
     )
     out = prepare_rows([row], options=opts)[0]
     assert out.image_storage_hash == existing
+
+
+def test_prepare_rows_warns_when_link_without_read_dicom_header(caplog):
+    row = ImportRow(
+        project_name="p",
+        storage_backend_key="sb",
+        object_key="x.dcm",
+        image_storage_format="dicom",
+    )
+    with caplog.at_level("WARNING", logger="eyened_orm.importer.preparation.pipeline"):
+        prepare_rows(
+            [row],
+            options=PreparationOptions(
+                infer_image_format=False,
+                read_dicom_header=False,
+                link_oct_enface_series=True,
+            ),
+        )
+    assert any("read_dicom_header=False" in r.message for r in caplog.records)
+
+
+def test_prepare_rows_warns_when_link_cannot_read_headers(caplog):
+    row = ImportRow(
+        project_name="p",
+        storage_backend_key="missing",
+        object_key="missing.dcm",
+        image_storage_format="dicom",
+    )
+    with caplog.at_level("WARNING", logger="eyened_orm.importer.preparation.pipeline"):
+        prepare_rows(
+            [row],
+            options=PreparationOptions(
+                infer_image_format=False,
+                read_dicom_header=True,
+                link_oct_enface_series=True,
+                raw_loader=lambda _r: None,
+            ),
+        )
+    assert any("no DICOM headers were read" in r.message for r in caplog.records)
+
+
+def test_prepare_rows_warns_opt_mapped_to_oct_not_octa(caplog):
+    ds = _base_file_dataset(
+        sop_instance_uid="1.2.840.10008.1.2.3.opt.warn",
+        sop_class_uid="1.2.840.10008.5.1.4.1.1.77.1.5.4",
+    )
+    ds.Modality = "OPT"
+    ds.SeriesInstanceUID = "1.2.840.10008.1.2.3.opt.warn.series"
+    raw = _save_ds(ds)
+
+    with caplog.at_level("WARNING", logger="eyened_orm.importer.preparation.pipeline"):
+        prepare_rows(
+            [
+                ImportRow(
+                    project_name="p",
+                    storage_backend_key="sb",
+                    object_key="opt.dcm",
+                    image_storage_format="dicom",
+                )
+            ],
+            options=PreparationOptions(
+                infer_image_format=False,
+                read_dicom_header=True,
+                raw_loader=lambda _r: raw,
+            ),
+        )
+    assert any("OCTA is not inferred" in r.message for r in caplog.records)
+
+
+def test_prepare_rows_warns_op_without_viewer_modality(caplog):
+    ds = _base_file_dataset(sop_instance_uid="1.2.840.10008.1.2.3.op.warn")
+    ds.Modality = "OP"
+    ds.Rows = 64
+    ds.Columns = 64
+    ds.SeriesInstanceUID = "1.2.840.10008.1.2.3.op.warn.series"
+    raw = _save_ds(ds)
+
+    with caplog.at_level("WARNING", logger="eyened_orm.importer.preparation.pipeline"):
+        prepare_rows(
+            [
+                ImportRow(
+                    project_name="p",
+                    storage_backend_key="sb",
+                    object_key="op.dcm",
+                    image_storage_format="dicom",
+                )
+            ],
+            options=PreparationOptions(
+                infer_image_format=False,
+                read_dicom_header=True,
+                raw_loader=lambda _r: raw,
+            ),
+        )
+    assert any("without a recognized ImageType subtype" in r.message for r in caplog.records)

--- a/orm/notebooks/task_importer_tutorial.ipynb
+++ b/orm/notebooks/task_importer_tutorial.ipynb
@@ -15,13 +15,13 @@
     "\n",
     "Entity chain (simplified):\n",
     "\n",
-    "`TaskDefinition` → `Task` (optional `Contact` / `Creator`) → `SubTask` (optional `Creator`) → `SubTaskImageLink` (`ImageInstanceID` is a plain FK — no `ImageInstance` entity in this graph).\n",
+    "`TaskDefinition` \u2192 `Task` (optional `Contact` / `Creator`) \u2192 `SubTask` (optional `Creator`) \u2192 `SubTaskImageLink` (`ImageInstanceID` is a plain FK \u2014 no `ImageInstance` entity in this graph).\n",
     "\n",
     "Typical workflow:\n",
     "\n",
     "1. Ensure target `ImageInstance` rows exist (e.g. import images with `ImportRow` + default `ENTITY_SPECS`).\n",
     "2. Build flat `ImportTaskRow` lists, or use `expand_task_import_rows` when many rows share the same task fields.\n",
-    "3. `plan_import(session, rows, entity_specs=TASK_ENTITY_SPECS)` → `ImportRun`.\n",
+    "3. `plan_import(session, rows, entity_specs=TASK_ENTITY_SPECS)` \u2192 `ImportRun`.\n",
     "4. Review (`run.display_summary()`), then `run.apply()` and `session.commit()`.\n",
     "\n",
     "Notes:\n",
@@ -224,7 +224,7 @@
    "source": [
     "## 2. Flat `ImportTaskRow` (one row = one `SubTaskImageLink`)\n",
     "\n",
-    "Repeat shared fields (`task_definition_name`, `task_name`, `creator_name`, …) on every row. Use the same `subtask_anonymous_identity` on rows that belong to the same logical subtask; increment `subtask_image_index` per image within that subtask."
+    "Repeat shared fields (`task_definition_name`, `task_name`, `creator_name`, \u2026) on every row. Use the same `subtask_anonymous_identity` on rows that belong to the same logical subtask; increment `subtask_image_index` per image within that subtask."
    ]
   },
   {
@@ -362,14 +362,14 @@
    "id": "9c353b89",
    "metadata": {},
    "source": [
-    "## 3. Grouped layout → `expand_task_import_rows`\n",
+    "## 3. Grouped layout \u2192 `expand_task_import_rows`\n",
     "\n",
-    "When one task shares many images across a few subtasks, use **one template row** plus a list of image-id **lists**. Each list is one anonymous subtask; `subtask_anonymous_identity` is set automatically to `1`, `2`, … in order.\n",
+    "When one task shares many images across a few subtasks, use **one template row** plus a list of image-id **lists**. Each list is one anonymous subtask; `subtask_anonymous_identity` is set automatically to `1`, `2`, \u2026 in order.\n",
     "\n",
     "Example (same task, two subtasks, overlapping images):\n",
     "\n",
-    "- First group: `[a, b, c]` → anonymous identity `1`\n",
-    "- Second group: `[a, d]` → anonymous identity `2`\n",
+    "- First group: `[a, b, c]` \u2192 anonymous identity `1`\n",
+    "- Second group: `[a, d]` \u2192 anonymous identity `2`\n",
     "\n",
     "That expands to five flat `ImportTaskRow` values with correct `subtask_image_index` within each group."
    ]
@@ -384,7 +384,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Expanded 2 groups → 5 flat rows\n",
+      "Expanded 2 groups \u2192 5 flat rows\n",
       "  anon= 1 img= 1 idx= 0\n",
       "  anon= 1 img= 2 idx= 1\n",
       "  anon= 1 img= 3 idx= 2\n",
@@ -486,7 +486,7 @@
     "image_groups = [[i0, i1, i2], [i0, i3]]\n",
     "\n",
     "expanded = expand_task_import_rows(template, image_groups)\n",
-    "print(f\"Expanded {len(image_groups)} groups → {len(expanded)} flat rows\")\n",
+    "print(f\"Expanded {len(image_groups)} groups \u2192 {len(expanded)} flat rows\")\n",
     "for r in expanded:\n",
     "    print(\n",
     "        \"  anon=\", r.subtask_anonymous_identity,\n",
@@ -559,8 +559,8 @@
    "source": [
     "## See also\n",
     "\n",
-    "- `importer_example.ipynb` — image / `ImportRow` pipeline, CSV, undo patterns.\n",
-    "- `eyened_orm/importer/tests/test_task_import_independent.py` and `test_task_import_expand.py` — minimal automated examples.\n",
+    "- `image_importer_tutorial.ipynb` \u2014 image / `ImportRow` pipeline, CSV, undo patterns.\n",
+    "- `eyened_orm/importer/tests/test_task_import_independent.py` and `test_task_import_expand.py` \u2014 minimal automated examples.\n",
     "- `ImportRun` (`display_summary`, `apply`, `write_json`, `undo`) works the same way for task runs."
    ]
   }


### PR DESCRIPTION
**Summary**
- Extend DICOM header preparation to auto-fill patient_identifier, study_date, both dicom_modality and viewer modality, and resolutions (including OPT PixelMeasures in shared functional groups).
- Add optional link_oct_enface_series preparation step so OPT volumes and their enface localizers share one series_instance_uid (Referenced SOP, with FrameOfReferenceUID fallback)—needed when each file has its own SeriesInstanceUID (e.g. Heidelberg exports).
- For now: emit warnings when series linking is a no-op (headers unread/unavailable) and when Spectralis-oriented modality heuristics apply (OPT→OCT only; OP without RED/AF left without viewer modality).
- Caller-supplied fields still win via merge-missing; explicit series_id is not rewritten.

**Test plan**
- [ ] pytest orm/eyened_orm/importer/tests/test_preparation_dicom_and_hashes.py
- [ ] Import a small Heidelberg OP+OPT batch with PreparationOptions(read_dicom_header=True, link_oct_enface_series=True) and relative object_keys under EYENED_STORAGE_MOUNTS
- [ ] Confirm OPT+IR share a Series in the viewer; resolutions populated on OP and OPT
- [ ] Confirm OT “Device Raw Data” is excluded by the importer notebook filter (or not imported)
- [ ] Confirm explicit patient_identifier / modality overrides are preserved
- [ ] Confirm warnings appear if linking is enabled without readable DICOM headers