### PR TITLE
Remove unused `mysql-connector-python` package with open security issues

### DIFF
--- a/orm/setup.py
+++ b/orm/setup.py
@@ -27,7 +27,6 @@ setup(
         "tqdm==4.*",
         "alembic==1.13.2",
         "pymysql>=1.1.1",
-        "mysql-connector-python==8.*",
         "pydicom==3.*",
         "pylibjpeg==2.*",
         "pylibjpeg-libjpeg==2.*",


### PR DESCRIPTION
- There is no reference to this package anywhere in the code
- The default connection examples all use `pymysql`, which is also a dependency
- The depended-on version has open security vulnerabilities that are not resolved, despite what dependabot reported: https://github.com/Eyened/eyened-platform/security/dependabot/5