### PR TITLE
Viewer URL / localStorage bookmarks (scaffold for #138)

### DIFF
--- a/client/src/lib/viewer-window/BrowserOverlay.svelte
+++ b/client/src/lib/viewer-window/BrowserOverlay.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
-    import { page } from "$app/state";
     import Browser from "$lib/browser/Browser.svelte";
     import {
         BrowserContext,
@@ -81,11 +80,12 @@
                 updateSubTaskImageLinks(currentInstanceIds);
             }
         } else {
-            // updates url (just visual, does not reload the page)
-            const searchParams = page.url.searchParams;
+            // history.replaceState (view-state) is not mirrored into page.url.
+            // eslint-disable-next-line svelte/prefer-svelte-reactivity -- one-shot close() rewrite
+            const searchParams = new URLSearchParams(window.location.search);
             searchParams.set("instances", currentInstanceIds.join(","));
             // eslint-disable-next-line svelte/no-navigation-without-resolve -- query-only nav on current route
-            goto(`?${page.url.searchParams.toString()}`.replaceAll("%2C", ","));
+            goto(`?${searchParams.toString()}`.replaceAll("%2C", ","));
         }
         viewerWindowContext.setInstanceIDs(currentInstanceIds);
     }

--- a/client/src/lib/viewer-window/ViewerWindow.svelte
+++ b/client/src/lib/viewer-window/ViewerWindow.svelte
@@ -23,9 +23,44 @@ Keeps track of the main panels and the top row of images.
     setContext("viewerWindowContext", viewerWindowContext);
     const registration = viewerWindowContext.registration;
 
-    // open first image
+    // Open main viewers from view-state when present; else first instance.
     const instanceIds = viewerWindowContext.instanceIds;
-    if (instanceIds.length) {
+    const pendingViewers = viewerWindowContext.viewState?.getViewers() ?? [];
+    if (pendingViewers.length) {
+        Promise.all(
+            pendingViewers.map(async (entry) => {
+                const instanceId = entry.id.replace(/_proj$/u, "");
+                const images = await viewerWindowContext.getImages(instanceId);
+                return (
+                    images.find((img) => img.image_id === entry.id) ??
+                    images[images.length - 1]
+                );
+            }),
+        )
+            .then((images) => {
+                const panels = images
+                    .filter((image): image is NonNullable<typeof image> =>
+                        Boolean(image),
+                    )
+                    .map((image) => ({
+                        component: MainViewer,
+                        props: { image },
+                    }));
+                if (!panels.length) return;
+                if (panels.length === 1) {
+                    viewerWindowContext.setPanel(panels[0]);
+                } else {
+                    viewerWindowContext.mainPanels = panels;
+                    viewerWindowContext.syncMainPanelsToViewState();
+                }
+            })
+            .catch((error) => {
+                console.error(
+                    "[viewerViewState] failed to restore open viewers",
+                    error,
+                );
+            });
+    } else if (instanceIds.length) {
         const openInstance = instanceIds[0];
         viewerWindowContext.getImages(openInstance).then((images) => {
             // images is normally a single image

--- a/client/src/lib/viewer-window/ViewerWindow.svelte
+++ b/client/src/lib/viewer-window/ViewerWindow.svelte
@@ -7,7 +7,6 @@ Keeps track of the main panels and the top row of images.
 <script lang="ts">
     import { onDestroy, onMount, setContext } from "svelte";
     import MainPanel from "./MainPanel.svelte";
-    import MainViewer from "./MainViewer.svelte";
     import TopRowImages from "./TopRowImages.svelte";
     import { ViewerWindowContext } from "./viewerWindowContext.svelte";
     import RegistrationItemLoader from "./RegistrationItemLoader.svelte";
@@ -23,55 +22,8 @@ Keeps track of the main panels and the top row of images.
     setContext("viewerWindowContext", viewerWindowContext);
     const registration = viewerWindowContext.registration;
 
-    // Open main viewers from view-state when present; else first instance.
-    const instanceIds = viewerWindowContext.instanceIds;
-    const pendingViewers = viewerWindowContext.viewState?.getViewers() ?? [];
-    if (pendingViewers.length) {
-        Promise.all(
-            pendingViewers.map(async (entry) => {
-                const instanceId = entry.id.replace(/_proj$/u, "");
-                const images = await viewerWindowContext.getImages(instanceId);
-                return (
-                    images.find((img) => img.image_id === entry.id) ??
-                    images[images.length - 1]
-                );
-            }),
-        )
-            .then((images) => {
-                const panels = images
-                    .filter((image): image is NonNullable<typeof image> =>
-                        Boolean(image),
-                    )
-                    .map((image) => ({
-                        component: MainViewer,
-                        props: { image },
-                    }));
-                if (!panels.length) return;
-                if (panels.length === 1) {
-                    viewerWindowContext.setPanel(panels[0]);
-                } else {
-                    viewerWindowContext.mainPanels = panels;
-                    viewerWindowContext.syncMainPanelsToViewState();
-                }
-            })
-            .catch((error) => {
-                console.error(
-                    "[viewerViewState] failed to restore open viewers",
-                    error,
-                );
-            });
-    } else if (instanceIds.length) {
-        const openInstance = instanceIds[0];
-        viewerWindowContext.getImages(openInstance).then((images) => {
-            // images is normally a single image
-            // for OCT it is an array: enface projection + oct image
-            const panel = {
-                component: MainViewer,
-                props: { image: images[images.length - 1] }, // last image (in case of OCT)
-            };
-            viewerWindowContext.setPanel(panel);
-        });
-    }
+    // Main viewers are restored by ViewerWindowContext after images load
+    // (see restoreMainViewersFromViewState) so task grade and /view share one path.
 
     let main: HTMLDivElement | undefined = $state();
     let isResizing = false;

--- a/client/src/lib/viewer-window/ViewerWindowLoader.svelte
+++ b/client/src/lib/viewer-window/ViewerWindowLoader.svelte
@@ -4,7 +4,6 @@ Used to create the viewerwindow context.
 
 -->
 <script lang="ts">
-    import { page } from "$app/state";
     import type { GlobalContext } from "$lib/data/globalContext.svelte";
     import { Registration } from "$lib/registration/registration";
     import type { TaskContext } from "$lib/tasks/TaskContext.svelte";
@@ -90,9 +89,11 @@ Used to create the viewerwindow context.
 
         const viewState = createViewerViewStateController({
             scope,
-            getSearchParams: () => new URLSearchParams(page.url.searchParams),
+            getSearchParams: () => new URLSearchParams(window.location.search),
             replaceUrl: (params) => {
                 // Avoid `new URL(...)` (svelte/prefer-svelte-reactivity).
+                // Use history.replaceState (not page.url) so we don't fight SvelteKit;
+                // readers must use window.location.search (see BrowserOverlay).
                 const searchRaw = params.toString();
                 const search = searchRaw
                     ? `?${searchRaw.replaceAll("%2C", ",")}`
@@ -103,8 +104,7 @@ Used to create the viewerwindow context.
                     `${window.location.pathname}${search}${window.location.hash}`,
                 );
             },
-            storage:
-                typeof localStorage !== "undefined" ? localStorage : undefined,
+            storage: localStorage,
         });
         viewState.hydrate();
 

--- a/client/src/lib/viewer-window/ViewerWindowLoader.svelte
+++ b/client/src/lib/viewer-window/ViewerWindowLoader.svelte
@@ -92,14 +92,15 @@ Used to create the viewerwindow context.
             scope,
             getSearchParams: () => new URLSearchParams(page.url.searchParams),
             replaceUrl: (params) => {
-                const url = new URL(window.location.href);
-                url.search = params.toString();
-                // Keep commas readable like BrowserOverlay does for instances
-                const search = url.search.replaceAll("%2C", ",");
+                // Avoid `new URL(...)` (svelte/prefer-svelte-reactivity).
+                const searchRaw = params.toString();
+                const search = searchRaw
+                    ? `?${searchRaw.replaceAll("%2C", ",")}`
+                    : "";
                 history.replaceState(
                     history.state,
                     "",
-                    `${url.pathname}${search}${url.hash}`,
+                    `${window.location.pathname}${search}${window.location.hash}`,
                 );
             },
             storage:

--- a/client/src/lib/viewer-window/ViewerWindowLoader.svelte
+++ b/client/src/lib/viewer-window/ViewerWindowLoader.svelte
@@ -4,12 +4,15 @@ Used to create the viewerwindow context.
 
 -->
 <script lang="ts">
+    import { page } from "$app/state";
     import type { GlobalContext } from "$lib/data/globalContext.svelte";
     import { Registration } from "$lib/registration/registration";
+    import type { TaskContext } from "$lib/tasks/TaskContext.svelte";
     import { Deferred } from "$lib/utils";
     import { WebGL } from "$lib/webgl/webgl";
     import { getContext, onMount } from "svelte";
     import ViewerWindow from "./ViewerWindow.svelte";
+    import { createViewerViewStateController } from "./viewerViewState";
     import { ViewerWindowContext } from "./viewerWindowContext.svelte";
 
     interface Props {
@@ -27,6 +30,7 @@ Used to create the viewerwindow context.
     }
     const globalContext = getContext<GlobalContext>("globalContext");
     const { user: creator } = globalContext;
+    const taskContext = getContext<TaskContext | undefined>("taskContext");
 
     const { promise, resolve, reject } = new Deferred<ViewerWindowContext>();
     let viewerWindowContext: ViewerWindowContext | null = null;
@@ -78,11 +82,37 @@ Used to create the viewerwindow context.
 
         webgl = new WebGL(mainCanvas);
         const registration = new Registration();
+
+        const scope =
+            taskContext?.subTask?.id != null
+                ? `subtask:${taskContext.subTask.id}`
+                : "view";
+
+        const viewState = createViewerViewStateController({
+            scope,
+            getSearchParams: () => new URLSearchParams(page.url.searchParams),
+            replaceUrl: (params) => {
+                const url = new URL(window.location.href);
+                url.search = params.toString();
+                // Keep commas readable like BrowserOverlay does for instances
+                const search = url.search.replaceAll("%2C", ",");
+                history.replaceState(
+                    history.state,
+                    "",
+                    `${url.pathname}${search}${url.hash}`,
+                );
+            },
+            storage:
+                typeof localStorage !== "undefined" ? localStorage : undefined,
+        });
+        viewState.hydrate();
+
         viewerWindowContext = new ViewerWindowContext(
             webgl,
             registration,
             creator,
             instanceIDs,
+            viewState,
         );
 
         resolve(viewerWindowContext);

--- a/client/src/lib/viewer-window/panelSegmentation/BscanLinks.svelte
+++ b/client/src/lib/viewer-window/panelSegmentation/BscanLinks.svelte
@@ -13,8 +13,6 @@
     const scanIndices = $derived(segmentationContext.scan_indices);
 
     const viewerContext = getContext<ViewerContext>("viewerContext");
-    const image = viewerContext.image;
-    const registration = viewerContext.registration;
 
     const displayItems = $derived(
         buildBscanDisplayItems(scanIndices, viewerContext.index),
@@ -25,7 +23,7 @@
         e.stopPropagation();
         const lock = viewerContext.lockScroll;
         viewerContext.lockScroll = false;
-        registration.setPosition(image.image_id, { x: 0, y: 0, index: scanNr });
+        viewerContext.setIndex(scanNr);
         setTimeout(() => (viewerContext.lockScroll = lock), 0);
     }
 </script>

--- a/client/src/lib/viewer-window/viewerViewState.test.ts
+++ b/client/src/lib/viewer-window/viewerViewState.test.ts
@@ -170,8 +170,10 @@ describe("createViewerViewStateController", () => {
         c.enableRecording();
         expect(params.get("v")).toBe("aaa");
         c.recordIndex("aaa", 4, 10);
+        c.flush();
         expect(params.get("v")).toBe("aaa.4");
         c.recordIndex("zzz", 1, 10);
+        c.flush();
         expect(params.get("v")).toBe("aaa.4");
     });
 

--- a/client/src/lib/viewer-window/viewerViewState.test.ts
+++ b/client/src/lib/viewer-window/viewerViewState.test.ts
@@ -5,7 +5,21 @@ import {
     parseStoredState,
     serializeStoredState,
     storageKey,
+    createViewerViewStateController,
 } from "./viewerViewState";
+
+function memoryStorage(): Pick<Storage, "getItem" | "setItem"> & {
+    data: Record<string, string>;
+} {
+    const data: Record<string, string> = {};
+    return {
+        data,
+        getItem: (k) => data[k] ?? null,
+        setItem: (k, v) => {
+            data[k] = v;
+        },
+    };
+}
 
 describe("parseFrameParam / serializeFrameParam", () => {
     it("round-trips id:index pairs", () => {
@@ -49,5 +63,90 @@ describe("storageKey", () => {
     it("prefixes scope", () => {
         expect(storageKey("view")).toBe("eyened:viewerViewState:view");
         expect(storageKey("subtask:99")).toBe("eyened:viewerViewState:subtask:99");
+    });
+});
+
+describe("createViewerViewStateController", () => {
+    it("prefers URL frame over localStorage on hydrate", () => {
+        const storage = memoryStorage();
+        storage.setItem(
+            "eyened:viewerViewState:view",
+            JSON.stringify({ version: 1, frames: { aaa: 1 } }),
+        );
+        let params = new URLSearchParams("frame=aaa:9");
+        const replaced: string[] = [];
+        const c = createViewerViewStateController({
+            scope: "view",
+            getSearchParams: () => params,
+            replaceUrl: (p) => {
+                replaced.push(p.toString());
+                params = new URLSearchParams(p);
+            },
+            storage,
+        });
+        c.hydrate();
+        expect(c.peekFrame("aaa", 100)).toBe(9);
+        c.enableRecording();
+        expect(params.get("frame")).toBe("aaa:9");
+    });
+
+    it("falls back to localStorage when URL frame empty", () => {
+        const storage = memoryStorage();
+        storage.setItem(
+            "eyened:viewerViewState:subtask:5",
+            JSON.stringify({ version: 1, frames: { aaa: 3 } }),
+        );
+        let params = new URLSearchParams();
+        const c = createViewerViewStateController({
+            scope: "subtask:5",
+            getSearchParams: () => params,
+            replaceUrl: (p) => {
+                params = new URLSearchParams(p);
+            },
+            storage,
+        });
+        c.hydrate();
+        expect(c.peekFrame("aaa", 10)).toBe(3);
+    });
+
+    it("ignores record until enableRecording", () => {
+        let params = new URLSearchParams();
+        const storage = memoryStorage();
+        const c = createViewerViewStateController({
+            scope: "view",
+            getSearchParams: () => params,
+            replaceUrl: (p) => {
+                params = new URLSearchParams(p);
+            },
+            storage,
+        });
+        c.hydrate();
+        c.record("aaa", 4, 10);
+        expect(params.get("frame")).toBeNull();
+        c.enableRecording();
+        c.record("aaa", 4, 10);
+        expect(params.get("frame")).toBe("aaa:4");
+        expect(
+            JSON.parse(storage.data["eyened:viewerViewState:view"]).frames.aaa,
+        ).toBe(4);
+    });
+
+    it("peekFrame rejects out-of-range; prune drops stale ids", () => {
+        let params = new URLSearchParams("frame=aaa:50,bbb:2");
+        const storage = memoryStorage();
+        const c = createViewerViewStateController({
+            scope: "view",
+            getSearchParams: () => params,
+            replaceUrl: (p) => {
+                params = new URLSearchParams(p);
+            },
+            storage,
+        });
+        c.hydrate();
+        expect(c.peekFrame("aaa", 10)).toBeUndefined();
+        expect(c.peekFrame("bbb", 10)).toBe(2);
+        c.enableRecording();
+        c.prune(["bbb"]);
+        expect(params.get("frame")).toBe("bbb:2");
     });
 });

--- a/client/src/lib/viewer-window/viewerViewState.test.ts
+++ b/client/src/lib/viewer-window/viewerViewState.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+    parseFrameParam,
+    serializeFrameParam,
+    parseStoredState,
+    serializeStoredState,
+    storageKey,
+} from "./viewerViewState";
+
+describe("parseFrameParam / serializeFrameParam", () => {
+    it("round-trips id:index pairs", () => {
+        const frames = { aaa: 42, bbb: 10 };
+        expect(parseFrameParam(serializeFrameParam(frames))).toEqual(frames);
+    });
+
+    it("returns empty object for null/empty", () => {
+        expect(parseFrameParam(null)).toEqual({});
+        expect(parseFrameParam("")).toEqual({});
+        expect(parseFrameParam(undefined)).toEqual({});
+    });
+
+    it("ignores malformed pairs and non-integer / negative indices", () => {
+        expect(parseFrameParam("aaa:42,bad,bbb:x,ccc:-1,ddd:3.5,eee:7")).toEqual({
+            aaa: 42,
+            eee: 7,
+        });
+    });
+
+    it("omits empty serialize", () => {
+        expect(serializeFrameParam({})).toBe("");
+    });
+});
+
+describe("parseStoredState / serializeStoredState", () => {
+    it("round-trips v1 payload", () => {
+        const state = { version: 1 as const, frames: { a: 1 } };
+        expect(parseStoredState(serializeStoredState(state))).toEqual(state);
+    });
+
+    it("returns null for invalid JSON, wrong version, or missing frames", () => {
+        expect(parseStoredState(null)).toBeNull();
+        expect(parseStoredState("{")).toBeNull();
+        expect(parseStoredState(JSON.stringify({ version: 2, frames: {} }))).toBeNull();
+        expect(parseStoredState(JSON.stringify({ version: 1 }))).toBeNull();
+    });
+});
+
+describe("storageKey", () => {
+    it("prefixes scope", () => {
+        expect(storageKey("view")).toBe("eyened:viewerViewState:view");
+        expect(storageKey("subtask:99")).toBe("eyened:viewerViewState:subtask:99");
+    });
+});

--- a/client/src/lib/viewer-window/viewerViewState.test.ts
+++ b/client/src/lib/viewer-window/viewerViewState.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
-    parseFrameParam,
-    serializeFrameParam,
+    parseViewersParam,
+    serializeViewersParam,
     parseStoredState,
     serializeStoredState,
     storageKey,
     createViewerViewStateController,
+    VIEW_STATE_PARAM,
+    instanceIdFromImageId,
 } from "./viewerViewState";
 
 function memoryStorage(): Pick<Storage, "getItem" | "setItem"> & {
@@ -21,68 +23,93 @@ function memoryStorage(): Pick<Storage, "getItem" | "setItem"> & {
     };
 }
 
-describe("parseFrameParam / serializeFrameParam", () => {
-    it("round-trips id:index pairs", () => {
-        const frames = { aaa: 42, bbb: 10 };
-        expect(parseFrameParam(serializeFrameParam(frames))).toEqual(frames);
+describe("parseViewersParam / serializeViewersParam", () => {
+    it("round-trips id.index and bare ids", () => {
+        const viewers = [
+            { id: "aaa", index: 42 },
+            { id: "bbb_proj" },
+            { id: "ccc", index: 10 },
+        ];
+        expect(parseViewersParam(serializeViewersParam(viewers))).toEqual(
+            viewers,
+        );
     });
 
-    it("returns empty object for null/empty", () => {
-        expect(parseFrameParam(null)).toEqual({});
-        expect(parseFrameParam("")).toEqual({});
-        expect(parseFrameParam(undefined)).toEqual({});
+    it("returns empty for null/empty", () => {
+        expect(parseViewersParam(null)).toEqual([]);
+        expect(parseViewersParam("")).toEqual([]);
+        expect(parseViewersParam(undefined)).toEqual([]);
     });
 
-    it("ignores malformed pairs and non-integer / negative indices", () => {
+    it("ignores malformed tokens", () => {
         expect(
-            parseFrameParam("aaa:42,bad,bbb:x,ccc:-1,ddd:3.5,eee:7"),
-        ).toEqual({
-            aaa: 42,
-            eee: 7,
-        });
+            parseViewersParam("aaa.42,bad!,bbb.x,ccc.-1,ddd.3.5,eee.7,fff"),
+        ).toEqual([
+            { id: "aaa", index: 42 },
+            { id: "eee", index: 7 },
+            { id: "fff" },
+        ]);
     });
 
     it("omits empty serialize", () => {
-        expect(serializeFrameParam({})).toBe("");
+        expect(serializeViewersParam([])).toBe("");
+    });
+
+    it("does not percent-encode dots in typical ids", () => {
+        const encoded = serializeViewersParam([
+            { id: "q4m7gj6h", index: 119 },
+            { id: "vc88pyyh", index: 15 },
+        ]);
+        expect(encoded).toBe("q4m7gj6h.119,vc88pyyh.15");
+        expect(encoded.includes("%")).toBe(false);
+        expect(encoded.includes(":")).toBe(false);
     });
 });
 
 describe("parseStoredState / serializeStoredState", () => {
-    it("round-trips v1 payload", () => {
-        const state = { version: 1 as const, frames: { a: 1 } };
+    it("round-trips v2 payload", () => {
+        const state = {
+            version: 2 as const,
+            viewers: [{ id: "a", index: 1 }, { id: "b" }],
+        };
         expect(parseStoredState(serializeStoredState(state))).toEqual(state);
     });
 
-    it("returns null for invalid JSON, wrong version, or missing frames", () => {
+    it("returns null for invalid or legacy payloads", () => {
         expect(parseStoredState(null)).toBeNull();
         expect(parseStoredState("{")).toBeNull();
         expect(
-            parseStoredState(JSON.stringify({ version: 2, frames: {} })),
+            parseStoredState(JSON.stringify({ version: 1, frames: {} })),
         ).toBeNull();
-        expect(parseStoredState(JSON.stringify({ version: 1 }))).toBeNull();
-        expect(
-            parseStoredState(JSON.stringify({ version: 1, frames: [5] })),
-        ).toBeNull();
+        expect(parseStoredState(JSON.stringify({ version: 2 }))).toBeNull();
     });
 });
 
-describe("storageKey", () => {
+describe("storageKey / instanceIdFromImageId", () => {
     it("prefixes scope", () => {
         expect(storageKey("view")).toBe("eyened:viewerViewState:view");
         expect(storageKey("subtask:99")).toBe(
             "eyened:viewerViewState:subtask:99",
         );
     });
+
+    it("strips _proj suffix", () => {
+        expect(instanceIdFromImageId("abc_proj")).toBe("abc");
+        expect(instanceIdFromImageId("abc")).toBe("abc");
+    });
 });
 
 describe("createViewerViewStateController", () => {
-    it("prefers URL frame over localStorage on hydrate", () => {
+    it(`prefers URL ${VIEW_STATE_PARAM} over localStorage on hydrate`, () => {
         const storage = memoryStorage();
         storage.setItem(
             "eyened:viewerViewState:view",
-            JSON.stringify({ version: 1, frames: { aaa: 1 } }),
+            JSON.stringify({
+                version: 2,
+                viewers: [{ id: "aaa", index: 1 }],
+            }),
         );
-        let params = new URLSearchParams("frame=aaa:9");
+        let params = new URLSearchParams("v=aaa.9,bbb");
         const c = createViewerViewStateController({
             scope: "view",
             getSearchParams: () => params,
@@ -92,16 +119,23 @@ describe("createViewerViewStateController", () => {
             storage,
         });
         c.hydrate();
-        expect(c.peekFrame("aaa", 100)).toBe(9);
+        expect(c.getViewers()).toEqual([
+            { id: "aaa", index: 9 },
+            { id: "bbb" },
+        ]);
         c.enableRecording();
-        expect(params.get("frame")).toBe("aaa:9");
+        expect(params.get("v")).toBe("aaa.9,bbb");
+        expect(params.get("frame")).toBeNull();
     });
 
-    it("falls back to localStorage when URL frame empty", () => {
+    it("falls back to localStorage when URL empty", () => {
         const storage = memoryStorage();
         storage.setItem(
             "eyened:viewerViewState:subtask:5",
-            JSON.stringify({ version: 1, frames: { aaa: 3 } }),
+            JSON.stringify({
+                version: 2,
+                viewers: [{ id: "aaa", index: 3 }],
+            }),
         );
         let params = new URLSearchParams();
         const c = createViewerViewStateController({
@@ -113,12 +147,12 @@ describe("createViewerViewStateController", () => {
             storage,
         });
         c.hydrate();
-        expect(c.peekFrame("aaa", 10)).toBe(3);
+        expect(c.peekIndex("aaa", 10)).toBe(3);
         c.enableRecording();
-        expect(params.get("frame")).toBe("aaa:3");
+        expect(params.get("v")).toBe("aaa.3");
     });
 
-    it("ignores record until enableRecording", () => {
+    it("ignores recordIndex until enableRecording and only for open viewers", () => {
         let params = new URLSearchParams();
         const storage = memoryStorage();
         const c = createViewerViewStateController({
@@ -130,18 +164,19 @@ describe("createViewerViewStateController", () => {
             storage,
         });
         c.hydrate();
-        c.record("aaa", 4, 10);
-        expect(params.get("frame")).toBeNull();
+        c.setOpenViewers([{ id: "aaa" }]);
+        c.recordIndex("aaa", 4, 10);
+        expect(params.get("v")).toBeNull();
         c.enableRecording();
-        c.record("aaa", 4, 10);
-        expect(params.get("frame")).toBe("aaa:4");
-        expect(
-            JSON.parse(storage.data["eyened:viewerViewState:view"]).frames.aaa,
-        ).toBe(4);
+        expect(params.get("v")).toBe("aaa");
+        c.recordIndex("aaa", 4, 10);
+        expect(params.get("v")).toBe("aaa.4");
+        c.recordIndex("zzz", 1, 10);
+        expect(params.get("v")).toBe("aaa.4");
     });
 
-    it("peekFrame rejects out-of-range; prune drops stale ids", () => {
-        let params = new URLSearchParams("frame=aaa:50,bbb:2");
+    it("peekIndex rejects out-of-range; prune drops stale instance viewers", () => {
+        let params = new URLSearchParams("v=aaa.50,bbb.2,ccc_proj");
         const storage = memoryStorage();
         const c = createViewerViewStateController({
             scope: "view",
@@ -152,10 +187,10 @@ describe("createViewerViewStateController", () => {
             storage,
         });
         c.hydrate();
-        expect(c.peekFrame("aaa", 10)).toBeUndefined();
-        expect(c.peekFrame("bbb", 10)).toBe(2);
+        expect(c.peekIndex("aaa", 10)).toBeUndefined();
+        expect(c.peekIndex("bbb", 10)).toBe(2);
         c.enableRecording();
-        c.prune(["bbb"]);
-        expect(params.get("frame")).toBe("bbb:2");
+        c.prune(["bbb", "ccc"]);
+        expect(params.get("v")).toBe("bbb.2,ccc_proj");
     });
 });

--- a/client/src/lib/viewer-window/viewerViewState.test.ts
+++ b/client/src/lib/viewer-window/viewerViewState.test.ts
@@ -34,7 +34,9 @@ describe("parseFrameParam / serializeFrameParam", () => {
     });
 
     it("ignores malformed pairs and non-integer / negative indices", () => {
-        expect(parseFrameParam("aaa:42,bad,bbb:x,ccc:-1,ddd:3.5,eee:7")).toEqual({
+        expect(
+            parseFrameParam("aaa:42,bad,bbb:x,ccc:-1,ddd:3.5,eee:7"),
+        ).toEqual({
             aaa: 42,
             eee: 7,
         });
@@ -54,15 +56,22 @@ describe("parseStoredState / serializeStoredState", () => {
     it("returns null for invalid JSON, wrong version, or missing frames", () => {
         expect(parseStoredState(null)).toBeNull();
         expect(parseStoredState("{")).toBeNull();
-        expect(parseStoredState(JSON.stringify({ version: 2, frames: {} }))).toBeNull();
+        expect(
+            parseStoredState(JSON.stringify({ version: 2, frames: {} })),
+        ).toBeNull();
         expect(parseStoredState(JSON.stringify({ version: 1 }))).toBeNull();
+        expect(
+            parseStoredState(JSON.stringify({ version: 1, frames: [5] })),
+        ).toBeNull();
     });
 });
 
 describe("storageKey", () => {
     it("prefixes scope", () => {
         expect(storageKey("view")).toBe("eyened:viewerViewState:view");
-        expect(storageKey("subtask:99")).toBe("eyened:viewerViewState:subtask:99");
+        expect(storageKey("subtask:99")).toBe(
+            "eyened:viewerViewState:subtask:99",
+        );
     });
 });
 
@@ -74,12 +83,10 @@ describe("createViewerViewStateController", () => {
             JSON.stringify({ version: 1, frames: { aaa: 1 } }),
         );
         let params = new URLSearchParams("frame=aaa:9");
-        const replaced: string[] = [];
         const c = createViewerViewStateController({
             scope: "view",
             getSearchParams: () => params,
             replaceUrl: (p) => {
-                replaced.push(p.toString());
                 params = new URLSearchParams(p);
             },
             storage,
@@ -107,6 +114,8 @@ describe("createViewerViewStateController", () => {
         });
         c.hydrate();
         expect(c.peekFrame("aaa", 10)).toBe(3);
+        c.enableRecording();
+        expect(params.get("frame")).toBe("aaa:3");
     });
 
     it("ignores record until enableRecording", () => {

--- a/client/src/lib/viewer-window/viewerViewState.ts
+++ b/client/src/lib/viewer-window/viewerViewState.ts
@@ -114,7 +114,11 @@ export type ViewerViewStateController = {
     setOpenViewers(viewers: OpenViewerEntry[]): void;
     recordIndex(imageId: string, index: number, depth: number): void;
     prune(instanceIds: readonly string[]): void;
+    /** Flush any pending debounced persist (e.g. on unmount). */
+    flush(): void;
 };
+
+const PERSIST_DEBOUNCE_MS = 250;
 
 export function createViewerViewStateController(options: {
     scope: string;
@@ -126,18 +130,16 @@ export function createViewerViewStateController(options: {
     const key = storageKey(options.scope);
     let viewers: OpenViewerEntry[] = [];
     let recording = false;
+    let persistTimer: ReturnType<typeof setTimeout> | undefined;
 
     function persist() {
         const params = new URLSearchParams(options.getSearchParams());
         const encoded = serializeViewersParam(viewers);
         if (encoded) params.set(VIEW_STATE_PARAM, encoded);
         else params.delete(VIEW_STATE_PARAM);
-        // Drop legacy param if present
-        params.delete("frame");
-        options.replaceUrl(params);
-        if (!storage) return;
         try {
-            storage.setItem(
+            options.replaceUrl(params);
+            storage?.setItem(
                 key,
                 serializeStoredState({
                     version: 2,
@@ -149,8 +151,23 @@ export function createViewerViewStateController(options: {
                 }),
             );
         } catch {
-            // private mode / quota — URL sync still applied
+            // private mode / quota / browser history rate limits
         }
+    }
+
+    function schedulePersist() {
+        if (persistTimer !== undefined) clearTimeout(persistTimer);
+        persistTimer = setTimeout(() => {
+            persistTimer = undefined;
+            persist();
+        }, PERSIST_DEBOUNCE_MS);
+    }
+
+    function flush() {
+        if (persistTimer === undefined) return;
+        clearTimeout(persistTimer);
+        persistTimer = undefined;
+        persist();
     }
 
     function sameViewers(a: OpenViewerEntry[], b: OpenViewerEntry[]): boolean {
@@ -219,7 +236,7 @@ export function createViewerViewStateController(options: {
             viewers = viewers.map((v, j) =>
                 j === i ? { id: v.id, index } : v,
             );
-            persist();
+            schedulePersist();
         },
         prune(instanceIds) {
             const allowed = new Set(instanceIds);
@@ -230,5 +247,6 @@ export function createViewerViewStateController(options: {
             viewers = next;
             if (recording) persist();
         },
+        flush,
     };
 }

--- a/client/src/lib/viewer-window/viewerViewState.ts
+++ b/client/src/lib/viewer-window/viewerViewState.ts
@@ -1,0 +1,71 @@
+export type ViewerViewStateV1 = {
+    version: 1;
+    frames: Record<string, number>;
+};
+
+export function storageKey(scope: string): string {
+    return `eyened:viewerViewState:${scope}`;
+}
+
+export function parseFrameParam(
+    raw: string | null | undefined,
+): Record<string, number> {
+    if (!raw) return {};
+    const out: Record<string, number> = {};
+    for (const part of raw.split(",")) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const colon = trimmed.indexOf(":");
+        if (colon <= 0) continue;
+        const id = trimmed.slice(0, colon).trim();
+        const indexStr = trimmed.slice(colon + 1).trim();
+        if (!id || !/^\d+$/.test(indexStr)) continue;
+        const index = Number(indexStr);
+        if (!Number.isInteger(index) || index < 0) continue;
+        out[id] = index;
+    }
+    return out;
+}
+
+export function serializeFrameParam(frames: Record<string, number>): string {
+    return Object.entries(frames)
+        .filter(
+            ([, index]) =>
+                Number.isInteger(index) && index >= 0 && Number.isFinite(index),
+        )
+        .map(([id, index]) => `${id}:${index}`)
+        .join(",");
+}
+
+export function parseStoredState(
+    raw: string | null | undefined,
+): ViewerViewStateV1 | null {
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (
+            !parsed ||
+            typeof parsed !== "object" ||
+            (parsed as ViewerViewStateV1).version !== 1 ||
+            typeof (parsed as ViewerViewStateV1).frames !== "object" ||
+            (parsed as ViewerViewStateV1).frames === null
+        ) {
+            return null;
+        }
+        const frames: Record<string, number> = {};
+        for (const [id, index] of Object.entries(
+            (parsed as ViewerViewStateV1).frames,
+        )) {
+            if (Number.isInteger(index) && (index as number) >= 0) {
+                frames[id] = index as number;
+            }
+        }
+        return { version: 1, frames };
+    } catch {
+        return null;
+    }
+}
+
+export function serializeStoredState(state: ViewerViewStateV1): string {
+    return JSON.stringify(state);
+}

--- a/client/src/lib/viewer-window/viewerViewState.ts
+++ b/client/src/lib/viewer-window/viewerViewState.ts
@@ -1,82 +1,118 @@
-export type ViewerViewStateV1 = {
-    version: 1;
-    frames: Record<string, number>;
+export type OpenViewerEntry = {
+    id: string;
+    index?: number;
 };
+
+export type ViewerViewStateV2 = {
+    version: 2;
+    viewers: OpenViewerEntry[];
+};
+
+/** Query param for open main viewers (+ optional frame index). */
+export const VIEW_STATE_PARAM = "v";
 
 export function storageKey(scope: string): string {
     return `eyened:viewerViewState:${scope}`;
 }
 
-export function parseFrameParam(
+/**
+ * Parse `v=id.index,id2,id3.5` — `.` separates optional index; `,` separates viewers.
+ * Malformed tokens are skipped.
+ */
+export function parseViewersParam(
     raw: string | null | undefined,
-): Record<string, number> {
-    if (!raw) return {};
-    const out: Record<string, number> = {};
+): OpenViewerEntry[] {
+    if (!raw) return [];
+    const out: OpenViewerEntry[] = [];
+    const idOk = /^[A-Za-z0-9_-]+$/;
     for (const part of raw.split(",")) {
         const trimmed = part.trim();
         if (!trimmed) continue;
-        const colon = trimmed.indexOf(":");
-        if (colon <= 0) continue;
-        const id = trimmed.slice(0, colon).trim();
-        const indexStr = trimmed.slice(colon + 1).trim();
-        if (!id || !/^\d+$/.test(indexStr)) continue;
-        const index = Number(indexStr);
-        if (!Number.isInteger(index) || index < 0) continue;
-        out[id] = index;
+        const dot = trimmed.lastIndexOf(".");
+        if (dot > 0) {
+            const id = trimmed.slice(0, dot).trim();
+            const indexStr = trimmed.slice(dot + 1).trim();
+            if (idOk.test(id) && /^\d+$/.test(indexStr)) {
+                const index = Number(indexStr);
+                if (Number.isInteger(index) && index >= 0) {
+                    out.push({ id, index });
+                    continue;
+                }
+            }
+        }
+        if (idOk.test(trimmed)) {
+            out.push({ id: trimmed });
+        }
     }
     return out;
 }
 
-export function serializeFrameParam(frames: Record<string, number>): string {
-    return Object.entries(frames)
-        .filter(
-            ([, index]) =>
-                Number.isInteger(index) && index >= 0 && Number.isFinite(index),
-        )
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([id, index]) => `${id}:${index}`)
+export function serializeViewersParam(viewers: OpenViewerEntry[]): string {
+    return viewers
+        .filter((v) => typeof v.id === "string" && v.id.length > 0)
+        .map((v) => {
+            if (
+                v.index !== undefined &&
+                Number.isInteger(v.index) &&
+                v.index >= 0
+            ) {
+                return `${v.id}.${v.index}`;
+            }
+            return v.id;
+        })
         .join(",");
 }
 
 export function parseStoredState(
     raw: string | null | undefined,
-): ViewerViewStateV1 | null {
+): ViewerViewStateV2 | null {
     if (!raw) return null;
     try {
         const parsed = JSON.parse(raw) as unknown;
         if (
             !parsed ||
             typeof parsed !== "object" ||
-            (parsed as ViewerViewStateV1).version !== 1 ||
-            typeof (parsed as ViewerViewStateV1).frames !== "object" ||
-            (parsed as ViewerViewStateV1).frames === null ||
-            Array.isArray((parsed as ViewerViewStateV1).frames)
+            (parsed as ViewerViewStateV2).version !== 2 ||
+            !Array.isArray((parsed as ViewerViewStateV2).viewers)
         ) {
             return null;
         }
-        const frames: Record<string, number> = {};
-        for (const [id, index] of Object.entries(
-            (parsed as ViewerViewStateV1).frames,
-        )) {
-            if (Number.isInteger(index) && (index as number) >= 0) {
-                frames[id] = index as number;
+        const viewers: OpenViewerEntry[] = [];
+        for (const item of (parsed as ViewerViewStateV2).viewers) {
+            if (!item || typeof item !== "object") continue;
+            const id = (item as OpenViewerEntry).id;
+            if (typeof id !== "string" || !id) continue;
+            const index = (item as OpenViewerEntry).index;
+            if (index === undefined) {
+                viewers.push({ id });
+            } else if (Number.isInteger(index) && index >= 0) {
+                viewers.push({ id, index });
+            } else {
+                viewers.push({ id });
             }
         }
-        return { version: 1, frames };
+        return { version: 2, viewers };
     } catch {
         return null;
     }
 }
 
-export function serializeStoredState(state: ViewerViewStateV1): string {
+export function serializeStoredState(state: ViewerViewStateV2): string {
     return JSON.stringify(state);
+}
+
+/** Map image_id → owning instance id (strip known suffixes like `_proj`). */
+export function instanceIdFromImageId(imageId: string): string {
+    return imageId.replace(/_proj$/u, "");
 }
 
 export type ViewerViewStateController = {
     hydrate(): void;
     enableRecording(): void;
-    peekFrame(instanceId: string, depth: number): number | undefined;
-    record(instanceId: string, index: number, depth: number): void;
+    getViewers(): OpenViewerEntry[];
+    peekIndex(imageId: string, depth: number): number | undefined;
+    setOpenViewers(viewers: OpenViewerEntry[]): void;
+    recordIndex(imageId: string, index: number, depth: number): void;
     prune(instanceIds: readonly string[]): void;
 };
 
@@ -88,46 +124,69 @@ export function createViewerViewStateController(options: {
 }): ViewerViewStateController {
     const storage = options.storage;
     const key = storageKey(options.scope);
-    let frames: Record<string, number> = {};
+    let viewers: OpenViewerEntry[] = [];
     let recording = false;
 
     function persist() {
         const params = new URLSearchParams(options.getSearchParams());
-        const encoded = serializeFrameParam(frames);
-        if (encoded) params.set("frame", encoded);
-        else params.delete("frame");
+        const encoded = serializeViewersParam(viewers);
+        if (encoded) params.set(VIEW_STATE_PARAM, encoded);
+        else params.delete(VIEW_STATE_PARAM);
+        // Drop legacy param if present
+        params.delete("frame");
         options.replaceUrl(params);
         if (!storage) return;
         try {
             storage.setItem(
                 key,
-                serializeStoredState({ version: 1, frames: { ...frames } }),
+                serializeStoredState({
+                    version: 2,
+                    viewers: viewers.map((v) =>
+                        v.index === undefined
+                            ? { id: v.id }
+                            : { id: v.id, index: v.index },
+                    ),
+                }),
             );
         } catch {
             // private mode / quota — URL sync still applied
         }
     }
 
+    function sameViewers(a: OpenViewerEntry[], b: OpenViewerEntry[]): boolean {
+        if (a.length !== b.length) return false;
+        return a.every((v, i) => v.id === b[i]?.id && v.index === b[i]?.index);
+    }
+
     return {
         hydrate() {
             recording = false;
-            const fromUrl = parseFrameParam(
-                options.getSearchParams().get("frame"),
+            const fromUrl = parseViewersParam(
+                options.getSearchParams().get(VIEW_STATE_PARAM),
             );
-            if (Object.keys(fromUrl).length > 0) {
-                frames = fromUrl;
+            if (fromUrl.length > 0) {
+                viewers = fromUrl;
                 return;
             }
             const stored = parseStoredState(storage?.getItem(key) ?? null);
-            frames = stored?.frames ?? {};
+            viewers = stored?.viewers ?? [];
         },
         enableRecording() {
             recording = true;
             persist();
         },
-        peekFrame(instanceId, depth) {
-            const index = frames[instanceId];
+        getViewers() {
+            return viewers.map((v) =>
+                v.index === undefined
+                    ? { id: v.id }
+                    : { id: v.id, index: v.index },
+            );
+        },
+        peekIndex(imageId, depth) {
+            const entry = viewers.find((v) => v.id === imageId);
+            const index = entry?.index;
             if (
+                index === undefined ||
                 !Number.isInteger(index) ||
                 index < 0 ||
                 index >= depth ||
@@ -137,23 +196,39 @@ export function createViewerViewStateController(options: {
             }
             return index;
         },
-        record(instanceId, index, depth) {
+        setOpenViewers(next) {
+            const normalized = next
+                .filter((v) => typeof v.id === "string" && v.id.length > 0)
+                .map((v) =>
+                    v.index !== undefined &&
+                    Number.isInteger(v.index) &&
+                    v.index >= 0
+                        ? { id: v.id, index: v.index }
+                        : { id: v.id },
+                );
+            if (sameViewers(viewers, normalized)) return;
+            viewers = normalized;
+            if (recording) persist();
+        },
+        recordIndex(imageId, index, depth) {
             if (!recording || depth <= 1) return;
             if (!Number.isInteger(index) || index < 0 || index >= depth) return;
-            if (frames[instanceId] === index) return;
-            frames[instanceId] = index;
+            const i = viewers.findIndex((v) => v.id === imageId);
+            if (i < 0) return;
+            if (viewers[i].index === index) return;
+            viewers = viewers.map((v, j) =>
+                j === i ? { id: v.id, index } : v,
+            );
             persist();
         },
         prune(instanceIds) {
             const allowed = new Set(instanceIds);
-            let changed = false;
-            for (const id of Object.keys(frames)) {
-                if (!allowed.has(id)) {
-                    delete frames[id];
-                    changed = true;
-                }
-            }
-            if (changed && recording) persist();
+            const next = viewers.filter((v) =>
+                allowed.has(instanceIdFromImageId(v.id)),
+            );
+            if (sameViewers(viewers, next)) return;
+            viewers = next;
+            if (recording) persist();
         },
     };
 }

--- a/client/src/lib/viewer-window/viewerViewState.ts
+++ b/client/src/lib/viewer-window/viewerViewState.ts
@@ -69,3 +69,88 @@ export function parseStoredState(
 export function serializeStoredState(state: ViewerViewStateV1): string {
     return JSON.stringify(state);
 }
+
+export type ViewerViewStateController = {
+    hydrate(): void;
+    enableRecording(): void;
+    peekFrame(instanceId: string, depth: number): number | undefined;
+    record(instanceId: string, index: number, depth: number): void;
+    prune(instanceIds: readonly string[]): void;
+};
+
+export function createViewerViewStateController(options: {
+    scope: string;
+    getSearchParams: () => URLSearchParams;
+    replaceUrl: (params: URLSearchParams) => void;
+    storage?: Pick<Storage, "getItem" | "setItem">;
+}): ViewerViewStateController {
+    const storage = options.storage;
+    const key = storageKey(options.scope);
+    let frames: Record<string, number> = {};
+    let recording = false;
+
+    function persist() {
+        const params = new URLSearchParams(options.getSearchParams());
+        const encoded = serializeFrameParam(frames);
+        if (encoded) params.set("frame", encoded);
+        else params.delete("frame");
+        options.replaceUrl(params);
+        if (!storage) return;
+        try {
+            storage.setItem(
+                key,
+                serializeStoredState({ version: 1, frames: { ...frames } }),
+            );
+        } catch {
+            // private mode / quota — URL sync still applied
+        }
+    }
+
+    return {
+        hydrate() {
+            recording = false;
+            const fromUrl = parseFrameParam(
+                options.getSearchParams().get("frame"),
+            );
+            if (Object.keys(fromUrl).length > 0) {
+                frames = fromUrl;
+                return;
+            }
+            const stored = parseStoredState(storage?.getItem(key) ?? null);
+            frames = stored?.frames ?? {};
+        },
+        enableRecording() {
+            recording = true;
+            persist();
+        },
+        peekFrame(instanceId, depth) {
+            const index = frames[instanceId];
+            if (
+                !Number.isInteger(index) ||
+                index < 0 ||
+                index >= depth ||
+                depth <= 1
+            ) {
+                return undefined;
+            }
+            return index;
+        },
+        record(instanceId, index, depth) {
+            if (!recording || depth <= 1) return;
+            if (!Number.isInteger(index) || index < 0 || index >= depth) return;
+            frames[instanceId] = index;
+            persist();
+        },
+        prune(instanceIds) {
+            const allowed = new Set(instanceIds);
+            let changed = false;
+            for (const id of Object.keys(frames)) {
+                if (!allowed.has(id)) {
+                    delete frames[id];
+                    changed = true;
+                }
+            }
+            if (changed && recording) persist();
+        },
+    };
+}

--- a/client/src/lib/viewer-window/viewerViewState.ts
+++ b/client/src/lib/viewer-window/viewerViewState.ts
@@ -33,6 +33,7 @@ export function serializeFrameParam(frames: Record<string, number>): string {
             ([, index]) =>
                 Number.isInteger(index) && index >= 0 && Number.isFinite(index),
         )
+        .sort(([a], [b]) => a.localeCompare(b))
         .map(([id, index]) => `${id}:${index}`)
         .join(",");
 }
@@ -48,7 +49,8 @@ export function parseStoredState(
             typeof parsed !== "object" ||
             (parsed as ViewerViewStateV1).version !== 1 ||
             typeof (parsed as ViewerViewStateV1).frames !== "object" ||
-            (parsed as ViewerViewStateV1).frames === null
+            (parsed as ViewerViewStateV1).frames === null ||
+            Array.isArray((parsed as ViewerViewStateV1).frames)
         ) {
             return null;
         }
@@ -138,6 +140,7 @@ export function createViewerViewStateController(options: {
         record(instanceId, index, depth) {
             if (!recording || depth <= 1) return;
             if (!Number.isInteger(index) || index < 0 || index >= depth) return;
+            if (frames[instanceId] === index) return;
             frames[instanceId] = index;
             persist();
         },

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -67,9 +67,17 @@ export class ViewerWindowContext {
         };
         loop();
 
-        void this.setInstanceIDs(instanceIDs).then(() => {
-            this.viewState?.enableRecording();
-        });
+        void this.setInstanceIDs(instanceIDs)
+            .then(() => {
+                this.viewState?.enableRecording();
+            })
+            .catch((error) => {
+                console.error(
+                    "[viewerViewState] initial load failed; enabling recording anyway",
+                    error,
+                );
+                this.viewState?.enableRecording();
+            });
     }
 
     addViewer(viewer: ViewerContext) {

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -355,13 +355,6 @@ export class ViewerWindowContext {
         this.viewState.setOpenViewers(entries);
     }
 
-    findImageByImageId(imageId: string): AbstractImage | undefined {
-        for (const image of this.topViewers.keys()) {
-            if (image.image_id === imageId) return image;
-        }
-        return undefined;
-    }
-
     getImages(instanceID: string): Promise<LoadedImages> {
         const instance = instances.get(instanceID);
         if (instance === undefined) {

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -50,6 +50,7 @@ export class ViewerWindowContext {
 
     private frame: number = 0;
     private loadedPatientIds = new Set<number>();
+    private destroyed = false;
 
     constructor(
         public readonly webgl: WebGL,
@@ -70,10 +71,13 @@ export class ViewerWindowContext {
 
         void this.setInstanceIDs(instanceIDs)
             .then(async () => {
+                if (this.destroyed) return;
                 await this.restoreMainViewersFromViewState();
+                if (this.destroyed) return;
                 this.viewState?.enableRecording();
             })
             .catch(async (error) => {
+                if (this.destroyed) return;
                 console.error(
                     "[viewerViewState] initial load failed; restoring/enabling anyway",
                     error,
@@ -86,6 +90,7 @@ export class ViewerWindowContext {
                         restoreError,
                     );
                 }
+                if (this.destroyed) return;
                 this.viewState?.enableRecording();
             });
     }
@@ -165,6 +170,7 @@ export class ViewerWindowContext {
     }
 
     destroy() {
+        this.destroyed = true;
         this.viewState?.flush();
         // Cancel animation frame
         cancelAnimationFrame(this.frame);

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -165,6 +165,7 @@ export class ViewerWindowContext {
     }
 
     destroy() {
+        this.viewState?.flush();
         // Cancel animation frame
         cancelAnimationFrame(this.frame);
 

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -19,6 +19,7 @@ import type { ImageGET } from "../../types/openapi_types";
 import MainViewer from "./MainViewer.svelte";
 import { EnfaceProjectionManager } from "./enfaceProjectionManager.svelte";
 import type { ViewerViewStateController } from "./viewerViewState";
+import { instanceIdFromImageId } from "./viewerViewState";
 
 export type MainPanelType = {
     component: any;
@@ -68,14 +69,23 @@ export class ViewerWindowContext {
         loop();
 
         void this.setInstanceIDs(instanceIDs)
-            .then(() => {
+            .then(async () => {
+                await this.restoreMainViewersFromViewState();
                 this.viewState?.enableRecording();
             })
-            .catch((error) => {
+            .catch(async (error) => {
                 console.error(
-                    "[viewerViewState] initial load failed; enabling recording anyway",
+                    "[viewerViewState] initial load failed; restoring/enabling anyway",
                     error,
                 );
+                try {
+                    await this.restoreMainViewersFromViewState();
+                } catch (restoreError) {
+                    console.error(
+                        "[viewerViewState] failed to restore open viewers",
+                        restoreError,
+                    );
+                }
                 this.viewState?.enableRecording();
             });
     }
@@ -271,6 +281,48 @@ export class ViewerWindowContext {
     removePanel(panel: MainPanelType) {
         this.mainPanels = this.mainPanels.filter((item) => item !== panel);
         this.syncMainPanelsToViewState();
+    }
+
+    /**
+     * Open main panels from hydrated view-state, or the first instance.
+     * Must run after setInstanceIDs so instances/images are in memory
+     * (task grade does not preload the instances store the way /view does).
+     */
+    async restoreMainViewersFromViewState() {
+        const pending = this.viewState?.getViewers() ?? [];
+        if (pending.length) {
+            const images = await Promise.all(
+                pending.map(async (entry) => {
+                    const instanceId = instanceIdFromImageId(entry.id);
+                    const loaded = await this.getImages(instanceId);
+                    return (
+                        loaded.find((img) => img.image_id === entry.id) ??
+                        loaded[loaded.length - 1]
+                    );
+                }),
+            );
+            const panels = images
+                .filter((image): image is AbstractImage => Boolean(image))
+                .map((image) => ({
+                    component: MainViewer,
+                    props: { image },
+                }));
+            if (!panels.length) return;
+            if (panels.length === 1) {
+                this.setPanel(panels[0]);
+            } else {
+                this.mainPanels = panels;
+                this.syncMainPanelsToViewState();
+            }
+            return;
+        }
+
+        if (!this.instanceIds.length) return;
+        const loaded = await this.getImages(this.instanceIds[0]);
+        this.setPanel({
+            component: MainViewer,
+            props: { image: loaded[loaded.length - 1] },
+        });
     }
 
     /** Keep URL/localStorage open-viewer list aligned with mainPanels. */

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -250,22 +250,60 @@ export class ViewerWindowContext {
 
     addImagePanel(image: AbstractImage) {
         this.mainPanels.push({ component: MainViewer, props: { image } });
+        this.syncMainPanelsToViewState();
     }
 
     setImagePanel(image: AbstractImage) {
         this.mainPanels = [{ component: MainViewer, props: { image } }];
+        this.syncMainPanelsToViewState();
     }
 
     setPanel(panel: MainPanelType) {
         this.mainPanels = [panel];
+        this.syncMainPanelsToViewState();
     }
 
     addPanel(panel: MainPanelType) {
         this.mainPanels.push(panel);
+        this.syncMainPanelsToViewState();
     }
 
     removePanel(panel: MainPanelType) {
         this.mainPanels = this.mainPanels.filter((item) => item !== panel);
+        this.syncMainPanelsToViewState();
+    }
+
+    /** Keep URL/localStorage open-viewer list aligned with mainPanels. */
+    syncMainPanelsToViewState() {
+        if (!this.viewState) return;
+        const prev = this.viewState.getViewers();
+        const entries = [];
+        for (const panel of this.mainPanels) {
+            const image = panel.props?.image as AbstractImage | undefined;
+            if (!image) continue;
+            const existing = prev.find((v) => v.id === image.image_id);
+            if (image.is3D && image.depth > 1) {
+                const live = [...this.viewers].find(
+                    (vc) => vc.image.image_id === image.image_id,
+                );
+                const index = live?.index ?? existing?.index;
+                entries.push(
+                    index !== undefined
+                        ? { id: image.image_id, index }
+                        : { id: image.image_id },
+                );
+            } else {
+                entries.push({ id: image.image_id });
+            }
+        }
+        this.viewState.setOpenViewers(entries);
+    }
+
+    findImageByImageId(imageId: string): AbstractImage | undefined {
+        for (const image of this.topViewers.keys()) {
+            if (image.image_id === imageId) return image;
+        }
+        return undefined;
     }
 
     getImages(instanceID: string): Promise<LoadedImages> {

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -302,12 +302,9 @@ export class ViewerWindowContext {
                     );
                 }),
             );
-            const panels = images
-                .filter((image): image is AbstractImage => Boolean(image))
-                .map((image) => ({
-                    component: MainViewer,
-                    props: { image },
-                }));
+            const panels = images.flatMap((image) =>
+                image ? [{ component: MainViewer, props: { image } }] : [],
+            );
             if (!panels.length) return;
             if (panels.length === 1) {
                 this.setPanel(panels[0]);

--- a/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
+++ b/client/src/lib/viewer-window/viewerWindowContext.svelte.ts
@@ -18,6 +18,7 @@ import { SvelteMap } from "svelte/reactivity";
 import type { ImageGET } from "../../types/openapi_types";
 import MainViewer from "./MainViewer.svelte";
 import { EnfaceProjectionManager } from "./enfaceProjectionManager.svelte";
+import type { ViewerViewStateController } from "./viewerViewState";
 
 export type MainPanelType = {
     component: any;
@@ -44,6 +45,8 @@ export class ViewerWindowContext {
     photoLocators = new SvelteMap<string, PhotoLocator[]>();
     photoLocatorSets: PhotoLocator[][] = $state([]);
 
+    public readonly viewState: ViewerViewStateController | undefined;
+
     private frame: number = 0;
     private loadedPatientIds = new Set<number>();
 
@@ -52,8 +55,10 @@ export class ViewerWindowContext {
         public readonly registration: Registration,
         public readonly creator: unknown,
         instanceIDs: string[] = [],
+        viewState?: ViewerViewStateController,
     ) {
         this.imageLoader = new ImageLoader(webgl);
+        this.viewState = viewState;
 
         // start rendering loop
         const loop = () => {
@@ -62,7 +67,9 @@ export class ViewerWindowContext {
         };
         loop();
 
-        this.setInstanceIDs(instanceIDs);
+        void this.setInstanceIDs(instanceIDs).then(() => {
+            this.viewState?.enableRecording();
+        });
     }
 
     addViewer(viewer: ViewerContext) {
@@ -85,6 +92,8 @@ export class ViewerWindowContext {
     }
 
     async setInstanceIDs(ids: string[]) {
+        this.viewState?.prune(ids);
+
         // ensure metadata of all instances is loaded
         const fetchOptions = {
             with_segmentations: true,
@@ -128,14 +137,13 @@ export class ViewerWindowContext {
         }
 
         // Load images for all instances
+        const loadPromises: Promise<unknown>[] = [];
         for (const id of ids) {
             const instance = instances.get(id);
-            if (instance) {
-                this.loadImage(instance);
-            } else {
-                console.warn(`Instance with id ${id} not found after fetch`);
-            }
+            if (instance) loadPromises.push(this.loadImage(instance));
+            else console.warn(`Instance with id ${id} not found after fetch`);
         }
+        await Promise.all(loadPromises);
     }
 
     destroy() {

--- a/client/src/lib/viewer/viewerContext.svelte.ts
+++ b/client/src/lib/viewer/viewerContext.svelte.ts
@@ -172,8 +172,8 @@ export class ViewerContext {
         this.addOverlay(new HotKeys());
 
         if (image.is3D && image.depth > 1) {
-            const pending = this.viewerWindowContext.viewState?.peekFrame(
-                this.instance.id,
+            const pending = this.viewerWindowContext.viewState?.peekIndex(
+                this.image.image_id,
                 image.depth,
             );
             if (pending !== undefined) {
@@ -199,8 +199,8 @@ export class ViewerContext {
         });
         this.index = i;
         if (this.image.is3D && this.image.depth > 1) {
-            this.viewerWindowContext.viewState?.record(
-                this.instance.id,
+            this.viewerWindowContext.viewState?.recordIndex(
+                this.image.image_id,
                 i,
                 this.image.depth,
             );

--- a/client/src/lib/viewer/viewerContext.svelte.ts
+++ b/client/src/lib/viewer/viewerContext.svelte.ts
@@ -176,9 +176,12 @@ export class ViewerContext {
                 this.image.image_id,
                 image.depth,
             );
-            if (pending !== undefined) {
-                this.setIndex(pending);
-            }
+            // Apply pending on viewer.index only. setIndex() writes the global
+            // registration pointer, which cannot hold per-viewer frames
+            // (known limitation for multiple open volumes).
+            this.index = pending ?? Math.round(image.depth / 2);
+        } else if (image.is3D) {
+            this.index = 0;
         }
     }
 
@@ -349,11 +352,8 @@ export class ViewerContext {
         );
         if (p) {
             this.index = p.index;
-        } else {
-            // this.index = Math.round(this.image.depth / 2);
-            this.index =
-                this.image.depth === 1 ? 0 : Math.round(this.image.depth / 2);
         }
+        // else keep this.index (mid-slice / restored pending / last setIndex)
 
         const renderTarget = { ...renderBounds, framebuffer: null };
 

--- a/client/src/lib/viewer/viewerContext.svelte.ts
+++ b/client/src/lib/viewer/viewerContext.svelte.ts
@@ -170,6 +170,16 @@ export class ViewerContext {
         this.addOverlay(new ZoomPan());
         this.addOverlay(new CursorOverlay());
         this.addOverlay(new HotKeys());
+
+        if (image.is3D && image.depth > 1) {
+            const pending = this.viewerWindowContext.viewState?.peekFrame(
+                this.instance.id,
+                image.depth,
+            );
+            if (pending !== undefined) {
+                this.setIndex(pending);
+            }
+        }
     }
 
     setIndex(i: number) {
@@ -188,6 +198,13 @@ export class ViewerContext {
             index: i,
         });
         this.index = i;
+        if (this.image.is3D && this.image.depth > 1) {
+            this.viewerWindowContext.viewState?.record(
+                this.instance.id,
+                i,
+                this.image.depth,
+            );
+        }
     }
 
     initTransform() {


### PR DESCRIPTION
## Summary

Graders can now **copy the browser URL** and land back on the same open main viewers (and frame/B-scan index where relevant). The same state is also remembered in **localStorage** so reopening a task or `/view` session on the same browser resumes where they left off.

URL shape:
- `v` = open main viewers (order matches the layout)
- uses the 'PublicID' to identify images (with _proj suffix for enface projection)
- optional `.N` = frame index for volumes / stacks

For example:
`…?v=abcdef,ghijkl.12,ghijkl_proj`


Works on both **`/view`** and **/task/<task_id>/grade/<subtask_id>** routes. Which images are *loaded* is unchanged (`instances=` / task image links); this only tracks **UI view state**.

## What’s in

- Shareable URL that updates as you open/close main viewers and scroll frames
- Auto-resume from URL (preferred) or localStorage on page load
- Per-subtask localStorage on task grade; shared `view` scope on `/view`

## What’s not (still #138 follow-ups)

- No “Go to last annotation” (only live scroll/open state, not last *edit*)
- No server/DB persistence (same PC / browser only for localStorage)
- No zoom, pan, window-level, open side panels, etc.