### PR TITLE
Map enface projections onto registered images via GPU registration hops

### DIFF
--- a/client/src/lib/registration/RegistrationImportEffect.svelte
+++ b/client/src/lib/registration/RegistrationImportEffect.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import type { Registration } from "$lib/registration/registration.svelte";
+    import { AffineRegistration } from "$lib/registration/affine";
+    import { Matrix } from "$lib/matrix";
+
+    interface Props {
+        registration: Registration;
+        /** Stable identity — effect should run once per value, not loop on revision. */
+        trigger: number;
+        onRun?: () => void;
+    }
+
+    let { registration, trigger, onRun }: Props = $props();
+
+    // Mirrors RegistrationItemLoader: $effect imports into Registration.
+    // Before untrack-on-bump, revision++ subscribed this effect → infinite loop.
+    $effect(() => {
+        void trigger;
+        onRun?.();
+        registration.importRegistrationItems(
+            [new AffineRegistration("a", "b_proj", Matrix.identity)],
+            false,
+        );
+        registration.recomputePathsNow();
+    });
+</script>

--- a/client/src/lib/registration/RegistrationImportEffect.test.ts
+++ b/client/src/lib/registration/RegistrationImportEffect.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { Registration } from "./registration.svelte";
+import RegistrationImportEffect from "./RegistrationImportEffect.svelte";
+
+describe("Registration import from $effect", () => {
+    it("does not infinite-loop when bumping revision inside the effect", async () => {
+        const registration = new Registration();
+        const onRun = vi.fn();
+
+        render(RegistrationImportEffect, {
+            props: { registration, trigger: 1, onRun },
+        });
+        await tick();
+        await Promise.resolve(); // scheduled path recompute microtask
+
+        expect(onRun.mock.calls.length).toBe(1);
+        expect(registration.revision).toBeGreaterThan(0);
+    });
+});

--- a/client/src/lib/registration/affine.ts
+++ b/client/src/lib/registration/affine.ts
@@ -18,7 +18,7 @@ export class AffineRegistration implements RegistrationItem {
     }
 
     get glslMapping(): string {
-        return `vec2 mapping(vec2 uv) {
+        return `vec2 map_hop(vec2 uv) {
             mat3 transform = ${mat3(this.M)}
             vec3 transformedUV = transform * vec3(uv * u_size_primary.xy, 1.0);
             vec2 result = transformedUV.xy / transformedUV.z;

--- a/client/src/lib/registration/affine.ts
+++ b/client/src/lib/registration/affine.ts
@@ -32,11 +32,17 @@ export class AffineRegistration implements RegistrationItem {
     }
 }
 
+/**
+ * GLSL `mat3(...)` takes its arguments column by column, so the emitted order is
+ * the same column-major order as `Matrix.asUniform`. Deriving it from that getter
+ * keeps the shader path and the `uniformMatrix3fv` path from drifting apart.
+ */
 export function mat3(M: Matrix): string {
+    const [c0x, c0y, c0z, c1x, c1y, c1z, c2x, c2y, c2z] = M.asUniform;
     return `mat3(
-        ${f(M.d)}, ${f(M.e)}, ${f(M.f)},
-        ${f(M.a)}, ${f(M.b)}, ${f(M.c)},
-        ${f(M.g)}, ${f(M.h)}, ${f(M.i)}
+        ${f(c0x)}, ${f(c0y)}, ${f(c0z)},
+        ${f(c1x)}, ${f(c1y)}, ${f(c1z)},
+        ${f(c2x)}, ${f(c2y)}, ${f(c2z)}
     );`;
 }
 

--- a/client/src/lib/registration/affineGlsl.test.ts
+++ b/client/src/lib/registration/affineGlsl.test.ts
@@ -4,10 +4,55 @@ import { Matrix } from "$lib/matrix";
 import { composeGlslPath } from "./composeGlslPath";
 import { CompositeRegistration } from "./composite";
 
+/** Parse the nine floats out of an emitted `mat3(...)` literal. */
+function parseMat3(source: string): number[] {
+    const args = source
+        .replace(/^\s*mat3\(/, "")
+        .replace(/\)\s*;?\s*$/, "")
+        .split(",")
+        .map((part) => Number(part.trim()));
+    expect(args).toHaveLength(9);
+    expect(args.every((v) => Number.isFinite(v))).toBe(true);
+    return args;
+}
+
+/** Mimic GLSL `transform * vec3(x, y, 1)` for a column-major mat3 literal. */
+function applyGlslMat3(
+    args: number[],
+    point: { x: number; y: number },
+): { x: number; y: number } {
+    const [c0x, c0y, c0z, c1x, c1y, c1z, c2x, c2y, c2z] = args;
+    const x = c0x * point.x + c1x * point.y + c2x;
+    const y = c0y * point.x + c1y * point.y + c2y;
+    const w = c0z * point.x + c1z * point.y + c2z;
+    return { x: x / w, y: y / w };
+}
+
 describe("affine GLSL helpers", () => {
     it("emits integer floats with .0", () => {
         expect(f(2)).toBe("2.0");
         expect(f(2.5)).toBe("2.5");
+    });
+
+    it("emits mat3 in column-major order matching Matrix.apply", () => {
+        // Deliberately non-symmetric, with a non-trivial projective row.
+        const M = new Matrix(2, 0.5, 10, -0.25, 3, -7, 0.001, 0.002, 1);
+        const args = parseMat3(mat3(M));
+
+        expect(args).toEqual(M.asUniform);
+
+        for (const point of [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: 0, y: 1 },
+            { x: 13, y: -42 },
+            { x: 256.5, y: 128.25 },
+        ]) {
+            const expected = M.apply(point);
+            const actual = applyGlslMat3(args, point);
+            expect(actual.x).toBeCloseTo(expected.x, 10);
+            expect(actual.y).toBeCloseTo(expected.y, 10);
+        }
     });
 
     it("glslMapping uses map_hop and composes", () => {

--- a/client/src/lib/registration/affineGlsl.test.ts
+++ b/client/src/lib/registration/affineGlsl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { AffineRegistration, f, mat3 } from "./affine";
+import { Matrix } from "$lib/matrix";
+import { composeGlslPath } from "./composeGlslPath";
+
+describe("affine GLSL helpers", () => {
+    it("emits integer floats with .0", () => {
+        expect(f(2)).toBe("2.0");
+        expect(f(2.5)).toBe("2.5");
+    });
+
+    it("glslMapping uses map_hop and composes", () => {
+        const M = new Matrix(1, 0, 10, 0, 1, 20, 0, 0, 1);
+        const item = new AffineRegistration("a", "b", M);
+        expect(item.glslMapping).toContain("vec2 map_hop(vec2 uv)");
+        expect(item.glslMapping).not.toMatch(/vec2 mapping\s*\(/);
+        const composed = composeGlslPath([item.glslMapping]);
+        expect(composed).toContain("map_0");
+        expect(composed).toContain("u_size_primary");
+        expect(composed).toContain("u_size_secondary");
+        expect(composed).toContain(mat3(M).trim().split("\n")[0]);
+    });
+});

--- a/client/src/lib/registration/affineGlsl.test.ts
+++ b/client/src/lib/registration/affineGlsl.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { AffineRegistration, f, mat3 } from "./affine";
 import { Matrix } from "$lib/matrix";
 import { composeGlslPath } from "./composeGlslPath";
+import { CompositeRegistration } from "./composite";
 
 describe("affine GLSL helpers", () => {
     it("emits integer floats with .0", () => {
@@ -19,5 +20,25 @@ describe("affine GLSL helpers", () => {
         expect(composed).toContain("u_size_primary");
         expect(composed).toContain("u_size_secondary");
         expect(composed).toContain(mat3(M).trim().split("\n")[0]);
+    });
+
+    it("composes a composite registration without duplicate helpers", () => {
+        const first = new AffineRegistration(
+            "a",
+            "b",
+            new Matrix(1, 0, 10, 0, 1, 20, 0, 0, 1),
+        );
+        const second = new AffineRegistration(
+            "b",
+            "c",
+            new Matrix(2, 0, 0, 0, 2, 0, 0, 0, 1),
+        );
+        const composite = new CompositeRegistration("a", "c", [first, second]);
+
+        const composed = composeGlslPath([composite.glslMapping]);
+
+        expect(composed.match(/vec2\s+map_0\s*\(/g)).toHaveLength(1);
+        expect(composed.match(/vec2\s+map_1\s*\(/g)).toHaveLength(1);
+        expect(composed.match(/vec2\s+mapping\s*\(/g)).toHaveLength(1);
     });
 });

--- a/client/src/lib/registration/bakeHopGlsl.test.ts
+++ b/client/src/lib/registration/bakeHopGlsl.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { AffineRegistration } from "./affine";
+import { CompositeRegistration } from "./composite";
+import { ParabolicRegistration } from "./parabolic";
+import { bakeHopGlsl, bakeParabolicHop } from "./enfaceToProj";
+import { Matrix } from "$lib/matrix";
+import { composeGlslPath } from "./composeGlslPath";
+
+describe("bakeHopGlsl parabolic", () => {
+    it("bakes coefficients and sizes into map_hop", () => {
+        const glsl = bakeParabolicHop(
+            [0.1, 0, 1, 0, 0, 0, 0],
+            [0, 0.2, 0, 1, 0, 0, 0],
+            [200, 100],
+            [150, 80],
+        );
+        expect(glsl).toContain("vec2 map_hop(vec2 uv)");
+        expect(glsl).toContain("200.0");
+        expect(glsl).toContain("100.0");
+        expect(glsl).toContain("150.0");
+        expect(glsl).toContain("80.0");
+        expect(glsl).toContain("0.1");
+        expect(glsl).toContain("0.2");
+        expect(glsl).not.toContain("u_size_primary");
+        expect(glsl).not.toContain("u_size_secondary");
+    });
+
+    it("rejects malformed coefficient arrays", () => {
+        expect(
+            bakeParabolicHop([0, 0, 0], [0, 0, 0, 0, 0, 0, 0], [1, 1], [1, 1]),
+        ).toBeNull();
+    });
+
+    it("bakes ParabolicRegistration via bakeHopGlsl", () => {
+        const item = new ParabolicRegistration(
+            "a",
+            "b",
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        );
+        const hop = bakeHopGlsl(item, [10, 10], [20, 20]);
+        expect(hop).toContain("dx_val");
+        const composed = composeGlslPath([hop!]);
+        expect(composed).toContain("map_0");
+    });
+
+    it("bakes mixed affine+parabolic composites in pixel space", () => {
+        const composite = new CompositeRegistration("a", "b", [
+            new AffineRegistration("a", "mid", Matrix.identity),
+            new ParabolicRegistration(
+                "mid",
+                "b",
+                [0.5, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+            ),
+        ]);
+        const hop = bakeHopGlsl(composite, [100, 100], [50, 50]);
+        expect(hop).not.toBeNull();
+        expect(hop).toContain("mat3");
+        expect(hop).toContain("dx_val");
+        expect(hop).toContain("100.0");
+        expect(hop).toContain("50.0");
+    });
+});

--- a/client/src/lib/registration/composeGlslPath.test.ts
+++ b/client/src/lib/registration/composeGlslPath.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { composeGlslPath } from "./composeGlslPath";
+
+const hopA = `vec2 map_hop(vec2 uv) { return uv * 2.0; }`;
+const hopB = `vec2 map_hop(vec2 uv) { return uv + 0.1; }`;
+
+describe("composeGlslPath", () => {
+    it("returns identity mapping for empty hops", () => {
+        const src = composeGlslPath([]);
+        expect(src).toContain("vec2 mapping(vec2 uv)");
+        expect(src).toMatch(/return uv;/);
+        expect(src).not.toContain("map_0");
+    });
+
+    it("renames a single hop to map_0 and chains it", () => {
+        const src = composeGlslPath([hopA]);
+        expect(src).toContain("vec2 map_0(vec2 uv)");
+        expect(src).not.toContain("map_hop");
+        expect(src).toContain("uv = map_0(uv);");
+        expect(src).toContain("return uv;");
+    });
+
+    it("chains multiple hops in order", () => {
+        const src = composeGlslPath([hopA, hopB]);
+        expect(src).toContain("vec2 map_0(vec2 uv)");
+        expect(src).toContain("vec2 map_1(vec2 uv)");
+        const i0 = src.indexOf("uv = map_0(uv);");
+        const i1 = src.indexOf("uv = map_1(uv);");
+        expect(i0).toBeGreaterThan(-1);
+        expect(i1).toBeGreaterThan(i0);
+    });
+
+    it("skips empty hop strings", () => {
+        const src = composeGlslPath(["", hopA, "  "]);
+        expect(src).toContain("map_0");
+        expect(src).not.toContain("map_1");
+    });
+
+    it("throws if a non-empty hop lacks map_hop", () => {
+        expect(() =>
+            composeGlslPath([`vec2 mapping(vec2 uv) { return uv; }`]),
+        ).toThrow(/map_hop/);
+    });
+});

--- a/client/src/lib/registration/composeGlslPath.ts
+++ b/client/src/lib/registration/composeGlslPath.ts
@@ -1,0 +1,35 @@
+const MAP_HOP_DECL = /vec2\s+map_hop\s*\(\s*vec2\s+uv\s*\)/g;
+
+/**
+ * Compose single-hop GLSL snippets into one mapping(uv) function.
+ * Each hop must declare `vec2 map_hop(vec2 uv)`.
+ */
+export function composeGlslPath(hops: string[]): string {
+    const renamed: string[] = [];
+    let count = 0;
+
+    for (const hop of hops) {
+        if (!hop.trim()) continue;
+        if (!/\bmap_hop\b/.test(hop)) {
+            throw new Error(
+                "composeGlslPath: hop must define vec2 map_hop(vec2 uv)",
+            );
+        }
+        renamed.push(
+            hop.replace(MAP_HOP_DECL, `vec2 map_${count}(vec2 uv)`),
+        );
+        count++;
+    }
+
+    if (count === 0) {
+        return `vec2 mapping(vec2 uv) { return uv; }`;
+    }
+
+    let mapping = `vec2 mapping(vec2 uv) {\n`;
+    for (let i = 0; i < count; i++) {
+        mapping += `  uv = map_${i}(uv);\n`;
+    }
+    mapping += `  return uv;\n}`;
+
+    return `${renamed.join("\n")}\n${mapping}`;
+}

--- a/client/src/lib/registration/composeGlslPath.ts
+++ b/client/src/lib/registration/composeGlslPath.ts
@@ -1,33 +1,44 @@
 const MAP_HOP_DECL = /vec2\s+map_hop\s*\(\s*vec2\s+uv\s*\)/g;
+const NUMBERED_MAP_DECL = /vec2\s+map_(\d+)\s*\(\s*vec2\s+uv\s*\)/g;
 
 /**
  * Compose single-hop GLSL snippets into one mapping(uv) function.
  * Each hop must declare `vec2 map_hop(vec2 uv)`.
  */
 export function composeGlslPath(hops: string[]): string {
+    const nonEmptyHops = hops.filter((hop) => hop.trim());
+    const reserved = new Set(
+        nonEmptyHops.flatMap((hop) =>
+            [...hop.matchAll(NUMBERED_MAP_DECL)].map((match) =>
+                Number(match[1]),
+            ),
+        ),
+    );
     const renamed: string[] = [];
-    let count = 0;
+    const helperNames: string[] = [];
+    let nextIndex = 0;
 
-    for (const hop of hops) {
-        if (!hop.trim()) continue;
+    for (const hop of nonEmptyHops) {
         if (!/\bmap_hop\b/.test(hop)) {
             throw new Error(
                 "composeGlslPath: hop must define vec2 map_hop(vec2 uv)",
             );
         }
-        renamed.push(
-            hop.replace(MAP_HOP_DECL, `vec2 map_${count}(vec2 uv)`),
-        );
-        count++;
+        while (reserved.has(nextIndex)) nextIndex++;
+        const helperName = `map_${nextIndex}`;
+        reserved.add(nextIndex);
+        nextIndex++;
+        renamed.push(hop.replace(MAP_HOP_DECL, `vec2 ${helperName}(vec2 uv)`));
+        helperNames.push(helperName);
     }
 
-    if (count === 0) {
+    if (helperNames.length === 0) {
         return `vec2 mapping(vec2 uv) { return uv; }`;
     }
 
     let mapping = `vec2 mapping(vec2 uv) {\n`;
-    for (let i = 0; i < count; i++) {
-        mapping += `  uv = map_${i}(uv);\n`;
+    for (const helperName of helperNames) {
+        mapping += `  uv = ${helperName}(uv);\n`;
     }
     mapping += `  return uv;\n}`;
 

--- a/client/src/lib/registration/composite.ts
+++ b/client/src/lib/registration/composite.ts
@@ -1,6 +1,8 @@
 import type { Position } from "$lib/types";
 import type { RegistrationItem } from "./registrationItem";
-import { composeGlslPath } from "./composeGlslPath";
+
+const MAP_HOP_DECL = /vec2\s+map_hop\s*\(\s*vec2\s+uv\s*\)/g;
+const NUMBERED_MAP_DECL = /vec2\s+map_(\d+)\s*\(\s*vec2\s+uv\s*\)/g;
 
 /**
  * CompositeRegistration is a class that represents a composite registration
@@ -29,16 +31,32 @@ export class CompositeRegistration implements RegistrationItem {
         const hops = this.transforms
             .map((t) => t.glslMapping)
             .filter((s) => s.trim().length > 0);
-        // CompositeRegistration still exposes a single mapping() for consumers
-        // that expect RegistrationItem.glslMapping to be composable as one hop.
-        // For multi-transform edges, bake the chain into one map_hop wrapper:
         if (hops.length === 0) return "";
-        const inner = composeGlslPath(hops);
-        // Re-wrap composed mapping() as map_hop for further composition:
-        return inner.replace(
-            /vec2\s+mapping\s*\(\s*vec2\s+uv\s*\)/,
-            "vec2 map_hop(vec2 uv)",
+
+        const reserved = new Set(
+            hops.flatMap((hop) =>
+                [...hop.matchAll(NUMBERED_MAP_DECL)].map((match) =>
+                    Number(match[1]),
+                ),
+            ),
         );
+        const helperNames: string[] = [];
+        let nextIndex = 0;
+        const helpers = hops.map((hop) => {
+            while (reserved.has(nextIndex)) nextIndex++;
+            const helperName = `map_${nextIndex}`;
+            reserved.add(nextIndex);
+            nextIndex++;
+            helperNames.push(helperName);
+            return hop.replace(MAP_HOP_DECL, `vec2 ${helperName}(vec2 uv)`);
+        });
+        let wrapper = "vec2 map_hop(vec2 uv) {\n";
+        for (const helperName of helperNames) {
+            wrapper += `  uv = ${helperName}(uv);\n`;
+        }
+        wrapper += "  return uv;\n}";
+
+        return `${helpers.join("\n")}\n${wrapper}`;
     }
 
     get inverse(): CompositeRegistration {

--- a/client/src/lib/registration/composite.ts
+++ b/client/src/lib/registration/composite.ts
@@ -1,5 +1,7 @@
 import type { Position } from "$lib/types";
 import type { RegistrationItem } from "./registrationItem";
+import { composeGlslPath } from "./composeGlslPath";
+
 /**
  * CompositeRegistration is a class that represents a composite registration
  * between two images. It is used to apply a series of transformations
@@ -24,20 +26,19 @@ export class CompositeRegistration implements RegistrationItem {
     }
 
     get glslMapping(): string {
-        let result = "";
-        let i = 0;
-        for (const transform of this.transforms) {
-            const subMapping = transform.glslMapping;
-            subMapping.replace(`vec2 mapping`, `vec2 mapping_${i}`);
-            result += subMapping;
-            i++;
-        }
-        result += `vec2 mapping(vec2 uv) {`;
-        for (let j = 0; j < i; j++) {
-            result += `uv = mapping_${j}(uv);`;
-        }
-        result += `return uv;}`;
-        return result;
+        const hops = this.transforms
+            .map((t) => t.glslMapping)
+            .filter((s) => s.trim().length > 0);
+        // CompositeRegistration still exposes a single mapping() for consumers
+        // that expect RegistrationItem.glslMapping to be composable as one hop.
+        // For multi-transform edges, bake the chain into one map_hop wrapper:
+        if (hops.length === 0) return "";
+        const inner = composeGlslPath(hops);
+        // Re-wrap composed mapping() as map_hop for further composition:
+        return inner.replace(
+            /vec2\s+mapping\s*\(\s*vec2\s+uv\s*\)/,
+            "vec2 map_hop(vec2 uv)",
+        );
     }
 
     get inverse(): CompositeRegistration {

--- a/client/src/lib/registration/enfaceToProj.test.ts
+++ b/client/src/lib/registration/enfaceToProj.test.ts
@@ -3,7 +3,7 @@ import {
     bakeEnfaceToProjHop,
     resolveRasterMaxMatchDistPx,
 } from "./enfaceToProj";
-import { LinePhotoLocator } from "./photoLocators";
+import { CirclePhotoLocator, LinePhotoLocator } from "./photoLocators";
 import { medianRasterLineSpacingPx } from "./photoLocatorHitSpec";
 
 function horiz(y: number, index: number) {
@@ -61,5 +61,25 @@ describe("bakeEnfaceToProjHop raster gate", () => {
         );
         expect(glsl).toBeTruthy();
         expect(glsl!).not.toContain("return vec2(-1.0)");
+    });
+});
+
+describe("bakeEnfaceToProjHop circular angle wrap", () => {
+    it("fract-wraps start_angle so circumferential UV stays in [0,1)", () => {
+        const ring = new CirclePhotoLocator(
+            "ir",
+            "oct",
+            { x: 50, y: 50 },
+            20,
+            Math.PI,
+            0,
+            100,
+        );
+        const glsl = bakeEnfaceToProjHop([ring], [200, 200], [100, 50], null);
+        expect(glsl).toBeTruthy();
+        expect(glsl!).toContain("fract(angle / TWO_PI)");
+        expect(glsl!).not.toContain(
+            "float r = angle / (2.0 * 3.141592653589793)",
+        );
     });
 });

--- a/client/src/lib/registration/enfaceToProj.test.ts
+++ b/client/src/lib/registration/enfaceToProj.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+    bakeEnfaceToProjHop,
+    resolveRasterMaxMatchDistPx,
+} from "./enfaceToProj";
+import { LinePhotoLocator } from "./photoLocators";
+import { medianRasterLineSpacingPx } from "./photoLocatorHitSpec";
+
+function horiz(y: number, index: number) {
+    return new LinePhotoLocator(
+        "ir",
+        "oct",
+        { x: 0, y },
+        { x: 100, y },
+        index,
+        100,
+    );
+}
+
+describe("medianRasterLineSpacingPx", () => {
+    it("returns median consecutive gap for parallel lines", () => {
+        // gaps 10, 10, 20 → median 10
+        const lines = [horiz(0, 0), horiz(10, 1), horiz(20, 2), horiz(40, 3)];
+        expect(medianRasterLineSpacingPx(lines)).toBeCloseTo(10);
+    });
+});
+
+describe("resolveRasterMaxMatchDistPx", () => {
+    it("prefers DICOM slice thickness converted via enface mm/px", () => {
+        const lines = [horiz(0, 0), horiz(10, 1)];
+        // 0.12 mm / 0.012 mm/px = 10 px
+        expect(resolveRasterMaxMatchDistPx(lines, 0.12, 0.012)).toBeCloseTo(10);
+    });
+
+    it("falls back to median line spacing when thickness missing", () => {
+        const lines = [horiz(0, 0), horiz(10, 1), horiz(20, 2)];
+        expect(resolveRasterMaxMatchDistPx(lines, null, null)).toBeCloseTo(10);
+    });
+});
+
+describe("bakeEnfaceToProjHop raster gate", () => {
+    it("keeps nearest-neighbor but rejects beyond maxMatchDistPx", () => {
+        const glsl = bakeEnfaceToProjHop(
+            [horiz(40, 0), horiz(50, 1)],
+            [200, 200],
+            [100, 50],
+            10,
+        );
+        expect(glsl).toBeTruthy();
+        expect(glsl!).toContain("bestDist");
+        expect(glsl!).toContain("if (bestDist > 10.0)");
+        expect(glsl!).toContain("return vec2(-1.0)");
+    });
+
+    it("omits gate when maxMatchDistPx is null", () => {
+        const glsl = bakeEnfaceToProjHop(
+            [horiz(40, 0), horiz(50, 1)],
+            [200, 200],
+            [100, 50],
+            null,
+        );
+        expect(glsl).toBeTruthy();
+        expect(glsl!).not.toContain("return vec2(-1.0)");
+    });
+});

--- a/client/src/lib/registration/enfaceToProj.ts
+++ b/client/src/lib/registration/enfaceToProj.ts
@@ -1,0 +1,229 @@
+import type { Position } from "$lib/types";
+import { f, mat3 } from "./affine";
+import { AffineRegistration } from "./affine";
+import { CompositeRegistration } from "./composite";
+import {
+    CirclePhotoLocator,
+    LinePhotoLocator,
+    type PhotoLocator,
+} from "./photoLocators";
+import type { RegistrationItem } from "./registrationItem";
+import { Matrix } from "$lib/matrix";
+
+/**
+ * Bake a single UV→UV hop with concrete pixel sizes.
+ * Multi-hop composition cannot share one u_size_primary/secondary pair.
+ */
+export function bakeHopGlsl(
+    item: RegistrationItem,
+    srcSize: [number, number],
+    dstSize: [number, number],
+): string | null {
+    if (item instanceof AffineRegistration) {
+        return bakeAffineHop(item.M, srcSize, dstSize);
+    }
+    if (item instanceof CompositeRegistration) {
+        return bakeCompositeHop(item, srcSize, dstSize);
+    }
+    if (item instanceof EnfaceToProjPhotolocations) {
+        return bakeEnfaceToProjHop(item.photoLocators, srcSize, dstSize);
+    }
+    return null;
+}
+
+export function bakeAffineHop(
+    M: Matrix,
+    srcSize: [number, number],
+    dstSize: [number, number],
+): string {
+    return `vec2 map_hop(vec2 uv) {
+            mat3 transform = ${mat3(M)}
+            vec3 transformedUV = transform * vec3(uv * vec2(${f(srcSize[0])}, ${f(srcSize[1])}), 1.0);
+            vec2 result = transformedUV.xy / transformedUV.z;
+            return result / vec2(${f(dstSize[0])}, ${f(dstSize[1])});
+        }`;
+}
+
+function bakeCompositeHop(
+    item: CompositeRegistration,
+    srcSize: [number, number],
+    dstSize: [number, number],
+): string | null {
+    const affines = item.transforms.filter(
+        (t): t is AffineRegistration => t instanceof AffineRegistration,
+    );
+    if (affines.length === 0 || affines.length !== item.transforms.length) {
+        return null;
+    }
+    // CPU applies T0 then T1 … → combined = Tn * … * T0
+    let combined = affines[0].M;
+    for (let i = 1; i < affines.length; i++) {
+        combined = affines[i].M.multiply(combined);
+    }
+    return bakeAffineHop(combined, srcSize, dstSize);
+}
+
+/** Direct enface → `{oct}_proj` edge derived from photo locators (for GPU sampling). */
+export class EnfaceToProjPhotolocations implements RegistrationItem {
+    /** Sizes are baked at resolve time via bakeHopGlsl — leave empty here. */
+    glslMapping = "";
+
+    constructor(
+        public readonly source: string,
+        public readonly target: string,
+        public readonly photoLocators: PhotoLocator[],
+        public readonly projWidth: number,
+        public readonly projDepth: number,
+    ) {}
+
+    mapping(p: Position): Position | undefined {
+        let minDistance = Infinity;
+        let best: Position | undefined;
+        for (const locator of this.photoLocators) {
+            const { distance, position } = locator.enfaceToOCT(p);
+            if (distance < minDistance) {
+                minDistance = distance;
+                best = {
+                    x: position.x,
+                    y: position.index + 0.5,
+                    index: 0,
+                };
+            }
+        }
+        return best;
+    }
+
+    get inverse(): RegistrationItem {
+        return new ProjToEnfacePhotolocations(
+            this.target,
+            this.source,
+            this.photoLocators,
+            this.projWidth,
+            this.projDepth,
+        );
+    }
+}
+
+/** Inverse of EnfaceToProj — CPU only for graph completeness; no GLSL yet. */
+export class ProjToEnfacePhotolocations implements RegistrationItem {
+    glslMapping = "";
+
+    constructor(
+        public readonly source: string,
+        public readonly target: string,
+        public readonly photoLocators: PhotoLocator[],
+        public readonly projWidth: number,
+        public readonly projDepth: number,
+    ) {}
+
+    mapping(p: Position): Position | undefined {
+        const index = Math.round(
+            Math.max(0, Math.min(p.y, this.projDepth - 1)),
+        );
+        const locator = this.photoLocators.find((loc) => loc.index === index);
+        if (!locator) {
+            return undefined;
+        }
+        return locator.OCTToEnface({ x: p.x, y: 0, index });
+    }
+
+    get inverse(): RegistrationItem {
+        return new EnfaceToProjPhotolocations(
+            this.target,
+            this.source,
+            this.photoLocators,
+            this.projWidth,
+            this.projDepth,
+        );
+    }
+}
+
+export function bakeEnfaceToProjHop(
+    photoLocators: PhotoLocator[],
+    srcSize: [number, number],
+    dstSize: [number, number],
+): string | null {
+    if (!photoLocators.length) {
+        return null;
+    }
+
+    const blocks: string[] = [];
+    for (const loc of photoLocators) {
+        if (loc instanceof LinePhotoLocator) {
+            blocks.push(`{
+                vec2 start = vec2(${f(loc.start.x)}, ${f(loc.start.y)});
+                vec2 end = vec2(${f(loc.end.x)}, ${f(loc.end.y)});
+                vec2 lineVec = end - start;
+                float len = length(lineVec);
+                if (len > 1e-6) {
+                    vec2 ptVec = p - start;
+                    float parallel = dot(ptVec, lineVec) / len;
+                    float dist = abs(lineVec.x * ptVec.y - lineVec.y * ptVec.x) / len;
+                    float ox = ${f(loc.width)} * parallel / len;
+                    float oy = ${f(loc.index)} + 0.5;
+                    if (dist < bestDist) {
+                        bestDist = dist;
+                        best = vec2(ox, oy);
+                    }
+                }
+            }`);
+        } else if (loc instanceof CirclePhotoLocator) {
+            blocks.push(`{
+                vec2 center = vec2(${f(loc.center.x)}, ${f(loc.center.y)});
+                vec2 vecc = p - center;
+                float radius = ${f(loc.radius)};
+                float dist = abs(length(vecc) - radius);
+                float angle = atan(vecc.y, vecc.x) - ${f(loc.start_angle)};
+                float r = angle / (2.0 * 3.141592653589793);
+                float ox = ${f(loc.width)} * r;
+                float oy = ${f(loc.index)} + 0.5;
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    best = vec2(ox, oy);
+                }
+            }`);
+        }
+    }
+
+    if (!blocks.length) {
+        return null;
+    }
+
+    return `vec2 map_hop(vec2 uv) {
+            vec2 p = uv * vec2(${f(srcSize[0])}, ${f(srcSize[1])});
+            float bestDist = 1e20;
+            vec2 best = vec2(0.0);
+            ${blocks.join("\n")}
+            return best / vec2(${f(dstSize[0])}, ${f(dstSize[1])});
+        }`;
+}
+
+/** Build enface ↔ `_proj` edges for an OCT volume that has photo locators. */
+export function enfaceToProjRegistrationItems(
+    photoLocators: PhotoLocator[],
+    octPublicId: string,
+    projWidth: number,
+    projDepth: number,
+): RegistrationItem[] {
+    const projId = `${octPublicId}_proj`;
+    const byEnface = new Map<string, PhotoLocator[]>();
+    for (const loc of photoLocators) {
+        const list = byEnface.get(loc.enfaceImageId) ?? [];
+        list.push(loc);
+        byEnface.set(loc.enfaceImageId, list);
+    }
+
+    const items: RegistrationItem[] = [];
+    for (const [enfaceId, locs] of byEnface) {
+        items.push(
+            new EnfaceToProjPhotolocations(
+                enfaceId,
+                projId,
+                locs,
+                projWidth,
+                projDepth,
+            ),
+        );
+    }
+    return items;
+}

--- a/client/src/lib/registration/enfaceToProj.ts
+++ b/client/src/lib/registration/enfaceToProj.ts
@@ -2,6 +2,7 @@ import type { Position } from "$lib/types";
 import { f, mat3 } from "./affine";
 import { AffineRegistration } from "./affine";
 import { CompositeRegistration } from "./composite";
+import { ParabolicRegistration } from "./parabolic";
 import {
     CirclePhotoLocator,
     LinePhotoLocator,
@@ -21,6 +22,9 @@ export function bakeHopGlsl(
 ): string | null {
     if (item instanceof AffineRegistration) {
         return bakeAffineHop(item.M, srcSize, dstSize);
+    }
+    if (item instanceof ParabolicRegistration) {
+        return bakeParabolicHop(item.dx, item.dy, srcSize, dstSize);
     }
     if (item instanceof CompositeRegistration) {
         return bakeCompositeHop(item, srcSize, dstSize);
@@ -44,23 +48,86 @@ export function bakeAffineHop(
         }`;
 }
 
+/** Pixel-space displacement matching ParabolicRegistration.mapping. */
+function bakeParabolicPixelStep(dx: number[], dy: number[]): string | null {
+    if (dx.length !== 7 || dy.length !== 7) {
+        return null;
+    }
+    return `{
+                float x = p.x;
+                float y = p.y;
+                float dx_val = ${f(dx[0])} + ${f(dx[1])} + ${f(dx[2])} * x + ${f(dx[3])} * y + ${f(dx[4])} * x * x + ${f(dx[5])} * x * y + ${f(dx[6])} * y * y;
+                float dy_val = ${f(dy[0])} + ${f(dy[1])} + ${f(dy[2])} * x + ${f(dy[3])} * y + ${f(dy[4])} * x * x + ${f(dy[5])} * x * y + ${f(dy[6])} * y * y;
+                p = vec2(x - dx_val, y - dy_val);
+            }`;
+}
+
+export function bakeParabolicHop(
+    dx: number[],
+    dy: number[],
+    srcSize: [number, number],
+    dstSize: [number, number],
+): string | null {
+    const step = bakeParabolicPixelStep(dx, dy);
+    if (!step) {
+        return null;
+    }
+    return `vec2 map_hop(vec2 uv) {
+            vec2 p = uv * vec2(${f(srcSize[0])}, ${f(srcSize[1])});
+            ${step}
+            return p / vec2(${f(dstSize[0])}, ${f(dstSize[1])});
+        }`;
+}
+
+function bakeAffinePixelStep(M: Matrix): string {
+    return `{
+                mat3 transform = ${mat3(M)}
+                vec3 tp = transform * vec3(p, 1.0);
+                p = tp.xy / tp.z;
+            }`;
+}
+
 function bakeCompositeHop(
     item: CompositeRegistration,
     srcSize: [number, number],
     dstSize: [number, number],
 ): string | null {
+    if (item.transforms.length === 0) {
+        return null;
+    }
+
     const affines = item.transforms.filter(
         (t): t is AffineRegistration => t instanceof AffineRegistration,
     );
-    if (affines.length === 0 || affines.length !== item.transforms.length) {
-        return null;
+    if (affines.length === item.transforms.length) {
+        // CPU applies T0 then T1 … → combined = Tn * … * T0
+        let combined = affines[0].M;
+        for (let i = 1; i < affines.length; i++) {
+            combined = affines[i].M.multiply(combined);
+        }
+        return bakeAffineHop(combined, srcSize, dstSize);
     }
-    // CPU applies T0 then T1 … → combined = Tn * … * T0
-    let combined = affines[0].M;
-    for (let i = 1; i < affines.length; i++) {
-        combined = affines[i].M.multiply(combined);
+
+    // Mixed affine/parabolic: same continuous pixel space as CompositeRegistration.mapping.
+    const steps: string[] = [];
+    for (const t of item.transforms) {
+        if (t instanceof AffineRegistration) {
+            steps.push(bakeAffinePixelStep(t.M));
+        } else if (t instanceof ParabolicRegistration) {
+            const step = bakeParabolicPixelStep(t.dx, t.dy);
+            if (!step) {
+                return null;
+            }
+            steps.push(step);
+        } else {
+            return null;
+        }
     }
-    return bakeAffineHop(combined, srcSize, dstSize);
+    return `vec2 map_hop(vec2 uv) {
+            vec2 p = uv * vec2(${f(srcSize[0])}, ${f(srcSize[1])});
+            ${steps.join("\n")}
+            return p / vec2(${f(dstSize[0])}, ${f(dstSize[1])});
+        }`;
 }
 
 /** Direct enface → `{oct}_proj` edge derived from photo locators (for GPU sampling). */

--- a/client/src/lib/registration/enfaceToProj.ts
+++ b/client/src/lib/registration/enfaceToProj.ts
@@ -10,6 +10,7 @@ import {
     type PhotoLocator,
 } from "./photoLocators";
 import {
+    medianCircularRadiusSpacingPx,
     medianRasterLineSpacingPx,
     rasterStackAxis,
 } from "./photoLocatorHitSpec";
@@ -293,13 +294,14 @@ export function bakeEnfaceToProjHop(
             }`);
         } else if (loc instanceof CirclePhotoLocator) {
             blocks.push(`{
+                const float TWO_PI = 6.283185307179586;
                 vec2 center = vec2(${f(loc.center.x)}, ${f(loc.center.y)});
                 vec2 vecc = p - center;
                 float radius = ${f(loc.radius)};
                 float dist = abs(length(vecc) - radius);
                 float angle = atan(vecc.y, vecc.x) - ${f(loc.start_angle)};
-                float r = angle / (2.0 * 3.141592653589793);
-                float ox = ${f(loc.width)} * r;
+                float t = fract(angle / TWO_PI);
+                float ox = ${f(loc.width)} * t;
                 float oy = ${f(loc.index)} + 0.5;
                 if (dist < bestDist) {
                     bestDist = dist;
@@ -351,16 +353,21 @@ export function enfaceToProjRegistrationItems(
         const lines = locs.filter(
             (l): l is LinePhotoLocator => l instanceof LinePhotoLocator,
         );
-        const hasCircles = locs.some((l) => l instanceof CirclePhotoLocator);
-        // Tiny step: gate raster-only families (no circles mixed in).
-        const maxMatchDistPx =
-            !hasCircles && lines.length >= 2
-                ? resolveRasterMaxMatchDistPx(
-                      lines,
-                      sliceThicknessMm,
-                      enfaceMmPerPxAlongStack(lines, instances.get(enfaceId)),
-                  )
-                : null;
+        const circles = locs.filter(
+            (l): l is CirclePhotoLocator => l instanceof CirclePhotoLocator,
+        );
+        let maxMatchDistPx: number | null = null;
+        if (circles.length === 0 && lines.length >= 2) {
+            maxMatchDistPx = resolveRasterMaxMatchDistPx(
+                lines,
+                sliceThicknessMm,
+                enfaceMmPerPxAlongStack(lines, instances.get(enfaceId)),
+            );
+        } else if (lines.length === 0 && circles.length >= 2) {
+            // Concentric rings: median radius gap (same units as photolocator px).
+            maxMatchDistPx = medianCircularRadiusSpacingPx(circles);
+        }
+        // Single circle / mixed: ungated nearest (circle angle uses fract below).
         items.push(
             new EnfaceToProjPhotolocations(
                 enfaceId,

--- a/client/src/lib/registration/enfaceToProj.ts
+++ b/client/src/lib/registration/enfaceToProj.ts
@@ -1,4 +1,5 @@
 import type { Position } from "$lib/types";
+import type { ImageGET } from "../../types/openapi_types";
 import { f, mat3 } from "./affine";
 import { AffineRegistration } from "./affine";
 import { CompositeRegistration } from "./composite";
@@ -8,8 +9,13 @@ import {
     LinePhotoLocator,
     type PhotoLocator,
 } from "./photoLocators";
+import {
+    medianRasterLineSpacingPx,
+    rasterStackAxis,
+} from "./photoLocatorHitSpec";
 import type { RegistrationItem } from "./registrationItem";
 import { Matrix } from "$lib/matrix";
+import { instances } from "$lib/data/stores.svelte";
 
 /**
  * Bake a single UV→UV hop with concrete pixel sizes.
@@ -30,7 +36,12 @@ export function bakeHopGlsl(
         return bakeCompositeHop(item, srcSize, dstSize);
     }
     if (item instanceof EnfaceToProjPhotolocations) {
-        return bakeEnfaceToProjHop(item.photoLocators, srcSize, dstSize);
+        return bakeEnfaceToProjHop(
+            item.photoLocators,
+            srcSize,
+            dstSize,
+            item.maxMatchDistPx,
+        );
     }
     return null;
 }
@@ -141,6 +152,8 @@ export class EnfaceToProjPhotolocations implements RegistrationItem {
         public readonly photoLocators: PhotoLocator[],
         public readonly projWidth: number,
         public readonly projDepth: number,
+        /** Raster-only: max perpendicular match distance in enface px (null = ungated). */
+        public readonly maxMatchDistPx: number | null = null,
     ) {}
 
     mapping(p: Position): Position | undefined {
@@ -156,6 +169,13 @@ export class EnfaceToProjPhotolocations implements RegistrationItem {
                     index: 0,
                 };
             }
+        }
+        if (
+            best &&
+            this.maxMatchDistPx != null &&
+            minDistance > this.maxMatchDistPx
+        ) {
+            return undefined;
         }
         return best;
     }
@@ -201,14 +221,51 @@ export class ProjToEnfacePhotolocations implements RegistrationItem {
             this.photoLocators,
             this.projWidth,
             this.projDepth,
+            // Inverse does not use maxMatchDistPx; forward edge owns the gate.
         );
     }
+}
+
+/**
+ * Prefer DICOM SliceThickness (mm) converted via enface mm/px along the stack
+ * axis; otherwise median spacing between parallel raster lines (enface px).
+ */
+export function resolveRasterMaxMatchDistPx(
+    lines: LinePhotoLocator[],
+    sliceThicknessMm?: number | null,
+    enfaceMmPerPx?: number | null,
+): number | null {
+    if (
+        sliceThicknessMm != null &&
+        sliceThicknessMm > 0 &&
+        enfaceMmPerPx != null &&
+        enfaceMmPerPx > 0
+    ) {
+        return sliceThicknessMm / enfaceMmPerPx;
+    }
+    return medianRasterLineSpacingPx(lines);
+}
+
+function enfaceMmPerPxAlongStack(
+    lines: LinePhotoLocator[],
+    enface: ImageGET | undefined,
+): number | null {
+    if (!enface || lines.length < 2) {
+        return null;
+    }
+    const axis = rasterStackAxis(lines);
+    const r =
+        axis === "vertical"
+            ? enface.resolution_vertical
+            : enface.resolution_horizontal;
+    return r != null && r > 0 ? r : null;
 }
 
 export function bakeEnfaceToProjHop(
     photoLocators: PhotoLocator[],
     srcSize: [number, number],
     dstSize: [number, number],
+    maxMatchDistPx: number | null = null,
 ): string | null {
     if (!photoLocators.length) {
         return null;
@@ -256,12 +313,20 @@ export function bakeEnfaceToProjHop(
         return null;
     }
 
+    const gate =
+        maxMatchDistPx != null && maxMatchDistPx > 0
+            ? `if (bestDist > ${f(maxMatchDistPx)}) {
+                return vec2(-1.0);
+            }
+            `
+            : "";
+
     return `vec2 map_hop(vec2 uv) {
             vec2 p = uv * vec2(${f(srcSize[0])}, ${f(srcSize[1])});
             float bestDist = 1e20;
             vec2 best = vec2(0.0);
             ${blocks.join("\n")}
-            return best / vec2(${f(dstSize[0])}, ${f(dstSize[1])});
+            ${gate}return best / vec2(${f(dstSize[0])}, ${f(dstSize[1])});
         }`;
 }
 
@@ -271,6 +336,7 @@ export function enfaceToProjRegistrationItems(
     octPublicId: string,
     projWidth: number,
     projDepth: number,
+    sliceThicknessMm?: number | null,
 ): RegistrationItem[] {
     const projId = `${octPublicId}_proj`;
     const byEnface = new Map<string, PhotoLocator[]>();
@@ -282,6 +348,19 @@ export function enfaceToProjRegistrationItems(
 
     const items: RegistrationItem[] = [];
     for (const [enfaceId, locs] of byEnface) {
+        const lines = locs.filter(
+            (l): l is LinePhotoLocator => l instanceof LinePhotoLocator,
+        );
+        const hasCircles = locs.some((l) => l instanceof CirclePhotoLocator);
+        // Tiny step: gate raster-only families (no circles mixed in).
+        const maxMatchDistPx =
+            !hasCircles && lines.length >= 2
+                ? resolveRasterMaxMatchDistPx(
+                      lines,
+                      sliceThicknessMm,
+                      enfaceMmPerPxAlongStack(lines, instances.get(enfaceId)),
+                  )
+                : null;
         items.push(
             new EnfaceToProjPhotolocations(
                 enfaceId,
@@ -289,6 +368,7 @@ export function enfaceToProjRegistrationItems(
                 locs,
                 projWidth,
                 projDepth,
+                maxMatchDistPx,
             ),
         );
     }

--- a/client/src/lib/registration/parabolic.ts
+++ b/client/src/lib/registration/parabolic.ts
@@ -34,7 +34,7 @@ export class ParabolicRegistration implements RegistrationItem {
     }
 
     get glslMapping(): string {
-        return `vec2 mapping(vec2 uv) {
+        return `vec2 map_hop(vec2 uv) {
             vec2 coord = uv * u_size_primary.xy;
             float x = coord.x;
             float y = coord.y;

--- a/client/src/lib/registration/photoLocatorHitSpec.test.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { CirclePhotoLocator, LinePhotoLocator } from "./photoLocators";
-import { buildPhotoLocatorHitSpec } from "./photoLocatorHitSpec";
+import { buildPhotoLocatorHitSpec, medianRasterLineSpacingPx } from "./photoLocatorHitSpec";
 
 function horiz(y: number, index: number) {
     return new LinePhotoLocator(
@@ -17,6 +17,12 @@ describe("buildPhotoLocatorHitSpec raster", () => {
     it("classifies parallel horizontals as raster", () => {
         const spec = buildPhotoLocatorHitSpec([horiz(40, 0), horiz(50, 1)]);
         expect(spec.kind).toBe("raster");
+    });
+
+    it("returns median consecutive gap for parallel lines", () => {
+        // gaps 10, 10, 20 → median 10
+        const lines = [horiz(0, 0), horiz(10, 1), horiz(20, 2), horiz(40, 3)];
+        expect(medianRasterLineSpacingPx(lines)).toBeCloseTo(10);
     });
 
     it("hits midway with half-gap delta (5px for 10px spacing)", () => {

--- a/client/src/lib/registration/photoLocatorHitSpec.test.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.test.ts
@@ -46,3 +46,60 @@ describe("buildPhotoLocatorHitSpec raster", () => {
         expect(spec.query({ x: 50, y: 42 })).toBeUndefined();
     });
 });
+
+function ray(
+    angle: number,
+    index: number,
+    hub = { x: 50, y: 50 },
+    len = 40,
+) {
+    return new LinePhotoLocator(
+        "ir",
+        "oct",
+        hub,
+        {
+            x: hub.x + len * Math.cos(angle),
+            y: hub.y + len * Math.sin(angle),
+        },
+        index,
+        100,
+    );
+}
+
+describe("buildPhotoLocatorHitSpec radial", () => {
+    it("classifies a concurrent fan as radial", () => {
+        const spec = buildPhotoLocatorHitSpec([
+            ray(0, 0),
+            ray(Math.PI / 6, 1),
+            ray(Math.PI / 3, 2),
+        ]);
+        expect(spec.kind).toBe("radial");
+    });
+
+    it("misses outside the exterior half angular gap", () => {
+        const a0 = 0;
+        const a1 = Math.PI / 5;
+        const spec = buildPhotoLocatorHitSpec([ray(a0, 0), ray(a1, 1)]);
+        const hub = { x: 50, y: 50 };
+        const outside = {
+            x: hub.x + 30 * Math.cos(-a1),
+            y: hub.y + 30 * Math.sin(-a1),
+        };
+        expect(spec.query(outside)).toBeUndefined();
+    });
+
+    it("hits between rays within half angular gap", () => {
+        const a0 = 0;
+        const a1 = Math.PI / 5;
+        const spec = buildPhotoLocatorHitSpec([ray(a0, 0), ray(a1, 1)]);
+        const hub = { x: 50, y: 50 };
+        const midAng = a0 + (a1 - a0) * 0.25;
+        const p = {
+            x: hub.x + 30 * Math.cos(midAng),
+            y: hub.y + 30 * Math.sin(midAng),
+        };
+        const hit = spec.query(p);
+        expect(hit).toBeDefined();
+        expect(hit!.index).toBe(0);
+    });
+});

--- a/client/src/lib/registration/photoLocatorHitSpec.test.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { LinePhotoLocator } from "./photoLocators";
+import { CirclePhotoLocator, LinePhotoLocator } from "./photoLocators";
 import { buildPhotoLocatorHitSpec } from "./photoLocatorHitSpec";
 
 function horiz(y: number, index: number) {
@@ -101,5 +101,35 @@ describe("buildPhotoLocatorHitSpec radial", () => {
         const hit = spec.query(p);
         expect(hit).toBeDefined();
         expect(hit!.index).toBe(0);
+    });
+});
+
+function ring(radius: number, index: number, start = Math.PI) {
+    return new CirclePhotoLocator(
+        "ir",
+        "oct",
+        { x: 50, y: 50 },
+        radius,
+        start,
+        index,
+        100,
+    );
+}
+
+describe("buildPhotoLocatorHitSpec circular", () => {
+    it("hits full ring with start_angle=π via wrap", () => {
+        const spec = buildPhotoLocatorHitSpec([ring(20, 0), ring(30, 1)]);
+        // point at angle 0 (east): must map despite start_angle=π
+        const hit = spec.query({ x: 70, y: 50 });
+        expect(hit).toBeDefined();
+        expect(hit!.index).toBe(0);
+        expect(hit!.x).toBeGreaterThanOrEqual(0);
+        expect(hit!.x).toBeLessThanOrEqual(100);
+    });
+
+    it("uses half radius gap; misses outside outer ring half-gap", () => {
+        const spec = buildPhotoLocatorHitSpec([ring(20, 0), ring(30, 1)]);
+        expect(spec.query({ x: 50 + 24, y: 50 })?.index).toBe(0); // 4px out from r=20
+        expect(spec.query({ x: 50 + 36, y: 50 })).toBeUndefined(); // 6px out from r=30
     });
 });

--- a/client/src/lib/registration/photoLocatorHitSpec.test.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { LinePhotoLocator } from "./photoLocators";
+import { buildPhotoLocatorHitSpec } from "./photoLocatorHitSpec";
+
+function horiz(y: number, index: number) {
+    return new LinePhotoLocator(
+        "ir",
+        "oct",
+        { x: 0, y },
+        { x: 100, y },
+        index,
+        100,
+    );
+}
+
+describe("buildPhotoLocatorHitSpec raster", () => {
+    it("classifies parallel horizontals as raster", () => {
+        const spec = buildPhotoLocatorHitSpec([horiz(40, 0), horiz(50, 1)]);
+        expect(spec.kind).toBe("raster");
+    });
+
+    it("hits midway with half-gap delta (5px for 10px spacing)", () => {
+        const spec = buildPhotoLocatorHitSpec([horiz(40, 0), horiz(50, 1)]);
+        const mid = spec.query({ x: 50, y: 42 });
+        expect(mid).toBeDefined();
+        expect(mid!.index).toBe(0);
+        expect(mid!.delta).toBeCloseTo(5);
+        expect(mid!.y).toBeCloseTo(0.5);
+    });
+
+    it("misses beyond the exterior half-gap past first/last", () => {
+        const spec = buildPhotoLocatorHitSpec([horiz(40, 0), horiz(50, 1)]);
+        expect(spec.query({ x: 50, y: 34 })).toBeUndefined(); // 6px above first
+        expect(spec.query({ x: 50, y: 56 })).toBeUndefined(); // 6px below last
+    });
+
+    it("misses past segment ends", () => {
+        const spec = buildPhotoLocatorHitSpec([horiz(40, 0), horiz(50, 1)]);
+        expect(spec.query({ x: -10, y: 40 })).toBeUndefined();
+        expect(spec.query({ x: 110, y: 40 })).toBeUndefined();
+    });
+
+    it("singleton uses delta=1", () => {
+        const spec = buildPhotoLocatorHitSpec([horiz(40, 0)]);
+        expect(spec.query({ x: 50, y: 40.5 })?.index).toBe(0);
+        expect(spec.query({ x: 50, y: 42 })).toBeUndefined();
+    });
+});

--- a/client/src/lib/registration/photoLocatorHitSpec.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.ts
@@ -23,6 +23,87 @@ type RasterMember = {
     delta: number;
 };
 
+function lineUnit(l: LinePhotoLocator) {
+    const dx = l.end.x - l.start.x;
+    const dy = l.end.y - l.start.y;
+    const len = Math.hypot(dx, dy) || 1;
+    return { ux: dx / len, uy: dy / len, len };
+}
+
+/** Least-squares hub: point minimizing sum of squared distances to infinite lines. */
+function estimateHub(lines: LinePhotoLocator[]): { x: number; y: number } {
+    let a00 = 0,
+        a01 = 0,
+        a11 = 0,
+        b0 = 0,
+        b1 = 0;
+    for (const l of lines) {
+        const { ux, uy } = lineUnit(l);
+        const nx = -uy;
+        const ny = ux;
+        a00 += nx * nx;
+        a01 += nx * ny;
+        a11 += ny * ny;
+        const d = nx * l.start.x + ny * l.start.y;
+        b0 += nx * d;
+        b1 += ny * d;
+    }
+    const det = a00 * a11 - a01 * a01;
+    if (Math.abs(det) < 1e-8) {
+        let x = 0,
+            y = 0;
+        for (const l of lines) {
+            x += l.start.x;
+            y += l.start.y;
+        }
+        return { x: x / lines.length, y: y / lines.length };
+    }
+    return {
+        x: (a11 * b0 - a01 * b1) / det,
+        y: (-a01 * b0 + a00 * b1) / det,
+    };
+}
+
+function distPointToLine(p: { x: number; y: number }, l: LinePhotoLocator) {
+    const lx = l.end.x - l.start.x;
+    const ly = l.end.y - l.start.y;
+    const len = Math.hypot(lx, ly) || 1;
+    return Math.abs(lx * (p.y - l.start.y) - ly * (p.x - l.start.x)) / len;
+}
+
+function median(vals: number[]): number {
+    const s = [...vals].sort((a, b) => a - b);
+    const m = Math.floor(s.length / 2);
+    return s.length % 2 ? s[m] : 0.5 * (s[m - 1] + s[m]);
+}
+
+function wrapPi(a: number) {
+    while (a <= -Math.PI) a += 2 * Math.PI;
+    while (a > Math.PI) a -= 2 * Math.PI;
+    return a;
+}
+
+function classifyLines(lines: LinePhotoLocator[]): "raster" | "radial" {
+    if (lines.length < 2) return "raster";
+    const hub = estimateHub(lines);
+    const dists = lines.map((l) => distPointToLine(hub, l));
+    const lengths = lines.map((l) => lineUnit(l).len);
+    const hubOk = median(dists) < 0.15 * median(lengths);
+    const angles = lines.map((l) => {
+        const mx = (l.start.x + l.end.x) / 2 - hub.x;
+        const my = (l.start.y + l.end.y) / 2 - hub.y;
+        return Math.atan2(my, mx);
+    });
+    let maxSpan = 0;
+    for (let i = 0; i < angles.length; i++) {
+        for (let j = i + 1; j < angles.length; j++) {
+            maxSpan = Math.max(maxSpan, Math.abs(wrapPi(angles[i] - angles[j])));
+        }
+    }
+    const wideFan = maxSpan > (25 * Math.PI) / 180;
+    return hubOk && wideFan ? "radial" : "raster";
+}
+
 function meanNormal(lines: LinePhotoLocator[]): { nx: number; ny: number } {
     let nx = 0;
     let ny = 0;
@@ -90,6 +171,66 @@ function buildRasterFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
     };
 }
 
+function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
+    const hub = estimateHub(lines);
+    type M = { loc: LinePhotoLocator; angle: number; delta: number; charR: number };
+    const members: M[] = lines.map((loc) => {
+        const mx = (loc.start.x + loc.end.x) / 2 - hub.x;
+        const my = (loc.start.y + loc.end.y) / 2 - hub.y;
+        return {
+            loc,
+            angle: Math.atan2(my, mx),
+            delta: 1,
+            charR: Math.hypot(mx, my) || 1,
+        };
+    });
+    members.sort((a, b) => a.angle - b.angle);
+    const charR = median(members.map((m) => m.charR));
+    for (let i = 0; i < members.length; i++) {
+        const gaps: number[] = [];
+        if (i > 0) gaps.push(members[i].angle - members[i - 1].angle);
+        if (i < members.length - 1)
+            gaps.push(members[i + 1].angle - members[i].angle);
+        members[i].delta = gaps.length
+            ? Math.min(...gaps) / 2
+            : 1 / Math.max(charR, 1);
+    }
+
+    return {
+        kind: "radial",
+        query(p) {
+            const ang = Math.atan2(p.y - hub.y, p.x - hub.x);
+            const r = Math.hypot(p.x - hub.x, p.y - hub.y);
+            if (r < 1e-6) return undefined;
+            let best: HitSpecResult | undefined;
+            let bestScore = Infinity;
+            for (const m of members) {
+                const d = Math.abs(wrapPi(ang - m.angle));
+                if (d > m.delta) continue;
+                const { loc } = m;
+                const lx = loc.end.x - loc.start.x;
+                const ly = loc.end.y - loc.start.y;
+                const len = Math.hypot(lx, ly) || 1;
+                const parallel =
+                    ((p.x - loc.start.x) * lx + (p.y - loc.start.y) * ly) / len;
+                if (parallel < 0 || parallel > len) continue;
+                const score = d / m.delta;
+                if (score < bestScore || (score === bestScore && d < (best?.d ?? Infinity))) {
+                    bestScore = score;
+                    best = {
+                        x: (loc.width * parallel) / len,
+                        y: loc.index + 0.5,
+                        index: loc.index,
+                        d,
+                        delta: m.delta,
+                    };
+                }
+            }
+            return best;
+        },
+    };
+}
+
 /** Task 1: lines → raster only. Tasks 2–3 extend classification. */
 export function buildPhotoLocatorHitSpec(
     locators: PhotoLocator[],
@@ -107,5 +248,8 @@ export function buildPhotoLocatorHitSpec(
         return { kind: "raster", query: () => undefined };
     }
     // Task 2 replaces this with classifyLines(lines)
-    return buildRasterFamily(lines);
+    const pattern = classifyLines(lines);
+    return pattern === "radial"
+        ? buildRadialFamily(lines)
+        : buildRasterFamily(lines);
 }

--- a/client/src/lib/registration/photoLocatorHitSpec.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.ts
@@ -118,7 +118,7 @@ function meanNormal(lines: LinePhotoLocator[]): { nx: number; ny: number } {
     return { nx: nx / nlen, ny: ny / nlen };
 }
 
-function buildRasterFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
+function rasterMembers(lines: LinePhotoLocator[]): RasterMember[] {
     const { nx, ny } = meanNormal(lines);
     const members: RasterMember[] = lines.map((loc) => {
         const mx = (loc.start.x + loc.end.x) / 2;
@@ -133,7 +133,11 @@ function buildRasterFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
             gaps.push(members[i + 1].offset - members[i].offset);
         members[i].delta = gaps.length ? Math.min(...gaps) / 2 : 1;
     }
+    return members;
+}
 
+function buildRasterFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
+    const members = rasterMembers(lines);
     return {
         kind: "raster",
         query(p) {
@@ -171,10 +175,19 @@ function buildRasterFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
     };
 }
 
-function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
+type RadialMember = {
+    loc: LinePhotoLocator;
+    angle: number;
+    delta: number;
+    charR: number;
+};
+
+function radialMembers(lines: LinePhotoLocator[]): {
+    hub: { x: number; y: number };
+    members: RadialMember[];
+} {
     const hub = estimateHub(lines);
-    type M = { loc: LinePhotoLocator; angle: number; delta: number; charR: number };
-    const members: M[] = lines.map((loc) => {
+    const members: RadialMember[] = lines.map((loc) => {
         const mx = (loc.start.x + loc.end.x) / 2 - hub.x;
         const my = (loc.start.y + loc.end.y) / 2 - hub.y;
         return {
@@ -195,7 +208,11 @@ function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
             ? Math.min(...gaps) / 2
             : 1 / Math.max(charR, 1);
     }
+    return { hub, members };
+}
 
+function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
+    const { hub, members } = radialMembers(lines);
     return {
         kind: "radial",
         query(p) {
@@ -215,7 +232,10 @@ function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
                     ((p.x - loc.start.x) * lx + (p.y - loc.start.y) * ly) / len;
                 if (parallel < 0 || parallel > len) continue;
                 const score = d / m.delta;
-                if (score < bestScore || (score === bestScore && d < (best?.d ?? Infinity))) {
+                if (
+                    score < bestScore ||
+                    (score === bestScore && d < (best?.d ?? Infinity))
+                ) {
                     bestScore = score;
                     best = {
                         x: (loc.width * parallel) / len,
@@ -233,12 +253,10 @@ function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
 
 const CENTER_EPS = 2; // px
 
-function buildCircularFamily(
-    circles: CirclePhotoLocator[],
-): PhotoLocatorHitSpec {
-    const c = circles[0].center;
-    type M = { loc: CirclePhotoLocator; delta: number };
-    const members: M[] = [...circles]
+type CircularMember = { loc: CirclePhotoLocator; delta: number };
+
+function circularMembers(circles: CirclePhotoLocator[]): CircularMember[] {
+    const members: CircularMember[] = [...circles]
         .sort((a, b) => a.radius - b.radius)
         .map((loc) => ({ loc, delta: 1 }));
     for (let i = 0; i < members.length; i++) {
@@ -249,7 +267,14 @@ function buildCircularFamily(
             gaps.push(members[i + 1].loc.radius - members[i].loc.radius);
         members[i].delta = gaps.length ? Math.min(...gaps) / 2 : 1;
     }
+    return members;
+}
 
+function buildCircularFamily(
+    circles: CirclePhotoLocator[],
+): PhotoLocatorHitSpec {
+    const c = circles[0].center;
+    const members = circularMembers(circles);
     return {
         kind: "circular",
         query(p) {

--- a/client/src/lib/registration/photoLocatorHitSpec.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.ts
@@ -231,6 +231,104 @@ function buildRadialFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
     };
 }
 
+const CENTER_EPS = 2; // px
+
+function buildCircularFamily(
+    circles: CirclePhotoLocator[],
+): PhotoLocatorHitSpec {
+    const c = circles[0].center;
+    type M = { loc: CirclePhotoLocator; delta: number };
+    const members: M[] = [...circles]
+        .sort((a, b) => a.radius - b.radius)
+        .map((loc) => ({ loc, delta: 1 }));
+    for (let i = 0; i < members.length; i++) {
+        const gaps: number[] = [];
+        if (i > 0)
+            gaps.push(members[i].loc.radius - members[i - 1].loc.radius);
+        if (i < members.length - 1)
+            gaps.push(members[i + 1].loc.radius - members[i].loc.radius);
+        members[i].delta = gaps.length ? Math.min(...gaps) / 2 : 1;
+    }
+
+    return {
+        kind: "circular",
+        query(p) {
+            const dx = p.x - c.x;
+            const dy = p.y - c.y;
+            const rr = Math.hypot(dx, dy);
+            let best: HitSpecResult | undefined;
+            let bestScore = Infinity;
+            for (const m of members) {
+                const d = Math.abs(rr - m.loc.radius);
+                if (d > m.delta) continue;
+                let angle = Math.atan2(dy, dx) - m.loc.start_angle;
+                let t = angle / (2 * Math.PI);
+                t = t - Math.floor(t); // fract → [0,1)
+                const score = d / m.delta;
+                if (
+                    score < bestScore ||
+                    (score === bestScore && d < (best?.d ?? Infinity))
+                ) {
+                    bestScore = score;
+                    best = {
+                        x: m.loc.width * t,
+                        y: m.loc.index + 0.5,
+                        index: m.loc.index,
+                        d,
+                        delta: m.delta,
+                    };
+                }
+            }
+            return best;
+        },
+    };
+}
+
+function groupCirclesByCenter(
+    circles: CirclePhotoLocator[],
+): CirclePhotoLocator[][] {
+    const groups: CirclePhotoLocator[][] = [];
+    for (const cir of circles) {
+        let g = groups.find(
+            (grp) =>
+                Math.hypot(
+                    grp[0].center.x - cir.center.x,
+                    grp[0].center.y - cir.center.y,
+                ) < CENTER_EPS,
+        );
+        if (!g) {
+            g = [];
+            groups.push(g);
+        }
+        g.push(cir);
+    }
+    return groups;
+}
+
+function mergeSpecs(specs: PhotoLocatorHitSpec[]): PhotoLocatorHitSpec {
+    if (specs.length === 1) return specs[0];
+    return {
+        kind: "mixed",
+        query(p) {
+            let best: HitSpecResult | undefined;
+            let bestScore = Infinity;
+            for (const s of specs) {
+                const hit = s.query(p);
+                if (!hit) continue;
+                const score = hit.d / hit.delta;
+                if (
+                    score < bestScore ||
+                    (score === bestScore && hit.d < (best?.d ?? Infinity))
+                ) {
+                    bestScore = score;
+                    best = hit;
+                }
+            }
+            return best;
+        },
+    };
+}
+
 /** Task 1: lines → raster only. Tasks 2–3 extend classification. */
 export function buildPhotoLocatorHitSpec(
     locators: PhotoLocator[],
@@ -241,15 +339,19 @@ export function buildPhotoLocatorHitSpec(
     const circles = locators.filter(
         (l): l is CirclePhotoLocator => l instanceof CirclePhotoLocator,
     );
-    if (circles.length) {
-        throw new Error("circular families: implement in Task 3");
+    const specs: PhotoLocatorHitSpec[] = [];
+    if (lines.length) {
+        specs.push(
+            classifyLines(lines) === "radial"
+                ? buildRadialFamily(lines)
+                : buildRasterFamily(lines),
+        );
     }
-    if (!lines.length) {
+    for (const g of groupCirclesByCenter(circles)) {
+        specs.push(buildCircularFamily(g));
+    }
+    if (!specs.length) {
         return { kind: "raster", query: () => undefined };
     }
-    // Task 2 replaces this with classifyLines(lines)
-    const pattern = classifyLines(lines);
-    return pattern === "radial"
-        ? buildRadialFamily(lines)
-        : buildRasterFamily(lines);
+    return mergeSpecs(specs);
 }

--- a/client/src/lib/registration/photoLocatorHitSpec.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.ts
@@ -104,6 +104,40 @@ function classifyLines(lines: LinePhotoLocator[]): "raster" | "radial" {
     return hubOk && wideFan ? "radial" : "raster";
 }
 
+/**
+ * Median consecutive spacing (px) along the mean normal for roughly parallel lines.
+ * Null when lines are not parallel enough or fewer than 2.
+ */
+export function medianRasterLineSpacingPx(
+    lines: LinePhotoLocator[],
+): number | null {
+    if (lines.length < 2) {
+        return null;
+    }
+    const dirs = lines.map(lineUnit);
+    const ref = dirs[0];
+    const parallelEnough = dirs.every(
+        (d) => Math.abs(d.ux * ref.ux + d.uy * ref.uy) > 0.95,
+    );
+    if (!parallelEnough) {
+        return null;
+    }
+    const members = rasterMembers(lines);
+    const gaps: number[] = [];
+    for (let i = 1; i < members.length; i++) {
+        gaps.push(members[i].offset - members[i - 1].offset);
+    }
+    return gaps.length ? median(gaps) : null;
+}
+
+/** Unit normal of the mean line direction (for choosing enface axis resolution). */
+export function rasterStackAxis(
+    lines: LinePhotoLocator[],
+): "horizontal" | "vertical" {
+    const { nx, ny } = meanNormal(lines);
+    return Math.abs(ny) >= Math.abs(nx) ? "vertical" : "horizontal";
+}
+
 function meanNormal(lines: LinePhotoLocator[]): { nx: number; ny: number } {
     let nx = 0;
     let ny = 0;

--- a/client/src/lib/registration/photoLocatorHitSpec.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.ts
@@ -1,0 +1,111 @@
+import {
+    CirclePhotoLocator,
+    LinePhotoLocator,
+    type PhotoLocator,
+} from "./photoLocators";
+
+export type HitSpecResult = {
+    x: number;
+    y: number;
+    index: number;
+    d: number;
+    delta: number;
+};
+
+export type PhotoLocatorHitSpec = {
+    readonly kind: "raster" | "radial" | "circular" | "mixed";
+    query(p: { x: number; y: number }): HitSpecResult | undefined;
+};
+
+type RasterMember = {
+    loc: LinePhotoLocator;
+    offset: number; // signed along mean normal
+    delta: number;
+};
+
+function meanNormal(lines: LinePhotoLocator[]): { nx: number; ny: number } {
+    let nx = 0;
+    let ny = 0;
+    for (const l of lines) {
+        const dx = l.end.x - l.start.x;
+        const dy = l.end.y - l.start.y;
+        const len = Math.hypot(dx, dy) || 1;
+        nx += -dy / len;
+        ny += dx / len;
+    }
+    const nlen = Math.hypot(nx, ny) || 1;
+    return { nx: nx / nlen, ny: ny / nlen };
+}
+
+function buildRasterFamily(lines: LinePhotoLocator[]): PhotoLocatorHitSpec {
+    const { nx, ny } = meanNormal(lines);
+    const members: RasterMember[] = lines.map((loc) => {
+        const mx = (loc.start.x + loc.end.x) / 2;
+        const my = (loc.start.y + loc.end.y) / 2;
+        return { loc, offset: mx * nx + my * ny, delta: 1 };
+    });
+    members.sort((a, b) => a.offset - b.offset);
+    for (let i = 0; i < members.length; i++) {
+        const gaps: number[] = [];
+        if (i > 0) gaps.push(members[i].offset - members[i - 1].offset);
+        if (i < members.length - 1)
+            gaps.push(members[i + 1].offset - members[i].offset);
+        members[i].delta = gaps.length ? Math.min(...gaps) / 2 : 1;
+    }
+
+    return {
+        kind: "raster",
+        query(p) {
+            let best: HitSpecResult | undefined;
+            let bestScore = Infinity;
+            for (const m of members) {
+                const { loc, delta } = m;
+                const lx = loc.end.x - loc.start.x;
+                const ly = loc.end.y - loc.start.y;
+                const len = Math.hypot(lx, ly);
+                if (len < 1e-6) continue;
+                const ptx = p.x - loc.start.x;
+                const pty = p.y - loc.start.y;
+                const parallel = (ptx * lx + pty * ly) / len;
+                if (parallel < 0 || parallel > len) continue;
+                const d = Math.abs(lx * pty - ly * ptx) / len;
+                if (d > delta) continue;
+                const score = d / delta;
+                if (
+                    score < bestScore ||
+                    (score === bestScore && d < (best?.d ?? Infinity))
+                ) {
+                    bestScore = score;
+                    best = {
+                        x: (loc.width * parallel) / len,
+                        y: loc.index + 0.5,
+                        index: loc.index,
+                        d,
+                        delta,
+                    };
+                }
+            }
+            return best;
+        },
+    };
+}
+
+/** Task 1: lines → raster only. Tasks 2–3 extend classification. */
+export function buildPhotoLocatorHitSpec(
+    locators: PhotoLocator[],
+): PhotoLocatorHitSpec {
+    const lines = locators.filter(
+        (l): l is LinePhotoLocator => l instanceof LinePhotoLocator,
+    );
+    const circles = locators.filter(
+        (l): l is CirclePhotoLocator => l instanceof CirclePhotoLocator,
+    );
+    if (circles.length) {
+        throw new Error("circular families: implement in Task 3");
+    }
+    if (!lines.length) {
+        return { kind: "raster", query: () => undefined };
+    }
+    // Task 2 replaces this with classifyLines(lines)
+    return buildRasterFamily(lines);
+}

--- a/client/src/lib/registration/photoLocatorHitSpec.ts
+++ b/client/src/lib/registration/photoLocatorHitSpec.ts
@@ -304,6 +304,24 @@ function circularMembers(circles: CirclePhotoLocator[]): CircularMember[] {
     return members;
 }
 
+/**
+ * Median consecutive radius gap (px) for concentric circles (same center).
+ * Null when fewer than 2 circles.
+ */
+export function medianCircularRadiusSpacingPx(
+    circles: CirclePhotoLocator[],
+): number | null {
+    if (circles.length < 2) {
+        return null;
+    }
+    const members = circularMembers(circles);
+    const gaps: number[] = [];
+    for (let i = 1; i < members.length; i++) {
+        gaps.push(members[i].loc.radius - members[i - 1].loc.radius);
+    }
+    return gaps.length ? median(gaps) : null;
+}
+
 function buildCircularFamily(
     circles: CirclePhotoLocator[],
 ): PhotoLocatorHitSpec {

--- a/client/src/lib/registration/registration.svelte.ts
+++ b/client/src/lib/registration/registration.svelte.ts
@@ -10,6 +10,21 @@ import { enfaceToProjRegistrationItems } from "./enfaceToProj";
 import type { mappingFunction, RegistrationItem } from "./registrationItem";
 import { getRegistrationSets, type RegistrationSet } from "./registrationItem";
 
+/** DICOM SliceThickness as mm/frame from OCT volume dimensions when available. */
+function sliceThicknessMmFromOct(image: AbstractImage): number | null {
+    const { depth, depth_mm } = image.dimensions;
+    if (depth > 1 && depth_mm > 0) {
+        return depth_mm / depth;
+    }
+    try {
+        const raw = image.meta?.x52009229?.[0]?.x00289110?.[0]?.x00180050;
+        const n = Number(raw);
+        return n > 0 ? n : null;
+    } catch {
+        return null;
+    }
+}
+
 export type Pointer = {
     image_id: string;
     position: Position;
@@ -160,6 +175,7 @@ export class Registration {
                     `${image.instance.id}`,
                     image.width,
                     image.depth,
+                    sliceThicknessMmFromOct(image),
                 ),
             );
         }

--- a/client/src/lib/registration/registration.svelte.ts
+++ b/client/src/lib/registration/registration.svelte.ts
@@ -6,6 +6,7 @@ import {
     type PhotoLocator,
 } from "./photoLocators";
 import { OCTToProj, ProjToOCT } from "./projectionRegistration";
+import { enfaceToProjRegistrationItems } from "./enfaceToProj";
 import type { mappingFunction, RegistrationItem } from "./registrationItem";
 import { getRegistrationSets, type RegistrationSet } from "./registrationItem";
 
@@ -152,6 +153,15 @@ export class Registration {
         if (image.is3D) {
             items.push(new OCTToProj(image.instance));
             items.push(new ProjToOCT(image.instance));
+            // Direct enface → `_proj` GPU hops (patient affines never target `_proj`).
+            items.push(
+                ...enfaceToProjRegistrationItems(
+                    photoLocators,
+                    `${image.instance.id}`,
+                    image.width,
+                    image.depth,
+                ),
+            );
         }
         this.importRegistrationItems(items);
     }
@@ -186,6 +196,11 @@ export class Registration {
     getLinkedImgIds(source: string): Set<string> {
         // eslint-disable-next-line svelte/prefer-svelte-reactivity -- plain query result
         return new Set(Object.keys(this.shortestPaths[source] ?? {}));
+    }
+
+    /** Shortest path node ids inclusive, or undefined if unreachable. */
+    getPath(source: string, target: string): string[] | undefined {
+        return this.shortestPaths[source]?.[target];
     }
 
     listDirectTargets(source: string): string[] {

--- a/client/src/lib/registration/registration.svelte.ts
+++ b/client/src/lib/registration/registration.svelte.ts
@@ -37,10 +37,22 @@ class Mapper<T> {
 }
 
 export class Registration {
+    /**
+     * Bumped whenever registration items are imported or paths are recomputed.
+     * The graph is mutated in place and keeps growing after viewers mount (photo
+     * locators load per image, patient-level sets load later still), so reactive
+     * consumers need a signal to re-query it.
+     */
+    revision = $state(0);
+
     private pointer: Pointer = {
         image_id: "",
         position: { x: 0, y: 0, index: 0 },
     };
+    // The graph and its caches are queried imperatively (RAF repaint, pointer
+    // mapping), never read from $effect/$derived directly — `revision` above is
+    // the reactive signal — so SvelteMap/SvelteSet would only add proxy cost.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- see above
     private cache = new Map<string, Position | undefined>();
 
     private readonly mappings = new Mapper<mappingFunction>();
@@ -114,6 +126,7 @@ export class Registration {
             if (!this.pathsDirty) return;
             this.pathsDirty = false;
             this.shortestPaths = allPairsShortestPaths(this.mappings);
+            this.revision++;
         });
     }
 
@@ -122,6 +135,7 @@ export class Registration {
         this.pathsDirty = false;
         this.recomputeScheduled = false;
         this.shortestPaths = allPairsShortestPaths(this.mappings);
+        this.revision++;
     }
 
     async addImage(image: AbstractImage, photoLocators: PhotoLocator[]) {
@@ -150,6 +164,7 @@ export class Registration {
         }
         this.pathsDirty = true;
         this.scheduleRecompute();
+        this.revision++;
     }
 
     /** Import all patient-level registration pairs and recompute paths for transitive linking. */
@@ -160,6 +175,7 @@ export class Registration {
     }
 
     getLinkedImgIds(source: string): Set<string> {
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- plain query result
         return new Set(Object.keys(this.shortestPaths[source] ?? {}));
     }
 
@@ -186,6 +202,8 @@ export class Registration {
     }
 }
 
+// Local BFS scratch state — never observed reactively.
+/* eslint-disable svelte/prefer-svelte-reactivity */
 function allPairsShortestPaths(graph: Mapper<mappingFunction>): {
     [node: string]: { [node: string]: string[] };
 } {

--- a/client/src/lib/registration/registration.svelte.ts
+++ b/client/src/lib/registration/registration.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from "svelte";
 import type { Position } from "$lib/types";
 import type { AbstractImage } from "$lib/webgl/abstractImage";
 import {
@@ -118,6 +119,14 @@ export class Registration {
         return currentPosition;
     }
 
+    private bumpRevision() {
+        // `revision++` both reads and writes. Callers often run from `$effect`
+        // (RegistrationItemLoader), and a tracked read would re-subscribe that
+        // effect to revision → infinite loop. Untrack the read so only explicit
+        // consumers (TopViewer `$derived`) depend on the signal.
+        this.revision = untrack(() => this.revision) + 1;
+    }
+
     private scheduleRecompute() {
         if (this.recomputeScheduled) return;
         this.recomputeScheduled = true;
@@ -126,7 +135,7 @@ export class Registration {
             if (!this.pathsDirty) return;
             this.pathsDirty = false;
             this.shortestPaths = allPairsShortestPaths(this.mappings);
-            this.revision++;
+            this.bumpRevision();
         });
     }
 
@@ -135,7 +144,7 @@ export class Registration {
         this.pathsDirty = false;
         this.recomputeScheduled = false;
         this.shortestPaths = allPairsShortestPaths(this.mappings);
-        this.revision++;
+        this.bumpRevision();
     }
 
     async addImage(image: AbstractImage, photoLocators: PhotoLocator[]) {
@@ -164,7 +173,7 @@ export class Registration {
         }
         this.pathsDirty = true;
         this.scheduleRecompute();
-        this.revision++;
+        this.bumpRevision();
     }
 
     /** Import all patient-level registration pairs and recompute paths for transitive linking. */

--- a/client/src/lib/registration/registration.ts
+++ b/client/src/lib/registration/registration.ts
@@ -163,6 +163,10 @@ export class Registration {
         return new Set(Object.keys(this.shortestPaths[source] ?? {}));
     }
 
+    listDirectTargets(source: string): string[] {
+        return [...this.registrationItems.targets(source)];
+    }
+
     mapPosition(
         source: string,
         target: string,

--- a/client/src/lib/registration/registrationRevision.test.ts
+++ b/client/src/lib/registration/registrationRevision.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { Matrix } from "$lib/matrix";
+import { AffineRegistration } from "./affine";
+import { Registration } from "./registration.svelte";
+
+describe("Registration.revision", () => {
+    it("starts at zero", () => {
+        expect(new Registration().revision).toBe(0);
+    });
+
+    it("bumps when registration items are imported", () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [new AffineRegistration("fundus", "oct1_proj", Matrix.identity)],
+            false,
+        );
+        expect(registration.revision).toBe(1);
+    });
+
+    it("bumps again for the debounced path recomputation", async () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [new AffineRegistration("fundus", "oct1_proj", Matrix.identity)],
+            false,
+        );
+        const afterImport = registration.revision;
+
+        await Promise.resolve();
+
+        expect(registration.revision).toBeGreaterThan(afterImport);
+    });
+
+    it("bumps on an explicit synchronous recomputation", () => {
+        const registration = new Registration();
+        const before = registration.revision;
+        registration.recomputePathsNow();
+        expect(registration.revision).toBe(before + 1);
+    });
+
+    it("bumps for a late patient-level import, so consumers re-resolve", () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [new AffineRegistration("fundus", "oct1_proj", Matrix.identity)],
+            false,
+        );
+        const before = registration.revision;
+
+        expect(registration.listDirectTargets("other")).toEqual([]);
+        registration.importRegistrationItems(
+            [new AffineRegistration("other", "oct2_proj", Matrix.identity)],
+            false,
+        );
+
+        expect(registration.revision).toBeGreaterThan(before);
+        expect(registration.listDirectTargets("other")).toEqual(["oct2_proj"]);
+    });
+});

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
@@ -44,7 +44,7 @@ describe("resolveEnfaceOverlaySources", () => {
         expect(sources[0].mode).toBe("binary");
     });
 
-    it("includes direct affine edges to _proj", () => {
+    it("includes direct affine and parabolic edges to _proj", () => {
         const registration = new Registration();
         registration.importRegistrationItems(
             [
@@ -77,12 +77,16 @@ describe("resolveEnfaceOverlaySources", () => {
             projMode: "binary",
             linkedModes: new Map([["oct1", "heatmap"]]),
         });
-        expect(sources).toHaveLength(1);
-        expect(sources[0].octPublicId).toBe("oct1");
-        expect(sources[0].mode).toBe("heatmap");
-        expect(sources[0].mappingGlsl).toContain("map_0");
-        expect(sources[0].sizePrimary).toEqual([200, 200]);
-        expect(sources[0].sizeSecondary).toEqual([100, 50]);
+        expect(sources).toHaveLength(2);
+        const byOct = Object.fromEntries(
+            sources.map((s) => [s.octPublicId, s]),
+        );
+        expect(byOct.oct1.mode).toBe("heatmap");
+        expect(byOct.oct1.mappingGlsl).toContain("map_0");
+        expect(byOct.oct1.sizePrimary).toEqual([200, 200]);
+        expect(byOct.oct1.sizeSecondary).toEqual([100, 50]);
+        expect(byOct.oct2.mode).toBe("off");
+        expect(byOct.oct2.mappingGlsl).toContain("dx_val");
     });
 
     it("composes affine + enface→proj along a multi-hop path", () => {
@@ -125,6 +129,55 @@ describe("resolveEnfaceOverlaySources", () => {
         expect(sources).toHaveLength(1);
         expect(sources[0].mappingGlsl).toContain("map_0");
         expect(sources[0].mappingGlsl).toContain("map_1");
+        expect(sources[0].mappingGlsl).toContain("bestDist");
+    });
+
+    it("composes parabolic + enface→proj along a multi-hop path", () => {
+        const registration = new Registration();
+        const locators = [
+            new LinePhotoLocator(
+                "ir",
+                "oct1",
+                { x: 0, y: 0 },
+                { x: 150, y: 0 },
+                0,
+                100,
+            ),
+        ];
+        registration.importRegistrationItems(
+            [
+                new ParabolicRegistration(
+                    "fundus",
+                    "ir",
+                    [0.1, 0, 0, 0, 0, 0, 0],
+                    [0, 0.2, 0, 0, 0, 0, 0],
+                ),
+                new EnfaceToProjPhotolocations(
+                    "ir",
+                    "oct1_proj",
+                    locators,
+                    100,
+                    50,
+                ),
+            ],
+            false,
+        );
+        registration.recomputePathsNow();
+
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "fundus",
+            imageWidth: 200,
+            imageHeight: 200,
+            registration,
+            managers: new Map([["oct1", fakeManager("oct1")]]),
+            getImageSize,
+            projMode: "binary",
+            linkedModes: new Map([["oct1", "binary"]]),
+        });
+        expect(sources).toHaveLength(1);
+        expect(sources[0].mappingGlsl).toContain("map_0");
+        expect(sources[0].mappingGlsl).toContain("map_1");
+        expect(sources[0].mappingGlsl).toContain("dx_val");
         expect(sources[0].mappingGlsl).toContain("bestDist");
     });
 

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
@@ -42,6 +42,7 @@ describe("resolveEnfaceOverlaySources", () => {
         expect(sources[0].octPublicId).toBe("oct1");
         expect(sources[0].mappingGlsl).toContain("return uv;");
         expect(sources[0].mode).toBe("binary");
+        expect(sources[0].identityMapping).toBe(true);
     });
 
     it("includes direct affine and parabolic edges to _proj", () => {
@@ -85,8 +86,10 @@ describe("resolveEnfaceOverlaySources", () => {
         expect(byOct.oct1.mappingGlsl).toContain("map_0");
         expect(byOct.oct1.sizePrimary).toEqual([200, 200]);
         expect(byOct.oct1.sizeSecondary).toEqual([100, 50]);
+        expect(byOct.oct1.identityMapping).toBe(false);
         expect(byOct.oct2.mode).toBe("off");
         expect(byOct.oct2.mappingGlsl).toContain("dx_val");
+        expect(byOct.oct2.identityMapping).toBe(false);
     });
 
     it("composes affine + enface→proj along a multi-hop path", () => {

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { Registration } from "./registration";
+import { AffineRegistration } from "./affine";
+import { ParabolicRegistration } from "./parabolic";
+import { Matrix } from "$lib/matrix";
+import { resolveEnfaceOverlaySources } from "./resolveEnfaceOverlaySources";
+import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
+
+function fakeManager(octId: string, width = 100, depth = 50) {
+    return {
+        octImage: { width, height: 200, depth },
+    } as unknown as EnfaceProjectionManager;
+}
+
+describe("resolveEnfaceOverlaySources", () => {
+    it("returns identity source for _proj", () => {
+        const registration = new Registration();
+        const managers = new Map([["oct1", fakeManager("oct1")]]);
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "oct1_proj",
+            imageWidth: 100,
+            imageHeight: 50,
+            registration,
+            managers,
+            projMode: "binary",
+            linkedModes: new Map(),
+        });
+        expect(sources).toHaveLength(1);
+        expect(sources[0].octPublicId).toBe("oct1");
+        expect(sources[0].mappingGlsl).toContain("return uv;");
+        expect(sources[0].mode).toBe("binary");
+    });
+
+    it("includes direct affine edges to _proj only", () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [
+                new AffineRegistration(
+                    "fundus",
+                    "oct1_proj",
+                    new Matrix(1, 0, 0, 0, 1, 0, 0, 0, 1),
+                ),
+                new ParabolicRegistration(
+                    "fundus",
+                    "oct2_proj",
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                ),
+            ],
+            false,
+        );
+        registration.recomputePathsNow();
+        const managers = new Map([
+            ["oct1", fakeManager("oct1")],
+            ["oct2", fakeManager("oct2")],
+        ]);
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "fundus",
+            imageWidth: 200,
+            imageHeight: 200,
+            registration,
+            managers,
+            projMode: "binary",
+            linkedModes: new Map([["oct1", "heatmap"]]),
+        });
+        expect(sources).toHaveLength(1);
+        expect(sources[0].octPublicId).toBe("oct1");
+        expect(sources[0].mode).toBe("heatmap");
+        expect(sources[0].mappingGlsl).toContain("map_0");
+        expect(sources[0].sizePrimary).toEqual([200, 200]);
+        expect(sources[0].sizeSecondary).toEqual([100, 50]);
+    });
+
+    it("defaults linked mode to off", () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [new AffineRegistration("fundus", "oct1_proj", Matrix.identity)],
+            false,
+        );
+        registration.recomputePathsNow();
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "fundus",
+            imageWidth: 10,
+            imageHeight: 10,
+            registration,
+            managers: new Map([["oct1", fakeManager("oct1")]]),
+            projMode: "binary",
+            linkedModes: new Map(),
+        });
+        expect(sources[0].mode).toBe("off");
+    });
+
+    it("omits sources without a loaded manager", () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [new AffineRegistration("fundus", "oct1_proj", Matrix.identity)],
+            false,
+        );
+        registration.recomputePathsNow();
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "fundus",
+            imageWidth: 10,
+            imageHeight: 10,
+            registration,
+            managers: new Map(),
+            projMode: "binary",
+            linkedModes: new Map([["oct1", "binary"]]),
+        });
+        expect(sources).toHaveLength(0);
+    });
+});

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
@@ -4,12 +4,24 @@ import { AffineRegistration } from "./affine";
 import { ParabolicRegistration } from "./parabolic";
 import { Matrix } from "$lib/matrix";
 import { resolveEnfaceOverlaySources } from "./resolveEnfaceOverlaySources";
+import { EnfaceToProjPhotolocations } from "./enfaceToProj";
+import { LinePhotoLocator } from "./photoLocators";
 import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
 
 function fakeManager(octId: string, width = 100, depth = 50) {
     return {
         octImage: { width, height: 200, depth },
     } as unknown as EnfaceProjectionManager;
+}
+
+const sizes = new Map<string, [number, number]>([
+    ["fundus", [200, 200]],
+    ["ir", [150, 150]],
+    ["oct1_proj", [100, 50]],
+]);
+
+function getImageSize(id: string) {
+    return sizes.get(id);
 }
 
 describe("resolveEnfaceOverlaySources", () => {
@@ -22,6 +34,7 @@ describe("resolveEnfaceOverlaySources", () => {
             imageHeight: 50,
             registration,
             managers,
+            getImageSize,
             projMode: "binary",
             linkedModes: new Map(),
         });
@@ -31,7 +44,7 @@ describe("resolveEnfaceOverlaySources", () => {
         expect(sources[0].mode).toBe("binary");
     });
 
-    it("includes direct affine edges to _proj only", () => {
+    it("includes direct affine edges to _proj", () => {
         const registration = new Registration();
         registration.importRegistrationItems(
             [
@@ -60,6 +73,7 @@ describe("resolveEnfaceOverlaySources", () => {
             imageHeight: 200,
             registration,
             managers,
+            getImageSize,
             projMode: "binary",
             linkedModes: new Map([["oct1", "heatmap"]]),
         });
@@ -69,6 +83,49 @@ describe("resolveEnfaceOverlaySources", () => {
         expect(sources[0].mappingGlsl).toContain("map_0");
         expect(sources[0].sizePrimary).toEqual([200, 200]);
         expect(sources[0].sizeSecondary).toEqual([100, 50]);
+    });
+
+    it("composes affine + enface→proj along a multi-hop path", () => {
+        const registration = new Registration();
+        const locators = [
+            new LinePhotoLocator(
+                "ir",
+                "oct1",
+                { x: 0, y: 0 },
+                { x: 150, y: 0 },
+                0,
+                100,
+            ),
+        ];
+        registration.importRegistrationItems(
+            [
+                new AffineRegistration("fundus", "ir", Matrix.identity),
+                new EnfaceToProjPhotolocations(
+                    "ir",
+                    "oct1_proj",
+                    locators,
+                    100,
+                    50,
+                ),
+            ],
+            false,
+        );
+        registration.recomputePathsNow();
+
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "fundus",
+            imageWidth: 200,
+            imageHeight: 200,
+            registration,
+            managers: new Map([["oct1", fakeManager("oct1")]]),
+            getImageSize,
+            projMode: "binary",
+            linkedModes: new Map([["oct1", "binary"]]),
+        });
+        expect(sources).toHaveLength(1);
+        expect(sources[0].mappingGlsl).toContain("map_0");
+        expect(sources[0].mappingGlsl).toContain("map_1");
+        expect(sources[0].mappingGlsl).toContain("bestDist");
     });
 
     it("defaults linked mode to off", () => {
@@ -84,6 +141,7 @@ describe("resolveEnfaceOverlaySources", () => {
             imageHeight: 10,
             registration,
             managers: new Map([["oct1", fakeManager("oct1")]]),
+            getImageSize: () => [10, 10],
             projMode: "binary",
             linkedModes: new Map(),
         });
@@ -103,6 +161,45 @@ describe("resolveEnfaceOverlaySources", () => {
             imageHeight: 10,
             registration,
             managers: new Map(),
+            getImageSize: () => [10, 10],
+            projMode: "binary",
+            linkedModes: new Map([["oct1", "binary"]]),
+        });
+        expect(sources).toHaveLength(0);
+    });
+
+    it("skips paths when an intermediate image size is unknown", () => {
+        const registration = new Registration();
+        registration.importRegistrationItems(
+            [
+                new AffineRegistration("fundus", "ir", Matrix.identity),
+                new EnfaceToProjPhotolocations(
+                    "ir",
+                    "oct1_proj",
+                    [
+                        new LinePhotoLocator(
+                            "ir",
+                            "oct1",
+                            { x: 0, y: 0 },
+                            { x: 10, y: 0 },
+                            0,
+                            100,
+                        ),
+                    ],
+                    100,
+                    50,
+                ),
+            ],
+            false,
+        );
+        registration.recomputePathsNow();
+        const sources = resolveEnfaceOverlaySources({
+            imageId: "fundus",
+            imageWidth: 200,
+            imageHeight: 200,
+            registration,
+            managers: new Map([["oct1", fakeManager("oct1")]]),
+            getImageSize: (id) => (id === "fundus" ? [200, 200] : undefined),
             projMode: "binary",
             linkedModes: new Map([["oct1", "binary"]]),
         });

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Registration } from "./registration";
+import { Registration } from "./registration.svelte";
 import { AffineRegistration } from "./affine";
 import { ParabolicRegistration } from "./parabolic";
 import { Matrix } from "$lib/matrix";

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.ts
@@ -11,6 +11,8 @@ export type EnfaceOverlaySourceResolved = {
     mode: EnfaceProjectionMode;
     sizePrimary: [number, number];
     sizeSecondary: [number, number];
+    /** True for the real `_proj` viewer (identity UV); linked hops stay false. */
+    identityMapping: boolean;
 };
 
 export function resolveEnfaceOverlaySources(args: {
@@ -48,6 +50,7 @@ export function resolveEnfaceOverlaySources(args: {
                 mode: args.projMode,
                 sizePrimary,
                 sizeSecondary: sizePrimary,
+                identityMapping: true,
             },
         ];
     }
@@ -99,6 +102,7 @@ export function resolveEnfaceOverlaySources(args: {
             mode: args.linkedModes.get(octPublicId) ?? "off",
             sizePrimary,
             sizeSecondary: projSize,
+            identityMapping: false,
         });
     }
     return sources;

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.ts
@@ -1,6 +1,6 @@
 import type { EnfaceProjectionMode } from "$lib/viewer/viewer-utils";
 import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
-import { AffineRegistration } from "./affine";
+import { bakeHopGlsl } from "./enfaceToProj";
 import { composeGlslPath } from "./composeGlslPath";
 import type { Registration } from "./registration.svelte";
 
@@ -25,6 +25,8 @@ export function resolveEnfaceOverlaySources(args: {
      */
     registrationRevision?: number;
     managers: ReadonlyMap<string, EnfaceProjectionManager>;
+    /** Pixel size lookup for intermediate path nodes (and current image). */
+    getImageSize: (imageId: string) => [number, number] | undefined;
     /** Mode for the real _proj viewer (single source). */
     projMode: EnfaceProjectionMode;
     /** Per-OCT modes for linked viewers; missing key ⇒ "off". */
@@ -51,29 +53,52 @@ export function resolveEnfaceOverlaySources(args: {
     }
 
     const sources: EnfaceOverlaySourceResolved[] = [];
-    for (const target of args.registration.listDirectTargets(args.imageId)) {
-        if (!target.endsWith("_proj")) {
+    for (const [octPublicId, manager] of args.managers) {
+        const projId = `${octPublicId}_proj`;
+        const path = args.registration.getPath(args.imageId, projId);
+        if (!path || path.length < 2) {
             continue;
         }
-        const item = args.registration.getRegistrationItem(
-            args.imageId,
-            target,
-        );
-        if (!(item instanceof AffineRegistration) || !item.glslMapping.trim()) {
+
+        const projSize: [number, number] = [
+            manager.octImage.width,
+            manager.octImage.depth,
+        ];
+        const hops: string[] = [];
+        let ok = true;
+        for (let i = 0; i < path.length - 1; i++) {
+            const from = path[i];
+            const to = path[i + 1];
+            const item = args.registration.getRegistrationItem(from, to);
+            if (!item) {
+                ok = false;
+                break;
+            }
+            const srcSize =
+                from === args.imageId ? sizePrimary : args.getImageSize(from);
+            const dstSize = to === projId ? projSize : args.getImageSize(to);
+            if (!srcSize || !dstSize) {
+                ok = false;
+                break;
+            }
+            const hop = bakeHopGlsl(item, srcSize, dstSize);
+            if (!hop) {
+                ok = false;
+                break;
+            }
+            hops.push(hop);
+        }
+        if (!ok) {
             continue;
         }
-        const octPublicId = target.slice(0, -"_proj".length);
-        const manager = args.managers.get(octPublicId);
-        if (!manager) {
-            continue;
-        }
+
         sources.push({
             octPublicId,
             manager,
-            mappingGlsl: composeGlslPath([item.glslMapping]),
+            mappingGlsl: composeGlslPath(hops),
             mode: args.linkedModes.get(octPublicId) ?? "off",
             sizePrimary,
-            sizeSecondary: [manager.octImage.width, manager.octImage.depth],
+            sizeSecondary: projSize,
         });
     }
     return sources;

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.ts
@@ -2,7 +2,7 @@ import type { EnfaceProjectionMode } from "$lib/viewer/viewer-utils";
 import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
 import { AffineRegistration } from "./affine";
 import { composeGlslPath } from "./composeGlslPath";
-import type { Registration } from "./registration";
+import type { Registration } from "./registration.svelte";
 
 export type EnfaceOverlaySourceResolved = {
     octPublicId: string;
@@ -18,6 +18,12 @@ export function resolveEnfaceOverlaySources(args: {
     imageWidth: number;
     imageHeight: number;
     registration: Registration;
+    /**
+     * `Registration.revision`. Deliberately unused here: passing it in makes
+     * reactive callers depend on it, so their derived sources re-resolve when
+     * registration items import after the viewer already mounted.
+     */
+    registrationRevision?: number;
     managers: ReadonlyMap<string, EnfaceProjectionManager>;
     /** Mode for the real _proj viewer (single source). */
     projMode: EnfaceProjectionMode;

--- a/client/src/lib/registration/resolveEnfaceOverlaySources.ts
+++ b/client/src/lib/registration/resolveEnfaceOverlaySources.ts
@@ -1,0 +1,74 @@
+import type { EnfaceProjectionMode } from "$lib/viewer/viewer-utils";
+import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
+import { AffineRegistration } from "./affine";
+import { composeGlslPath } from "./composeGlslPath";
+import type { Registration } from "./registration";
+
+export type EnfaceOverlaySourceResolved = {
+    octPublicId: string;
+    manager: EnfaceProjectionManager;
+    mappingGlsl: string;
+    mode: EnfaceProjectionMode;
+    sizePrimary: [number, number];
+    sizeSecondary: [number, number];
+};
+
+export function resolveEnfaceOverlaySources(args: {
+    imageId: string;
+    imageWidth: number;
+    imageHeight: number;
+    registration: Registration;
+    managers: ReadonlyMap<string, EnfaceProjectionManager>;
+    /** Mode for the real _proj viewer (single source). */
+    projMode: EnfaceProjectionMode;
+    /** Per-OCT modes for linked viewers; missing key ⇒ "off". */
+    linkedModes: ReadonlyMap<string, EnfaceProjectionMode>;
+}): EnfaceOverlaySourceResolved[] {
+    const sizePrimary: [number, number] = [args.imageWidth, args.imageHeight];
+
+    if (args.imageId.endsWith("_proj")) {
+        const octPublicId = args.imageId.slice(0, -"_proj".length);
+        const manager = args.managers.get(octPublicId);
+        if (!manager) {
+            return [];
+        }
+        return [
+            {
+                octPublicId,
+                manager,
+                mappingGlsl: composeGlslPath([]),
+                mode: args.projMode,
+                sizePrimary,
+                sizeSecondary: sizePrimary,
+            },
+        ];
+    }
+
+    const sources: EnfaceOverlaySourceResolved[] = [];
+    for (const target of args.registration.listDirectTargets(args.imageId)) {
+        if (!target.endsWith("_proj")) {
+            continue;
+        }
+        const item = args.registration.getRegistrationItem(
+            args.imageId,
+            target,
+        );
+        if (!(item instanceof AffineRegistration) || !item.glslMapping.trim()) {
+            continue;
+        }
+        const octPublicId = target.slice(0, -"_proj".length);
+        const manager = args.managers.get(octPublicId);
+        if (!manager) {
+            continue;
+        }
+        sources.push({
+            octPublicId,
+            manager,
+            mappingGlsl: composeGlslPath([item.glslMapping]),
+            mode: args.linkedModes.get(octPublicId) ?? "off",
+            sizePrimary,
+            sizeSecondary: [manager.octImage.width, manager.octImage.depth],
+        });
+    }
+    return sources;
+}

--- a/client/src/lib/viewer-window/ImageWindow.svelte
+++ b/client/src/lib/viewer-window/ImageWindow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { ImageLoader } from "$lib/data-loading/imageLoader";
     import type { GlobalContext } from "$lib/data/globalContext.svelte";
-    import { Registration } from "$lib/registration/registration";
+    import { Registration } from "$lib/registration/registration.svelte";
     import type { WebGL } from "$lib/webgl/webgl";
     import { getContext, setContext } from "svelte";
     import type { ImageGET } from "../../types/openapi_types";

--- a/client/src/lib/viewer-window/RegistrationItemLoader.svelte
+++ b/client/src/lib/viewer-window/RegistrationItemLoader.svelte
@@ -5,7 +5,7 @@
         getAffineTransforms,
         getPointsetRegistrations,
     } from "$lib/registration/pointsetRegistration";
-    import type { Registration } from "$lib/registration/registration";
+    import type { Registration } from "$lib/registration/registration.svelte";
     import {
         getRegistrationSets,
         type RegistrationSet,

--- a/client/src/lib/viewer-window/TopViewer.svelte
+++ b/client/src/lib/viewer-window/TopViewer.svelte
@@ -10,7 +10,7 @@
     import MainIcon from "./icons/MainIcon.svelte";
     import Lines from "./icons/Lines.svelte";
     import EnfaceProjectionModeIcon from "./icons/EnfaceProjectionModeIcon.svelte";
-    import { composeGlslPath } from "$lib/registration/composeGlslPath";
+    import { resolveEnfaceOverlaySources } from "$lib/registration/resolveEnfaceOverlaySources";
 
     interface Props {
         image: AbstractImage;
@@ -28,10 +28,22 @@
     setContext("viewerContext", viewerContext);
 
     const isProjImage = $derived(image.image_id.endsWith("_proj"));
-    const enfaceProjectionManager = $derived(
-        isProjImage
-            ? viewerWindowContext.enfaceProjectionManagers.get(publicId)
-            : undefined,
+    const resolved = $derived.by(() =>
+        resolveEnfaceOverlaySources({
+            imageId: image.image_id,
+            imageWidth: image.width,
+            imageHeight: image.height,
+            registration: viewerWindowContext.registration,
+            managers: viewerWindowContext.enfaceProjectionManagers,
+            projMode: viewerContext.enfaceProjectionMode,
+            linkedModes: viewerContext.enfaceProjectionModesByOct,
+        }),
+    );
+    const paintSources = $derived.by(() =>
+        resolved.flatMap((source) => {
+            const mainViewerContext = source.manager.mainViewerContext;
+            return mainViewerContext ? [{ ...source, mainViewerContext }] : [];
+        }),
     );
 
     let photoLocators = $derived(
@@ -61,25 +73,11 @@
     });
 
     $effect(() => {
-        const manager = enfaceProjectionManager;
-        const ctx = manager?.mainViewerContext;
-        if (!manager || !ctx || viewerContext.enfaceProjectionMode === "off") {
+        const sources = paintSources.filter((source) => source.mode !== "off");
+        if (!sources.length) {
             return;
         }
-        const mappingGlsl = composeGlslPath([]);
-        return viewerContext.addOverlay(
-            new EnfaceProjectionOverlay([
-                {
-                    octPublicId: publicId,
-                    manager,
-                    mainViewerContext: ctx,
-                    mappingGlsl,
-                    mode: viewerContext.enfaceProjectionMode,
-                    sizePrimary: [image.width, image.height],
-                    sizeSecondary: [image.width, image.height],
-                },
-            ]),
-        );
+        return viewerContext.addOverlay(new EnfaceProjectionOverlay(sources));
     });
 
     function toggleLinesOverlay(e: MouseEvent) {
@@ -92,6 +90,11 @@
         const modes: EnfaceProjectionMode[] = ["off", "binary", "heatmap"];
         const index = modes.indexOf(viewerContext.enfaceProjectionMode);
         viewerContext.enfaceProjectionMode = modes[(index + 1) % modes.length];
+    }
+
+    function cycleLinkedProjectionMode(e: MouseEvent, octPublicId: string) {
+        e.stopPropagation();
+        viewerContext.cycleEnfaceProjectionModeForOct(octPublicId);
     }
 
     function selectImage(e: MouseEvent) {
@@ -111,11 +114,11 @@
         <span class="public-id">{publicId}</span>
         <CopyIconButton text={publicId} ariaLabel="Copy public ID" />
     </div>
-    {#if hasLocators || enfaceProjectionManager}
+    {#if hasLocators || resolved.length > 0}
         <div class="header overlay">
             <div class="content outer">
                 <div class="content">
-                    {#if enfaceProjectionManager}
+                    {#if isProjImage && resolved.length > 0}
                         <MainIcon
                             onclick={cycleProjectionMode}
                             active={viewerContext.enfaceProjectionMode !==
@@ -128,6 +131,28 @@
                             ]}
                             iconSnippet={projectionModeIcon}
                         />
+                    {:else}
+                        {#each resolved as source (source.octPublicId)}
+                            <MainIcon
+                                onclick={(event) =>
+                                    cycleLinkedProjectionMode(
+                                        event,
+                                        source.octPublicId,
+                                    )}
+                                active={source.mode !== "off"}
+                                tooltip={`${projectionModeLabels[source.mode]} (${source.octPublicId})`}
+                                hoverColor={projectionModeHoverColors[
+                                    source.mode
+                                ]}
+                            >
+                                {#snippet iconSnippet()}
+                                    <EnfaceProjectionModeIcon
+                                        mode={source.mode}
+                                        gradientId={`enface-heatmap-${publicId}-${source.octPublicId}`}
+                                    />
+                                {/snippet}
+                            </MainIcon>
+                        {/each}
                     {/if}
                     {#if hasLocators}
                         <MainIcon

--- a/client/src/lib/viewer-window/TopViewer.svelte
+++ b/client/src/lib/viewer-window/TopViewer.svelte
@@ -10,6 +10,7 @@
     import MainIcon from "./icons/MainIcon.svelte";
     import Lines from "./icons/Lines.svelte";
     import EnfaceProjectionModeIcon from "./icons/EnfaceProjectionModeIcon.svelte";
+    import { composeGlslPath } from "$lib/registration/composeGlslPath";
 
     interface Props {
         image: AbstractImage;
@@ -60,16 +61,25 @@
     });
 
     $effect(() => {
-        const ctx = enfaceProjectionManager?.mainViewerContext;
-        if (
-            enfaceProjectionManager &&
-            ctx &&
-            viewerContext.enfaceProjectionMode !== "off"
-        ) {
-            return viewerContext.addOverlay(
-                new EnfaceProjectionOverlay(enfaceProjectionManager, ctx),
-            );
+        const manager = enfaceProjectionManager;
+        const ctx = manager?.mainViewerContext;
+        if (!manager || !ctx || viewerContext.enfaceProjectionMode === "off") {
+            return;
         }
+        const mappingGlsl = composeGlslPath([]);
+        return viewerContext.addOverlay(
+            new EnfaceProjectionOverlay([
+                {
+                    octPublicId: publicId,
+                    manager,
+                    mainViewerContext: ctx,
+                    mappingGlsl,
+                    mode: viewerContext.enfaceProjectionMode,
+                    sizePrimary: [image.width, image.height],
+                    sizeSecondary: [image.width, image.height],
+                },
+            ]),
+        );
     });
 
     function toggleLinesOverlay(e: MouseEvent) {

--- a/client/src/lib/viewer-window/TopViewer.svelte
+++ b/client/src/lib/viewer-window/TopViewer.svelte
@@ -28,12 +28,18 @@
     setContext("viewerContext", viewerContext);
 
     const isProjImage = $derived(image.image_id.endsWith("_proj"));
+    // Photo locators and patient-level registration sets keep importing after this
+    // viewer mounts, so the overlay sources have to re-resolve on every bump.
+    const registrationRevision = $derived(
+        viewerWindowContext.registration.revision,
+    );
     const resolved = $derived.by(() =>
         resolveEnfaceOverlaySources({
             imageId: image.image_id,
             imageWidth: image.width,
             imageHeight: image.height,
             registration: viewerWindowContext.registration,
+            registrationRevision,
             managers: viewerWindowContext.enfaceProjectionManagers,
             projMode: viewerContext.enfaceProjectionMode,
             linkedModes: viewerContext.enfaceProjectionModesByOct,

--- a/client/src/lib/viewer-window/TopViewer.svelte
+++ b/client/src/lib/viewer-window/TopViewer.svelte
@@ -11,6 +11,7 @@
     import Lines from "./icons/Lines.svelte";
     import EnfaceProjectionModeIcon from "./icons/EnfaceProjectionModeIcon.svelte";
     import { resolveEnfaceOverlaySources } from "$lib/registration/resolveEnfaceOverlaySources";
+    import { instances } from "$lib/data/stores.svelte";
 
     interface Props {
         image: AbstractImage;
@@ -41,6 +42,26 @@
             registration: viewerWindowContext.registration,
             registrationRevision,
             managers: viewerWindowContext.enfaceProjectionManagers,
+            getImageSize: (id) => {
+                for (const [img] of viewerWindowContext.topViewers) {
+                    if (img.image_id === id) {
+                        return [img.width, img.height];
+                    }
+                }
+                if (id.endsWith("_proj")) {
+                    const octId = id.slice(0, -"_proj".length);
+                    const mgr =
+                        viewerWindowContext.enfaceProjectionManagers.get(octId);
+                    if (mgr) {
+                        return [mgr.octImage.width, mgr.octImage.depth];
+                    }
+                }
+                const meta = instances.get(id);
+                if (meta) {
+                    return [meta.columns, meta.rows];
+                }
+                return undefined;
+            },
             projMode: viewerContext.enfaceProjectionMode,
             linkedModes: viewerContext.enfaceProjectionModesByOct,
         }),

--- a/client/src/lib/viewer-window/TopViewer.svelte
+++ b/client/src/lib/viewer-window/TopViewer.svelte
@@ -104,7 +104,9 @@
         if (!sources.length) {
             return;
         }
-        return viewerContext.addOverlay(new EnfaceProjectionOverlay(sources));
+        return viewerContext.addOverlay(
+            new EnfaceProjectionOverlay(sources, image.webgl),
+        );
     });
 
     function toggleLinesOverlay(e: MouseEvent) {

--- a/client/src/lib/viewer-window/ViewerWindowLoader.svelte
+++ b/client/src/lib/viewer-window/ViewerWindowLoader.svelte
@@ -5,7 +5,7 @@ Used to create the viewerwindow context.
 -->
 <script lang="ts">
     import type { GlobalContext } from "$lib/data/globalContext.svelte";
-    import { Registration } from "$lib/registration/registration";
+    import { Registration } from "$lib/registration/registration.svelte";
     import { Deferred } from "$lib/utils";
     import { WebGL } from "$lib/webgl/webgl";
     import { getContext, onMount } from "svelte";

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -9,7 +9,7 @@ import {
     loadPhotoLocators,
     type PhotoLocator,
 } from "$lib/registration/photoLocators";
-import type { Registration } from "$lib/registration/registration";
+import type { Registration } from "$lib/registration/registration.svelte";
 import { ViewerContext } from "$lib/viewer/viewerContext.svelte";
 import { AbstractImage } from "$lib/webgl/abstractImage";
 import type { Image3D } from "$lib/webgl/image3D";

--- a/client/src/lib/viewer/overlays/ETDRSGridItemOverlay.svelte.ts
+++ b/client/src/lib/viewer/overlays/ETDRSGridItemOverlay.svelte.ts
@@ -1,4 +1,4 @@
-import type { Registration } from "$lib/registration/registration";
+import type { Registration } from "$lib/registration/registration.svelte";
 import type { Position, Position2D } from "$lib/types";
 import type { Overlay, ViewerEvent } from "../viewer-utils";
 import type { ViewerContext } from "../viewerContext.svelte";

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
@@ -3,16 +3,14 @@ import type { MainViewerContext } from "./MainViewerContext.svelte";
 import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
 import type { ViewerContext } from "../viewerContext.svelte";
 import type { RenderTarget } from "$lib/webgl/types";
+import type { WebGL } from "$lib/webgl/webgl";
 
-const { getOrCompile, getShaderTemplateCache, getBaseUniforms } = vi.hoisted(
-    () => ({
-        getOrCompile: vi.fn(),
-        getShaderTemplateCache: vi.fn(),
-        getBaseUniforms: vi.fn(() => ({ u_base: "base" })),
-    }),
-);
+const { compileShaderTemplate, getBaseUniforms } = vi.hoisted(() => ({
+    compileShaderTemplate: vi.fn(),
+    getBaseUniforms: vi.fn(() => ({ u_base: "base" })),
+}));
 
-vi.mock("$lib/webgl/shaderTemplate", () => ({ getShaderTemplateCache }));
+vi.mock("$lib/webgl/shaderTemplate", () => ({ compileShaderTemplate }));
 
 vi.mock("$lib/webgl/imageRenderer", () => ({ getBaseUniforms }));
 
@@ -48,38 +46,47 @@ function source(
     };
 }
 
+const webgl = {} as WebGL;
+
 describe("EnfaceProjectionOverlay", () => {
     beforeEach(() => {
-        getOrCompile.mockReset();
-        getShaderTemplateCache.mockReset();
-        getShaderTemplateCache.mockReturnValue({ getOrCompile });
+        compileShaderTemplate.mockReset();
         getBaseUniforms.mockClear();
         getBaseUniforms.mockReturnValue({ u_base: "base" });
     });
 
-    it("renders every enabled source with its mapped program and dimensions", () => {
+    it("compiles enabled sources once in the constructor and reuses them on repaint", () => {
         const firstPass = vi.fn();
         const secondPass = vi.fn();
-        getOrCompile
+        compileShaderTemplate
             .mockReturnValueOnce({ pass: firstPass })
             .mockReturnValueOnce({ pass: secondPass });
-        const overlay = new EnfaceProjectionOverlay([
-            source("binary", "first"),
-            source("off", "disabled"),
-            source("heatmap", "second"),
-        ]);
+
+        const overlay = new EnfaceProjectionOverlay(
+            [
+                source("binary", "first"),
+                source("off", "disabled"),
+                source("heatmap", "second"),
+            ],
+            webgl,
+        );
+
+        expect(compileShaderTemplate).toHaveBeenCalledTimes(2);
+        expect(
+            compileShaderTemplate.mock.calls.map((call) => call[2]),
+        ).toEqual([{ mapping: "first" }, { mapping: "second" }]);
+
         const viewerContext = {
-            image: { webgl: "webgl" },
+            image: { webgl },
         } as unknown as ViewerContext;
         const renderTarget = {} as RenderTarget;
 
         overlay.repaint(viewerContext, renderTarget);
+        overlay.repaint(viewerContext, renderTarget);
 
-        expect(getOrCompile).toHaveBeenCalledTimes(2);
-        expect(getOrCompile.mock.calls.map((call) => call[2])).toEqual([
-            { mapping: "first" },
-            { mapping: "second" },
-        ]);
+        expect(compileShaderTemplate).toHaveBeenCalledTimes(2);
+        expect(firstPass).toHaveBeenCalledTimes(2);
+        expect(secondPass).toHaveBeenCalledTimes(2);
         expect(firstPass).toHaveBeenCalledWith(
             renderTarget,
             expect.objectContaining({
@@ -104,60 +111,24 @@ describe("EnfaceProjectionOverlay", () => {
 
     it("skips a source whose mapped shader fails to compile", () => {
         const pass = vi.fn();
-        getOrCompile
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        compileShaderTemplate
             .mockImplementationOnce(() => {
                 throw new Error("compile failed");
             })
             .mockReturnValueOnce({ pass });
-        const overlay = new EnfaceProjectionOverlay([
-            source("binary", "broken"),
-            source("binary", "valid"),
-        ]);
+
+        const overlay = new EnfaceProjectionOverlay(
+            [source("binary", "broken"), source("binary", "valid")],
+            webgl,
+        );
 
         overlay.repaint(
-            { image: { webgl: "webgl" } } as unknown as ViewerContext,
+            { image: { webgl } } as unknown as ViewerContext,
             {} as RenderTarget,
         );
 
-        expect(getOrCompile).toHaveBeenCalledTimes(2);
+        expect(compileShaderTemplate).toHaveBeenCalledTimes(2);
         expect(pass).toHaveBeenCalledOnce();
-    });
-
-    it("skips a source whose shader is negative-cached as null", () => {
-        const pass = vi.fn();
-        getOrCompile.mockReturnValueOnce(null).mockReturnValueOnce({ pass });
-        const overlay = new EnfaceProjectionOverlay([
-            source("binary", "known-bad"),
-            source("binary", "valid"),
-        ]);
-
-        overlay.repaint(
-            { image: { webgl: "webgl" } } as unknown as ViewerContext,
-            {} as RenderTarget,
-        );
-
-        expect(getOrCompile).toHaveBeenCalledTimes(2);
-        expect(pass).toHaveBeenCalledOnce();
-    });
-
-    it("looks the program cache up on the webgl context instead of owning one", () => {
-        getOrCompile.mockReturnValue({ pass: vi.fn() });
-        const viewerContext = {
-            image: { webgl: "webgl" },
-        } as unknown as ViewerContext;
-
-        new EnfaceProjectionOverlay([source("binary", "shared")]).repaint(
-            viewerContext,
-            {} as RenderTarget,
-        );
-        new EnfaceProjectionOverlay([source("heatmap", "shared")]).repaint(
-            viewerContext,
-            {} as RenderTarget,
-        );
-
-        expect(getShaderTemplateCache.mock.calls).toEqual([
-            ["webgl"],
-            ["webgl"],
-        ]);
     });
 });

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MainViewerContext } from "./MainViewerContext.svelte";
+import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
+import type { ViewerContext } from "../viewerContext.svelte";
+import type { RenderTarget } from "$lib/webgl/types";
+
+const { getOrCompile, getBaseUniforms } = vi.hoisted(() => ({
+    getOrCompile: vi.fn(),
+    getBaseUniforms: vi.fn(() => ({ u_base: "base" })),
+}));
+
+vi.mock("$lib/webgl/shaderTemplate", () => ({
+    ShaderTemplateCache: class {
+        getOrCompile = getOrCompile;
+    },
+}));
+
+vi.mock("$lib/webgl/imageRenderer", () => ({ getBaseUniforms }));
+
+import {
+    EnfaceProjectionOverlay,
+    type EnfaceOverlayPaintSource,
+} from "./EnfaceProjectionOverlay";
+
+function source(
+    mode: EnfaceOverlayPaintSource["mode"],
+    mappingGlsl: string,
+    alpha = 0.5,
+): EnfaceOverlayPaintSource {
+    return {
+        octPublicId: mappingGlsl,
+        manager: {
+            getVisibleProjections: () => [
+                {
+                    projection: {
+                        textureData: { texture: `${mappingGlsl}-texture` },
+                        getThicknessRange: () => ({ min: 2, max: 8 }),
+                    },
+                    color: [255, 128, 0],
+                    layerAlpha: 0.4,
+                },
+            ],
+        } as unknown as EnfaceProjectionManager,
+        mainViewerContext: { alpha } as MainViewerContext,
+        mappingGlsl,
+        mode,
+        sizePrimary: [200, 100],
+        sizeSecondary: [50, 25],
+    };
+}
+
+describe("EnfaceProjectionOverlay", () => {
+    beforeEach(() => {
+        getOrCompile.mockReset();
+        getBaseUniforms.mockClear();
+    });
+
+    it("renders every enabled source with its mapped program and dimensions", () => {
+        const firstPass = vi.fn();
+        const secondPass = vi.fn();
+        getOrCompile
+            .mockReturnValueOnce({ pass: firstPass })
+            .mockReturnValueOnce({ pass: secondPass });
+        const overlay = new EnfaceProjectionOverlay([
+            source("binary", "first"),
+            source("off", "disabled"),
+            source("heatmap", "second"),
+        ]);
+        const viewerContext = {
+            image: { webgl: "webgl" },
+        } as unknown as ViewerContext;
+        const renderTarget = {} as RenderTarget;
+
+        overlay.repaint(viewerContext, renderTarget);
+
+        expect(getOrCompile).toHaveBeenCalledTimes(2);
+        expect(getOrCompile.mock.calls.map((call) => call[2])).toEqual([
+            { mapping: "first" },
+            { mapping: "second" },
+        ]);
+        expect(firstPass).toHaveBeenCalledWith(
+            renderTarget,
+            expect.objectContaining({
+                u_base: "base",
+                u_mode: 0,
+                u_min_thickness: 0,
+                u_max_thickness: 1,
+                u_alpha: 0.2,
+                u_size_primary: [200, 100],
+                u_size_secondary: [50, 25],
+            }),
+        );
+        expect(secondPass).toHaveBeenCalledWith(
+            renderTarget,
+            expect.objectContaining({
+                u_mode: 1,
+                u_min_thickness: 2,
+                u_max_thickness: 8,
+            }),
+        );
+    });
+
+    it("skips a source whose mapped shader fails to compile", () => {
+        const pass = vi.fn();
+        getOrCompile
+            .mockImplementationOnce(() => {
+                throw new Error("compile failed");
+            })
+            .mockReturnValueOnce({ pass });
+        const overlay = new EnfaceProjectionOverlay([
+            source("binary", "broken"),
+            source("binary", "valid"),
+        ]);
+
+        overlay.repaint(
+            { image: { webgl: "webgl" } } as unknown as ViewerContext,
+            {} as RenderTarget,
+        );
+
+        expect(getOrCompile).toHaveBeenCalledTimes(2);
+        expect(pass).toHaveBeenCalledOnce();
+    });
+});

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
@@ -4,16 +4,15 @@ import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectio
 import type { ViewerContext } from "../viewerContext.svelte";
 import type { RenderTarget } from "$lib/webgl/types";
 
-const { getOrCompile, getBaseUniforms } = vi.hoisted(() => ({
-    getOrCompile: vi.fn(),
-    getBaseUniforms: vi.fn(() => ({ u_base: "base" })),
-}));
+const { getOrCompile, getShaderTemplateCache, getBaseUniforms } = vi.hoisted(
+    () => ({
+        getOrCompile: vi.fn(),
+        getShaderTemplateCache: vi.fn(),
+        getBaseUniforms: vi.fn(() => ({ u_base: "base" })),
+    }),
+);
 
-vi.mock("$lib/webgl/shaderTemplate", () => ({
-    ShaderTemplateCache: class {
-        getOrCompile = getOrCompile;
-    },
-}));
+vi.mock("$lib/webgl/shaderTemplate", () => ({ getShaderTemplateCache }));
 
 vi.mock("$lib/webgl/imageRenderer", () => ({ getBaseUniforms }));
 
@@ -52,7 +51,10 @@ function source(
 describe("EnfaceProjectionOverlay", () => {
     beforeEach(() => {
         getOrCompile.mockReset();
+        getShaderTemplateCache.mockReset();
+        getShaderTemplateCache.mockReturnValue({ getOrCompile });
         getBaseUniforms.mockClear();
+        getBaseUniforms.mockReturnValue({ u_base: "base" });
     });
 
     it("renders every enabled source with its mapped program and dimensions", () => {
@@ -119,5 +121,43 @@ describe("EnfaceProjectionOverlay", () => {
 
         expect(getOrCompile).toHaveBeenCalledTimes(2);
         expect(pass).toHaveBeenCalledOnce();
+    });
+
+    it("skips a source whose shader is negative-cached as null", () => {
+        const pass = vi.fn();
+        getOrCompile.mockReturnValueOnce(null).mockReturnValueOnce({ pass });
+        const overlay = new EnfaceProjectionOverlay([
+            source("binary", "known-bad"),
+            source("binary", "valid"),
+        ]);
+
+        overlay.repaint(
+            { image: { webgl: "webgl" } } as unknown as ViewerContext,
+            {} as RenderTarget,
+        );
+
+        expect(getOrCompile).toHaveBeenCalledTimes(2);
+        expect(pass).toHaveBeenCalledOnce();
+    });
+
+    it("looks the program cache up on the webgl context instead of owning one", () => {
+        getOrCompile.mockReturnValue({ pass: vi.fn() });
+        const viewerContext = {
+            image: { webgl: "webgl" },
+        } as unknown as ViewerContext;
+
+        new EnfaceProjectionOverlay([source("binary", "shared")]).repaint(
+            viewerContext,
+            {} as RenderTarget,
+        );
+        new EnfaceProjectionOverlay([source("heatmap", "shared")]).repaint(
+            viewerContext,
+            {} as RenderTarget,
+        );
+
+        expect(getShaderTemplateCache.mock.calls).toEqual([
+            ["webgl"],
+            ["webgl"],
+        ]);
     });
 });

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.test.ts
@@ -23,6 +23,7 @@ function source(
     mode: EnfaceOverlayPaintSource["mode"],
     mappingGlsl: string,
     alpha = 0.5,
+    identityMapping = false,
 ): EnfaceOverlayPaintSource {
     return {
         octPublicId: mappingGlsl,
@@ -43,6 +44,7 @@ function source(
         mode,
         sizePrimary: [200, 100],
         sizeSecondary: [50, 25],
+        identityMapping,
     };
 }
 
@@ -92,6 +94,7 @@ describe("EnfaceProjectionOverlay", () => {
             expect.objectContaining({
                 u_base: "base",
                 u_mode: 0,
+                u_nearest_sample: 0,
                 u_min_thickness: 0,
                 u_max_thickness: 1,
                 u_alpha: 0.2,
@@ -103,8 +106,45 @@ describe("EnfaceProjectionOverlay", () => {
             renderTarget,
             expect.objectContaining({
                 u_mode: 1,
+                u_nearest_sample: 0,
                 u_min_thickness: 2,
                 u_max_thickness: 8,
+            }),
+        );
+    });
+
+    it("uses nearest thickness sampling only for identity _proj binary", () => {
+        const binaryPass = vi.fn();
+        const heatmapPass = vi.fn();
+        compileShaderTemplate
+            .mockReturnValueOnce({ pass: binaryPass })
+            .mockReturnValueOnce({ pass: heatmapPass });
+
+        const overlay = new EnfaceProjectionOverlay(
+            [
+                source("binary", "proj-id", 0.5, true),
+                source("heatmap", "proj-heat", 0.5, true),
+            ],
+            webgl,
+        );
+
+        overlay.repaint(
+            { image: { webgl } } as unknown as ViewerContext,
+            {} as RenderTarget,
+        );
+
+        expect(binaryPass).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                u_mode: 0,
+                u_nearest_sample: 1,
+            }),
+        );
+        expect(heatmapPass).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                u_mode: 1,
+                u_nearest_sample: 0,
             }),
         );
     });

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
@@ -60,6 +60,9 @@ export class EnfaceProjectionOverlay implements Overlay {
             }
 
             const renderAsHeatmap = source.mode === "heatmap";
+            // Nearest only for identity `_proj` binary — avoid LINEAR row bleed.
+            const nearestSample =
+                source.identityMapping && !renderAsHeatmap ? 1 : 0;
             for (const { projection, color, layerAlpha } of projections) {
                 const thicknessRange = renderAsHeatmap
                     ? projection.getThicknessRange()
@@ -72,6 +75,7 @@ export class EnfaceProjectionOverlay implements Overlay {
                     u_max_thickness: thicknessRange.max,
                     u_alpha: layerAlpha * source.mainViewerContext.alpha,
                     u_mode: renderAsHeatmap ? 1 : 0,
+                    u_nearest_sample: nearestSample,
                     u_outline: false,
                     u_size_primary: source.sizePrimary,
                     u_size_secondary: source.sizeSecondary,

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
@@ -1,6 +1,6 @@
 import type { EnfaceOverlaySourceResolved } from "$lib/registration/resolveEnfaceOverlaySources";
 import { getBaseUniforms } from "$lib/webgl/imageRenderer";
-import { ShaderTemplateCache } from "$lib/webgl/shaderTemplate";
+import { getShaderTemplateCache } from "$lib/webgl/shaderTemplate";
 import type { RenderTarget } from "$lib/webgl/types";
 import fs_render_enface_projection from "./fs_render_enface_projection.frag";
 import type { Overlay } from "../viewer-utils";
@@ -12,12 +12,11 @@ export type EnfaceOverlayPaintSource = EnfaceOverlaySourceResolved & {
 };
 
 export class EnfaceProjectionOverlay implements Overlay {
-    private readonly programs = new ShaderTemplateCache();
-
     constructor(readonly sources: EnfaceOverlayPaintSource[]) {}
 
     repaint(viewerContext: ViewerContext, renderTarget: RenderTarget): void {
         const base = getBaseUniforms(viewerContext);
+        const programs = getShaderTemplateCache(viewerContext.image.webgl);
 
         for (const source of this.sources) {
             if (source.mode === "off" || !source.mainViewerContext) {
@@ -26,12 +25,15 @@ export class EnfaceProjectionOverlay implements Overlay {
 
             let program;
             try {
-                program = this.programs.getOrCompile(
+                program = programs.getOrCompile(
                     viewerContext.image.webgl,
                     fs_render_enface_projection,
                     { mapping: source.mappingGlsl },
                 );
             } catch {
+                continue;
+            }
+            if (!program) {
                 continue;
             }
 

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
@@ -1,47 +1,63 @@
-import type { EnfaceProjectionManager } from "$lib/viewer-window/enfaceProjectionManager.svelte";
+import type { EnfaceOverlaySourceResolved } from "$lib/registration/resolveEnfaceOverlaySources";
 import { getBaseUniforms } from "$lib/webgl/imageRenderer";
+import { ShaderTemplateCache } from "$lib/webgl/shaderTemplate";
 import type { RenderTarget } from "$lib/webgl/types";
+import fs_render_enface_projection from "./fs_render_enface_projection.frag";
 import type { Overlay } from "../viewer-utils";
 import type { ViewerContext } from "../viewerContext.svelte";
 import type { MainViewerContext } from "./MainViewerContext.svelte";
 
+export type EnfaceOverlayPaintSource = EnfaceOverlaySourceResolved & {
+    mainViewerContext: MainViewerContext;
+};
+
 export class EnfaceProjectionOverlay implements Overlay {
-    constructor(
-        readonly manager: EnfaceProjectionManager,
-        readonly mainViewerContext: MainViewerContext,
-    ) {}
+    private readonly programs = new ShaderTemplateCache();
+
+    constructor(readonly sources: EnfaceOverlayPaintSource[]) {}
 
     repaint(viewerContext: ViewerContext, renderTarget: RenderTarget): void {
-        const mode = viewerContext.enfaceProjectionMode;
-        if (mode === "off") {
-            return;
-        }
+        const base = getBaseUniforms(viewerContext);
 
-        const projections = this.manager.getVisibleProjections();
-        if (!projections.length) {
-            return;
-        }
+        for (const source of this.sources) {
+            if (source.mode === "off" || !source.mainViewerContext) {
+                continue;
+            }
 
-        const uniforms = getBaseUniforms(viewerContext);
-        const renderAsHeatmap = mode === "heatmap";
+            let program;
+            try {
+                program = this.programs.getOrCompile(
+                    viewerContext.image.webgl,
+                    fs_render_enface_projection,
+                    { mapping: source.mappingGlsl },
+                );
+            } catch {
+                continue;
+            }
 
-        for (const { projection, color, layerAlpha } of projections) {
-            const thicknessRange = renderAsHeatmap
-                ? projection.getThicknessRange()
-                : { min: 0, max: 1 };
-            viewerContext.image.webgl.shaders.renderEnfaceProjection.pass(
-                renderTarget,
-                {
-                    ...uniforms,
+            const projections = source.manager.getVisibleProjections();
+            if (!projections.length) {
+                continue;
+            }
+
+            const renderAsHeatmap = source.mode === "heatmap";
+            for (const { projection, color, layerAlpha } of projections) {
+                const thicknessRange = renderAsHeatmap
+                    ? projection.getThicknessRange()
+                    : { min: 0, max: 1 };
+                program.pass(renderTarget, {
+                    ...base,
                     u_thickness: projection.textureData.texture,
                     u_color: color.map((c) => c / 255),
                     u_min_thickness: thicknessRange.min,
                     u_max_thickness: thicknessRange.max,
-                    u_alpha: layerAlpha * this.mainViewerContext.alpha,
+                    u_alpha: layerAlpha * source.mainViewerContext.alpha,
                     u_mode: renderAsHeatmap ? 1 : 0,
                     u_outline: false,
-                },
-            );
+                    u_size_primary: source.sizePrimary,
+                    u_size_secondary: source.sizeSecondary,
+                });
+            }
         }
     }
 }

--- a/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
+++ b/client/src/lib/viewer/overlays/EnfaceProjectionOverlay.ts
@@ -1,6 +1,8 @@
 import type { EnfaceOverlaySourceResolved } from "$lib/registration/resolveEnfaceOverlaySources";
 import { getBaseUniforms } from "$lib/webgl/imageRenderer";
-import { getShaderTemplateCache } from "$lib/webgl/shaderTemplate";
+import { compileShaderTemplate } from "$lib/webgl/shaderTemplate";
+import type { TextureShaderProgram } from "$lib/webgl/FragmentShaderProgram";
+import type { WebGL } from "$lib/webgl/webgl";
 import type { RenderTarget } from "$lib/webgl/types";
 import fs_render_enface_projection from "./fs_render_enface_projection.frag";
 import type { Overlay } from "../viewer-utils";
@@ -11,32 +13,47 @@ export type EnfaceOverlayPaintSource = EnfaceOverlaySourceResolved & {
     mainViewerContext: MainViewerContext;
 };
 
+type PreparedSource = {
+    source: EnfaceOverlayPaintSource;
+    program: TextureShaderProgram;
+};
+
+/**
+ * Programs are compiled once when the overlay is created. TopViewer rebuilds
+ * this overlay when registration / modes change, so repaint only draws.
+ */
 export class EnfaceProjectionOverlay implements Overlay {
-    constructor(readonly sources: EnfaceOverlayPaintSource[]) {}
+    private readonly prepared: PreparedSource[] = [];
 
-    repaint(viewerContext: ViewerContext, renderTarget: RenderTarget): void {
-        const base = getBaseUniforms(viewerContext);
-        const programs = getShaderTemplateCache(viewerContext.image.webgl);
-
-        for (const source of this.sources) {
+    constructor(sources: EnfaceOverlayPaintSource[], webgl: WebGL) {
+        for (const source of sources) {
             if (source.mode === "off" || !source.mainViewerContext) {
                 continue;
             }
-
-            let program;
             try {
-                program = programs.getOrCompile(
-                    viewerContext.image.webgl,
+                const program = compileShaderTemplate(
+                    webgl,
                     fs_render_enface_projection,
                     { mapping: source.mappingGlsl },
                 );
-            } catch {
-                continue;
+                this.prepared.push({ source, program });
+            } catch (err) {
+                console.error(
+                    "EnfaceProjectionOverlay: shader compile failed",
+                    err,
+                );
             }
-            if (!program) {
-                continue;
-            }
+        }
+    }
 
+    repaint(viewerContext: ViewerContext, renderTarget: RenderTarget): void {
+        if (!this.prepared.length) {
+            return;
+        }
+
+        const base = getBaseUniforms(viewerContext);
+
+        for (const { source, program } of this.prepared) {
             const projections = source.manager.getVisibleProjections();
             if (!projections.length) {
                 continue;

--- a/client/src/lib/viewer/overlays/fs_render_enface_projection.frag
+++ b/client/src/lib/viewer/overlays/fs_render_enface_projection.frag
@@ -31,7 +31,7 @@ vec3 heatmap(float value) {
     return c4;
 }
 
-// @insert mapping
+/// @insert mapping
 
 void main() {
     color_out = vec4(0.0);

--- a/client/src/lib/viewer/overlays/fs_render_enface_projection.frag
+++ b/client/src/lib/viewer/overlays/fs_render_enface_projection.frag
@@ -9,6 +9,8 @@ uniform float u_max_thickness;
 uniform float u_alpha;
 uniform int u_mode;
 uniform vec3 u_image_size;
+uniform vec2 u_size_primary;
+uniform vec2 u_size_secondary;
 in vec2 v_uv;
 
 layout(location = 0) out vec4 color_out;
@@ -29,19 +31,24 @@ vec3 heatmap(float value) {
     return c4;
 }
 
+// @insert mapping
+
 void main() {
     color_out = vec4(0.0);
-    float thickness = texture(u_thickness, v_uv).r;
+    vec2 mapped = mapping(v_uv);
+    if(mapped.x < 0.0 || mapped.x > 1.0 || mapped.y < 0.0 || mapped.y > 1.0) {
+        return;
+    }
+
+    float thickness = texture(u_thickness, mapped).r;
     if(thickness <= 0.0) {
         return;
     }
 
     if(u_mode == 0) {
-        // Mask: any thickness > 0 renders as a flat feature color.
         vec4 feature_color = vec4(u_color, 1.0);
         color_out = mix(vec4(0.0), feature_color, u_alpha);
     } else {
-        // Heatmap: stretch foreground thickness between min and max.
         float range = max(u_max_thickness - u_min_thickness, 1e-6);
         float normalized = clamp((thickness - u_min_thickness) / range, 0.0, 1.0);
         color_out.rgb = heatmap(normalized);

--- a/client/src/lib/viewer/overlays/fs_render_enface_projection.frag
+++ b/client/src/lib/viewer/overlays/fs_render_enface_projection.frag
@@ -8,6 +8,7 @@ uniform float u_min_thickness;
 uniform float u_max_thickness;
 uniform float u_alpha;
 uniform int u_mode;
+uniform int u_nearest_sample;
 uniform vec3 u_image_size;
 uniform vec2 u_size_primary;
 uniform vec2 u_size_secondary;
@@ -33,6 +34,16 @@ vec3 heatmap(float value) {
 
 /// @insert mapping
 
+float sampleThickness(vec2 mapped) {
+    // Identity `_proj` binary: discrete B-scan rows must not bleed via LINEAR.
+    if(u_nearest_sample != 0) {
+        vec2 sz = u_size_secondary;
+        ivec2 tc = ivec2(clamp(floor(mapped * sz), vec2(0.0), sz - 1.0));
+        return texelFetch(u_thickness, tc, 0).r;
+    }
+    return texture(u_thickness, mapped).r;
+}
+
 void main() {
     color_out = vec4(0.0);
     vec2 mapped = mapping(v_uv);
@@ -40,7 +51,7 @@ void main() {
         return;
     }
 
-    float thickness = texture(u_thickness, mapped).r;
+    float thickness = sampleThickness(mapped);
     if(thickness <= 0.0) {
         return;
     }

--- a/client/src/lib/viewer/viewerContext.svelte.ts
+++ b/client/src/lib/viewer/viewerContext.svelte.ts
@@ -206,10 +206,6 @@ export class ViewerContext {
         this.enfaceProjectionModesByOct = map;
     }
 
-    getEnfaceProjectionModeForOct(octPublicId: string): EnfaceProjectionMode {
-        return this.enfaceProjectionModesByOct.get(octPublicId) ?? "off";
-    }
-
     initTransform() {
         this.transform = this.getInitTransform();
     }

--- a/client/src/lib/viewer/viewerContext.svelte.ts
+++ b/client/src/lib/viewer/viewerContext.svelte.ts
@@ -67,6 +67,11 @@ export class ViewerContext {
     hideOverlays: boolean = $state(false);
     renderMode: RenderMode = $state("Original");
     enfaceProjectionMode: EnfaceProjectionMode = $state("off");
+    /** Per-OCT enface overlay mode for non-_proj top-row images. */
+    enfaceProjectionModesByOct: Map<string, EnfaceProjectionMode> = $state(
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- Replace the Map to notify $state consumers.
+        new Map(),
+    );
     lockScroll: boolean = $state(false);
     windowLevel: WindowLevel = $state({ min: 0, max: 255 });
     cursorStyle: cursorStyle = $state("default");
@@ -188,6 +193,21 @@ export class ViewerContext {
             index: i,
         });
         this.index = i;
+    }
+
+    cycleEnfaceProjectionModeForOct(octPublicId: string): void {
+        const modes: EnfaceProjectionMode[] = ["off", "binary", "heatmap"];
+        const current =
+            this.enfaceProjectionModesByOct.get(octPublicId) ?? "off";
+        const next = modes[(modes.indexOf(current) + 1) % modes.length];
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- Replace the Map to notify $state consumers.
+        const map = new Map(this.enfaceProjectionModesByOct);
+        map.set(octPublicId, next);
+        this.enfaceProjectionModesByOct = map;
+    }
+
+    getEnfaceProjectionModeForOct(octPublicId: string): EnfaceProjectionMode {
+        return this.enfaceProjectionModesByOct.get(octPublicId) ?? "off";
     }
 
     initTransform() {

--- a/client/src/lib/viewer/viewerContext.svelte.ts
+++ b/client/src/lib/viewer/viewerContext.svelte.ts
@@ -5,7 +5,7 @@ import { BaseImageRenderer } from "$lib/webgl/imageRenderer";
 import type { Shaders } from "$lib/webgl/shaders";
 import { SvelteSet } from "svelte/reactivity";
 import type { ImageGET } from "../../types/openapi_types";
-import type { Registration } from "../registration/registration";
+import type { Registration } from "../registration/registration.svelte";
 import type { ViewerWindowContext } from "../viewer-window/viewerWindowContext.svelte";
 import { HotKeys } from "./controls/hotkeys";
 import { ScrollOCT } from "./controls/scrollOCT";

--- a/client/src/lib/webgl/multiImageFragment/redblue.frag
+++ b/client/src/lib/webgl/multiImageFragment/redblue.frag
@@ -19,7 +19,7 @@ in vec2 v_uv;
 
 layout(location = 0) out vec4 color_out;
 
-// @insert mapping
+/// @insert mapping
 
 void main() {
 

--- a/client/src/lib/webgl/multiImageRenderer.ts
+++ b/client/src/lib/webgl/multiImageRenderer.ts
@@ -2,7 +2,7 @@ import { TextureShaderProgram } from "$lib/webgl/FragmentShaderProgram";
 import type { Image2D } from "$lib/webgl/image2D";
 import type { WebGL } from "./webgl";
 import type { RenderTarget } from "./types";
-import type { Registration } from "$lib/registration/registration";
+import type { Registration } from "$lib/registration/registration.svelte";
 import type { ViewerContext } from "$lib/viewer/viewerContext.svelte";
 import { composeGlslPath } from "$lib/registration/composeGlslPath";
 import fs_redblue from "./multiImageFragment/redblue.frag";

--- a/client/src/lib/webgl/multiImageRenderer.ts
+++ b/client/src/lib/webgl/multiImageRenderer.ts
@@ -4,6 +4,7 @@ import type { WebGL } from "./webgl";
 import type { RenderTarget } from "./types";
 import type { Registration } from "$lib/registration/registration";
 import type { ViewerContext } from "$lib/viewer/viewerContext.svelte";
+import { composeGlslPath } from "$lib/registration/composeGlslPath";
 import fs_redblue from "./multiImageFragment/redblue.frag";
 import { getBaseUniforms, type ImageRenderer } from "./imageRenderer";
 
@@ -58,7 +59,7 @@ export class MultiImageRenderer implements ImageRenderer {
         if (item && item.glslMapping) {
             const fs_updated = fs_redblue.replace(
                 `// @insert mapping`,
-                item.glslMapping,
+                composeGlslPath([item.glslMapping]),
             );
             this.shaderRedBlue = new TextureShaderProgram(
                 this.webgl,

--- a/client/src/lib/webgl/programInfo.ts
+++ b/client/src/lib/webgl/programInfo.ts
@@ -32,6 +32,11 @@ export class ProgramInfo {
         gl.attachShader(program, vertexShader);
         gl.attachShader(program, fragmentShader);
         gl.linkProgram(program);
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const log = gl.getProgramInfoLog(program);
+            gl.deleteProgram(program);
+            throw new Error(`Program link failed: ${log ?? "no log"}`);
+        }
 
         this.program = program;
 

--- a/client/src/lib/webgl/shaderTemplate.test.ts
+++ b/client/src/lib/webgl/shaderTemplate.test.ts
@@ -1,5 +1,27 @@
-import { describe, it, expect } from "vitest";
-import { applyInserts, shaderCacheKey } from "./shaderTemplate";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const { textureShaderProgram } = vi.hoisted(() => ({
+    textureShaderProgram: vi.fn(),
+}));
+
+vi.mock("./FragmentShaderProgram", () => ({
+    TextureShaderProgram: class {
+        constructor(webgl: unknown, source: string) {
+            textureShaderProgram(webgl, source);
+        }
+    },
+}));
+
+import {
+    applyInserts,
+    getShaderTemplateCache,
+    shaderCacheKey,
+    ShaderTemplateCache,
+} from "./shaderTemplate";
+import type { WebGL } from "./webgl";
+
+const webgl = {} as WebGL;
+const template = "// @insert mapping";
 
 describe("applyInserts", () => {
     it("replaces insert slots", () => {
@@ -12,9 +34,9 @@ describe("applyInserts", () => {
     });
 
     it("throws if a slot is missing from the template", () => {
-        expect(() =>
-            applyInserts("no slots", { mapping: "x" }),
-        ).toThrow(/mapping/);
+        expect(() => applyInserts("no slots", { mapping: "x" })).toThrow(
+            /mapping/,
+        );
     });
 });
 
@@ -29,5 +51,46 @@ describe("shaderCacheKey", () => {
         const a = shaderCacheKey("t", { mapping: "m1" });
         const b = shaderCacheKey("t", { mapping: "m2" });
         expect(a).not.toBe(b);
+    });
+});
+
+describe("ShaderTemplateCache", () => {
+    beforeEach(() => {
+        textureShaderProgram.mockReset();
+    });
+
+    it("compiles once per key and returns the cached program", () => {
+        const cache = new ShaderTemplateCache();
+        const first = cache.getOrCompile(webgl, template, { mapping: "m" });
+        const second = cache.getOrCompile(webgl, template, { mapping: "m" });
+
+        expect(first).toBe(second);
+        expect(textureShaderProgram).toHaveBeenCalledOnce();
+    });
+
+    it("throws once on failure, then returns null without recompiling", () => {
+        textureShaderProgram.mockImplementation(() => {
+            throw new Error("compile failed");
+        });
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        const cache = new ShaderTemplateCache();
+
+        expect(() =>
+            cache.getOrCompile(webgl, template, { mapping: "bad" }),
+        ).toThrow(/compile failed/);
+        expect(
+            cache.getOrCompile(webgl, template, { mapping: "bad" }),
+        ).toBeNull();
+        expect(textureShaderProgram).toHaveBeenCalledOnce();
+    });
+});
+
+describe("getShaderTemplateCache", () => {
+    it("returns one cache per webgl context", () => {
+        const a = {} as WebGL;
+        const b = {} as WebGL;
+
+        expect(getShaderTemplateCache(a)).toBe(getShaderTemplateCache(a));
+        expect(getShaderTemplateCache(a)).not.toBe(getShaderTemplateCache(b));
     });
 });

--- a/client/src/lib/webgl/shaderTemplate.test.ts
+++ b/client/src/lib/webgl/shaderTemplate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { applyInserts, shaderCacheKey } from "./shaderTemplate";
+
+describe("applyInserts", () => {
+    it("replaces insert slots", () => {
+        const template = `A\n// @insert mapping\nB`;
+        const out = applyInserts(template, {
+            mapping: "vec2 mapping(vec2 uv) { return uv; }",
+        });
+        expect(out).toContain("vec2 mapping(vec2 uv)");
+        expect(out).not.toContain("@insert");
+    });
+
+    it("throws if a slot is missing from the template", () => {
+        expect(() =>
+            applyInserts("no slots", { mapping: "x" }),
+        ).toThrow(/mapping/);
+    });
+});
+
+describe("shaderCacheKey", () => {
+    it("is stable for same inputs", () => {
+        const a = shaderCacheKey("t", { mapping: "m1" });
+        const b = shaderCacheKey("t", { mapping: "m1" });
+        expect(a).toBe(b);
+    });
+
+    it("changes when insert content changes", () => {
+        const a = shaderCacheKey("t", { mapping: "m1" });
+        const b = shaderCacheKey("t", { mapping: "m2" });
+        expect(a).not.toBe(b);
+    });
+});

--- a/client/src/lib/webgl/shaderTemplate.test.ts
+++ b/client/src/lib/webgl/shaderTemplate.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 const { textureShaderProgram } = vi.hoisted(() => ({
     textureShaderProgram: vi.fn(),
@@ -12,16 +12,8 @@ vi.mock("./FragmentShaderProgram", () => ({
     },
 }));
 
-import {
-    applyInserts,
-    getShaderTemplateCache,
-    shaderCacheKey,
-    ShaderTemplateCache,
-} from "./shaderTemplate";
+import { applyInserts, compileShaderTemplate } from "./shaderTemplate";
 import type { WebGL } from "./webgl";
-
-const webgl = {} as WebGL;
-const template = "// @insert mapping";
 
 describe("applyInserts", () => {
     it("replaces insert slots", () => {
@@ -34,7 +26,6 @@ describe("applyInserts", () => {
     });
 
     it("prefers /// @insert so vite-plugin-glsl-preserved markers work", () => {
-        // vite-plugin-glsl strips `//` comments but keeps `///`.
         const template = `A\n/// @insert mapping\nB`;
         const out = applyInserts(template, {
             mapping: "vec2 mapping(vec2 uv) { return uv; }",
@@ -50,57 +41,16 @@ describe("applyInserts", () => {
     });
 });
 
-describe("shaderCacheKey", () => {
-    it("is stable for same inputs", () => {
-        const a = shaderCacheKey("t", { mapping: "m1" });
-        const b = shaderCacheKey("t", { mapping: "m1" });
-        expect(a).toBe(b);
-    });
-
-    it("changes when insert content changes", () => {
-        const a = shaderCacheKey("t", { mapping: "m1" });
-        const b = shaderCacheKey("t", { mapping: "m2" });
-        expect(a).not.toBe(b);
-    });
-});
-
-describe("ShaderTemplateCache", () => {
-    beforeEach(() => {
-        textureShaderProgram.mockReset();
-    });
-
-    it("compiles once per key and returns the cached program", () => {
-        const cache = new ShaderTemplateCache();
-        const first = cache.getOrCompile(webgl, template, { mapping: "m" });
-        const second = cache.getOrCompile(webgl, template, { mapping: "m" });
-
-        expect(first).toBe(second);
-        expect(textureShaderProgram).toHaveBeenCalledOnce();
-    });
-
-    it("throws once on failure, then returns null without recompiling", () => {
-        textureShaderProgram.mockImplementation(() => {
-            throw new Error("compile failed");
+describe("compileShaderTemplate", () => {
+    it("applies inserts then constructs a TextureShaderProgram", () => {
+        textureShaderProgram.mockClear();
+        const webgl = {} as WebGL;
+        compileShaderTemplate(webgl, "A\n/// @insert mapping\nB", {
+            mapping: "vec2 mapping(vec2 uv) { return uv; }",
         });
-        vi.spyOn(console, "error").mockImplementation(() => {});
-        const cache = new ShaderTemplateCache();
-
-        expect(() =>
-            cache.getOrCompile(webgl, template, { mapping: "bad" }),
-        ).toThrow(/compile failed/);
-        expect(
-            cache.getOrCompile(webgl, template, { mapping: "bad" }),
-        ).toBeNull();
-        expect(textureShaderProgram).toHaveBeenCalledOnce();
-    });
-});
-
-describe("getShaderTemplateCache", () => {
-    it("returns one cache per webgl context", () => {
-        const a = {} as WebGL;
-        const b = {} as WebGL;
-
-        expect(getShaderTemplateCache(a)).toBe(getShaderTemplateCache(a));
-        expect(getShaderTemplateCache(a)).not.toBe(getShaderTemplateCache(b));
+        expect(textureShaderProgram).toHaveBeenCalledWith(
+            webgl,
+            "A\nvec2 mapping(vec2 uv) { return uv; }\nB",
+        );
     });
 });

--- a/client/src/lib/webgl/shaderTemplate.test.ts
+++ b/client/src/lib/webgl/shaderTemplate.test.ts
@@ -33,6 +33,16 @@ describe("applyInserts", () => {
         expect(out).not.toContain("@insert");
     });
 
+    it("prefers /// @insert so vite-plugin-glsl-preserved markers work", () => {
+        // vite-plugin-glsl strips `//` comments but keeps `///`.
+        const template = `A\n/// @insert mapping\nB`;
+        const out = applyInserts(template, {
+            mapping: "vec2 mapping(vec2 uv) { return uv; }",
+        });
+        expect(out).toBe("A\nvec2 mapping(vec2 uv) { return uv; }\nB");
+        expect(out).not.toMatch(/^\//m);
+    });
+
     it("throws if a slot is missing from the template", () => {
         expect(() => applyInserts("no slots", { mapping: "x" })).toThrow(
             /mapping/,

--- a/client/src/lib/webgl/shaderTemplate.ts
+++ b/client/src/lib/webgl/shaderTemplate.ts
@@ -1,0 +1,63 @@
+import { TextureShaderProgram } from "./FragmentShaderProgram";
+import type { WebGL } from "./webgl";
+
+export function applyInserts(
+    template: string,
+    inserts: Record<string, string>,
+): string {
+    let out = template;
+    for (const [name, code] of Object.entries(inserts)) {
+        const marker = `// @insert ${name}`;
+        if (!out.includes(marker)) {
+            throw new Error(
+                `applyInserts: template missing slot "// @insert ${name}"`,
+            );
+        }
+        out = out.split(marker).join(code);
+    }
+    return out;
+}
+
+/** Deterministic cache key (not cryptographic). */
+export function shaderCacheKey(
+    template: string,
+    inserts: Record<string, string>,
+): string {
+    const parts = Object.keys(inserts)
+        .sort()
+        .map((k) => `${k}=${inserts[k]}`);
+    return `${template.length}:${fnv1a(template)}|${fnv1a(parts.join("\n"))}`;
+}
+
+function fnv1a(s: string): string {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(16);
+}
+
+export class ShaderTemplateCache {
+    private readonly cache = new Map<string, TextureShaderProgram>();
+
+    getOrCompile(
+        webgl: WebGL,
+        template: string,
+        inserts: Record<string, string>,
+    ): TextureShaderProgram {
+        const key = shaderCacheKey(template, inserts);
+        const hit = this.cache.get(key);
+        if (hit) return hit;
+
+        try {
+            const source = applyInserts(template, inserts);
+            const program = new TextureShaderProgram(webgl, source);
+            this.cache.set(key, program);
+            return program;
+        } catch (err) {
+            console.error("ShaderTemplateCache: compile failed", err);
+            throw err;
+        }
+    }
+}

--- a/client/src/lib/webgl/shaderTemplate.ts
+++ b/client/src/lib/webgl/shaderTemplate.ts
@@ -7,10 +7,19 @@ export function applyInserts(
 ): string {
     let out = template;
     for (const [name, code] of Object.entries(inserts)) {
-        const marker = `// @insert ${name}`;
-        if (!out.includes(marker)) {
+        // vite-plugin-glsl strips ordinary `//` comments; `///` is preserved.
+        // Check the triple-slash form first — `// @insert X` is a substring of
+        // `/// @insert X`, so matching single-slash first would leave a stray `/`.
+        const triple = `/// @insert ${name}`;
+        const single = `// @insert ${name}`;
+        const marker = out.includes(triple)
+            ? triple
+            : out.includes(single)
+              ? single
+              : null;
+        if (!marker) {
             throw new Error(
-                `applyInserts: template missing slot "// @insert ${name}"`,
+                `applyInserts: template missing slot "// @insert ${name}" or "/// @insert ${name}"`,
             );
         }
         out = out.split(marker).join(code);

--- a/client/src/lib/webgl/shaderTemplate.ts
+++ b/client/src/lib/webgl/shaderTemplate.ts
@@ -39,16 +39,18 @@ function fnv1a(s: string): string {
 }
 
 export class ShaderTemplateCache {
-    private readonly cache = new Map<string, TextureShaderProgram>();
+    /** `null` marks a key that already failed to compile, so we never retry it. */
+    private readonly cache = new Map<string, TextureShaderProgram | null>();
 
     getOrCompile(
         webgl: WebGL,
         template: string,
         inserts: Record<string, string>,
-    ): TextureShaderProgram {
+    ): TextureShaderProgram | null {
         const key = shaderCacheKey(template, inserts);
-        const hit = this.cache.get(key);
-        if (hit) return hit;
+        if (this.cache.has(key)) {
+            return this.cache.get(key)!;
+        }
 
         try {
             const source = applyInserts(template, inserts);
@@ -56,8 +58,25 @@ export class ShaderTemplateCache {
             this.cache.set(key, program);
             return program;
         } catch (err) {
+            this.cache.set(key, null);
             console.error("ShaderTemplateCache: compile failed", err);
             throw err;
         }
     }
+}
+
+const cachesByWebGL = new WeakMap<WebGL, ShaderTemplateCache>();
+
+/**
+ * Shader programs are tied to a GL context, not to whoever asked for them.
+ * Keying the cache on the `WebGL` instance lets short-lived consumers (overlays
+ * that get recreated whenever their props change) reuse compiled programs.
+ */
+export function getShaderTemplateCache(webgl: WebGL): ShaderTemplateCache {
+    let cache = cachesByWebGL.get(webgl);
+    if (!cache) {
+        cache = new ShaderTemplateCache();
+        cachesByWebGL.set(webgl, cache);
+    }
+    return cache;
 }

--- a/client/src/lib/webgl/shaderTemplate.ts
+++ b/client/src/lib/webgl/shaderTemplate.ts
@@ -27,65 +27,11 @@ export function applyInserts(
     return out;
 }
 
-/** Deterministic cache key (not cryptographic). */
-export function shaderCacheKey(
+/** Compile a fragment template with insert slots. Caller owns/reuses the program. */
+export function compileShaderTemplate(
+    webgl: WebGL,
     template: string,
     inserts: Record<string, string>,
-): string {
-    const parts = Object.keys(inserts)
-        .sort()
-        .map((k) => `${k}=${inserts[k]}`);
-    return `${template.length}:${fnv1a(template)}|${fnv1a(parts.join("\n"))}`;
-}
-
-function fnv1a(s: string): string {
-    let h = 0x811c9dc5;
-    for (let i = 0; i < s.length; i++) {
-        h ^= s.charCodeAt(i);
-        h = Math.imul(h, 0x01000193);
-    }
-    return (h >>> 0).toString(16);
-}
-
-export class ShaderTemplateCache {
-    /** `null` marks a key that already failed to compile, so we never retry it. */
-    private readonly cache = new Map<string, TextureShaderProgram | null>();
-
-    getOrCompile(
-        webgl: WebGL,
-        template: string,
-        inserts: Record<string, string>,
-    ): TextureShaderProgram | null {
-        const key = shaderCacheKey(template, inserts);
-        if (this.cache.has(key)) {
-            return this.cache.get(key)!;
-        }
-
-        try {
-            const source = applyInserts(template, inserts);
-            const program = new TextureShaderProgram(webgl, source);
-            this.cache.set(key, program);
-            return program;
-        } catch (err) {
-            this.cache.set(key, null);
-            console.error("ShaderTemplateCache: compile failed", err);
-            throw err;
-        }
-    }
-}
-
-const cachesByWebGL = new WeakMap<WebGL, ShaderTemplateCache>();
-
-/**
- * Shader programs are tied to a GL context, not to whoever asked for them.
- * Keying the cache on the `WebGL` instance lets short-lived consumers (overlays
- * that get recreated whenever their props change) reuse compiled programs.
- */
-export function getShaderTemplateCache(webgl: WebGL): ShaderTemplateCache {
-    let cache = cachesByWebGL.get(webgl);
-    if (!cache) {
-        cache = new ShaderTemplateCache();
-        cachesByWebGL.set(webgl, cache);
-    }
-    return cache;
+): TextureShaderProgram {
+    return new TextureShaderProgram(webgl, applyInserts(template, inserts));
 }

--- a/client/src/lib/webgl/shaders.ts
+++ b/client/src/lib/webgl/shaders.ts
@@ -25,13 +25,10 @@ import fs_enfaceProjectMask from "./glsl/fs_enface_project_mask.frag";
 import fs_enfaceProjectProbability from "./glsl/fs_enface_project_probability.frag";
 import fs_enfaceProjectMultiClass from "./glsl/fs_enface_project_multiclass.frag";
 import fs_enfaceProjectMultiLabel from "./glsl/fs_enface_project_multilabel.frag";
-import fs_renderEnfaceProjection from "$lib/viewer/overlays/fs_render_enface_projection.frag";
 import fs_minmax_reduction from "./glsl/fs_minmax_reduction.frag";
 import fs_normalize from "./glsl/fs_normalize.frag";
 import fs_extract_slice from "./glsl/fs_extract_slice.frag";
 import type { WebGL } from "./webgl";
-import { applyInserts } from "./shaderTemplate";
-import { composeGlslPath } from "$lib/registration/composeGlslPath";
 
 /** Inject shared segmentation quad outline helpers before main(). */
 function withSegBoundsOutline(fragmentSource: string): string {
@@ -67,7 +64,6 @@ export class Shaders {
     enfaceProjectProbability: PixelShaderProgram;
     enfaceProjectMultiClass: PixelShaderProgram;
     enfaceProjectMultiLabel: PixelShaderProgram;
-    renderEnfaceProjection: TextureShaderProgram;
     minMaxReduction: PixelShaderProgram;
     normalize: PixelShaderProgram;
     extractSlice: PixelShaderProgram;
@@ -120,12 +116,6 @@ export class Shaders {
         this.enfaceProjectMultiLabel = new PixelShaderProgram(
             webgl,
             fs_enfaceProjectMultiLabel,
-        );
-        this.renderEnfaceProjection = new TextureShaderProgram(
-            webgl,
-            applyInserts(fs_renderEnfaceProjection, {
-                mapping: composeGlslPath([]),
-            }),
         );
         this.minMaxReduction = new PixelShaderProgram(
             webgl,

--- a/client/src/lib/webgl/shaders.ts
+++ b/client/src/lib/webgl/shaders.ts
@@ -30,6 +30,8 @@ import fs_minmax_reduction from "./glsl/fs_minmax_reduction.frag";
 import fs_normalize from "./glsl/fs_normalize.frag";
 import fs_extract_slice from "./glsl/fs_extract_slice.frag";
 import type { WebGL } from "./webgl";
+import { applyInserts } from "./shaderTemplate";
+import { composeGlslPath } from "$lib/registration/composeGlslPath";
 
 /** Inject shared segmentation quad outline helpers before main(). */
 function withSegBoundsOutline(fragmentSource: string): string {
@@ -121,7 +123,9 @@ export class Shaders {
         );
         this.renderEnfaceProjection = new TextureShaderProgram(
             webgl,
-            fs_renderEnfaceProjection,
+            applyInserts(fs_renderEnfaceProjection, {
+                mapping: composeGlslPath([]),
+            }),
         );
         this.minMaxReduction = new PixelShaderProgram(
             webgl,

--- a/client/src/lib/webgl/webgl.ts
+++ b/client/src/lib/webgl/webgl.ts
@@ -68,6 +68,11 @@ export class WebGL {
         }
         gl.shaderSource(shader, shaderSource);
         gl.compileShader(shader);
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+            const log = gl.getShaderInfoLog(shader);
+            gl.deleteShader(shader);
+            throw new Error(`Shader compilation failed: ${log ?? "no log"}`);
+        }
         return shader;
     }
 }

--- a/client/vitest-setup.ts
+++ b/client/vitest-setup.ts
@@ -2,6 +2,29 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/svelte";
 
+// jsdom has no WebGL; texture.ts reads GLenum constants at module load.
+if (typeof WebGL2RenderingContext === "undefined") {
+    globalThis.WebGL2RenderingContext = {
+        RED_INTEGER: 0x8d94,
+        NEAREST: 0x2600,
+        RED: 0x1903,
+        UNSIGNED_BYTE: 0x1401,
+        LINEAR: 0x2601,
+        RG: 0x8227,
+        FLOAT: 0x1406,
+        R8: 0x8229,
+        R8UI: 0x8232,
+        UNSIGNED_SHORT: 0x1403,
+        R16UI: 0x8234,
+        UNSIGNED_INT: 0x1405,
+        R32UI: 0x8236,
+        R32F: 0x822e,
+        RG32F: 0x8230,
+        RGBA: 0x1908,
+        RGBA8: 0x8058,
+    } as unknown as typeof WebGL2RenderingContext;
+}
+
 // Unmount any component rendered by a test so DOM state never leaks between tests.
 afterEach(() => {
     cleanup();


### PR DESCRIPTION
## Summary
- Render enface segmentation overlays on registered top-row images by composing baked GLSL registration hops (affine / parabolic / photolocator → `_proj`).
- Gate raster overlays with DICOM slice thickness (or median B-scan line spacing) so fill stops past the first/last photolocator; wrap circle scan angles with `fract` so Heidelberg rings sample correctly.
- Compile overlay shaders once per overlay lifetime; re-resolve sources when late registration imports arrive.

## Test plan
- [ ] Volume (line) OCT: enable enface mode on `_proj` and on a registered IR/fundus; confirm strip fill without infinite bleed above/below first/last B-scan
- [ ] Circle OCT: overlay appears on registered enface with full ring sampling (not blank)
- [ ] Linked multi-hop path (fundus → IR → `_proj`) still paints when per-OCT mode is on
- [ ] Toggle off/mask/heatmap per linked OCT independently of `_proj` mode
- [ ] `cd client && npx vitest run src/lib/registration/`


Made with [Cursor](https://cursor.com)